### PR TITLE
Improve Shell config

### DIFF
--- a/home/.chezmoiscripts/darwin/run_once_before_10-setup-fish.sh.tmpl
+++ b/home/.chezmoiscripts/darwin/run_once_before_10-setup-fish.sh.tmpl
@@ -98,7 +98,3 @@ else
 fi
 
 log_success "Fish shell setup completed successfully!"
-echo ""
-log_info "Next steps:"
-echo "  1. Restart your terminal"
-echo "  2. Verify by running: echo \$SHELL"

--- a/home/.chezmoiscripts/linux/run_once_install-precommit.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_once_install-precommit.sh.tmpl
@@ -6,10 +6,16 @@
 
 set -e
 
-# Check if we're in a git repository - skip in CI environments
+# Check if we're in a git repository - if not, try to use chezmoi source directory
 if ! git rev-parse --git-dir >/dev/null 2>&1; then
-    echo "ℹ️  Skipping pre-commit installation (not in a git repository)"
-    exit 0
+    # Try to use the chezmoi source directory if it's a git repository
+    if [ -d "{{ .chezmoi.sourceDir }}/.git" ]; then
+        echo "📁 Changing to chezmoi source directory..."
+        cd "{{ .chezmoi.sourceDir }}"
+    else
+        echo "ℹ️  Skipping pre-commit installation (not in a git repository)"
+        exit 0
+    fi
 fi
 
 {{- if eq .installType "light" }}

--- a/home/dot_config/fish/config.fish
+++ b/home/dot_config/fish/config.fish
@@ -18,6 +18,13 @@ end
 fish_add_path $HOME/.local/bin
 fish_add_path $HOME/bin
 
+# Initialize Homebrew (macOS)
+if test -f /opt/homebrew/bin/brew
+    eval (/opt/homebrew/bin/brew shellenv)
+else if test -f /usr/local/bin/brew
+    eval (/usr/local/bin/brew shellenv)
+end
+
 # Load custom functions from conf.d/
 # Files in conf.d/ are automatically sourced
 # TODO: Decide to migrate functions to fish syntax or keep bash scripts

--- a/home/dot_config/fish/functions/chezmoi_reset.fish
+++ b/home/dot_config/fish/functions/chezmoi_reset.fish
@@ -1,0 +1,136 @@
+function chezmoi_reset --description 'Reset chezmoi run_once_ or run_onchange_ script states'
+    # Parse arguments
+    argparse --name=chezmoi_reset h/help 'f/force' -- $argv
+    or return 1
+
+    # Show help if requested
+    if set -q _flag_help
+        echo "Usage: chezmoi_reset [OPTIONS] TYPE"
+        echo
+        echo "Reset chezmoi script execution states to force scripts to run again."
+        echo
+        echo "Arguments:"
+        echo "  TYPE          Type of scripts to reset:"
+        echo "                  once      - Reset run_once_ scripts (scriptState bucket)"
+        echo "                  onchange  - Reset run_onchange_ scripts (entryState bucket)"
+        echo "                  all       - Reset both types"
+        echo
+        echo "Options:"
+        echo "  -h, --help    Show this help message"
+        echo "  -f, --force   Skip confirmation prompt"
+        echo
+        echo "Examples:"
+        echo "  chezmoi_reset once        # Reset run_once_ scripts"
+        echo "  chezmoi_reset onchange    # Reset run_onchange_ scripts"
+        echo "  chezmoi_reset all -f      # Reset all without confirmation"
+        return 0
+    end
+
+    # Check if chezmoi is available
+    if not command -q chezmoi
+        set_color red
+        echo "Error: chezmoi is not installed or not in PATH"
+        set_color normal
+        return 1
+    end
+
+    # Validate argument count
+    if test (count $argv) -ne 1
+        set_color red
+        echo "Error: Expected exactly one argument (once, onchange, or all)"
+        set_color normal
+        echo "Run 'chezmoi_reset --help' for usage information"
+        return 1
+    end
+
+    set -l reset_type $argv[1]
+
+    # Define bucket mappings
+    set -l buckets
+    switch $reset_type
+        case once
+            set buckets scriptState
+        case onchange
+            set buckets entryState
+        case all
+            set buckets entryState scriptState
+        case '*'
+            set_color red
+            echo "Error: Invalid type '$reset_type'. Use 'once', 'onchange', or 'all'"
+            set_color normal
+            return 1
+    end
+
+    # Confirmation prompt (unless --force)
+    if not set -q _flag_force
+        set_color yellow
+        echo "⚠️  This will reset the following chezmoi state:"
+        set_color normal
+        for bucket in $buckets
+            switch $bucket
+                case scriptState
+                    echo "  • run_once_ scripts (will run again on next apply)"
+                case entryState
+                    echo "  • run_onchange_ scripts (will run again if changed)"
+            end
+        end
+        echo
+        set_color yellow
+        read -l -P "Continue? [y/N] " confirm
+        set_color normal
+
+        switch $confirm
+            case Y y
+                # Continue
+            case '*'
+                echo "Cancelled"
+                return 0
+        end
+    end
+
+    # Delete buckets
+    set -l success true
+    for bucket in $buckets
+        echo "🔄 Deleting bucket: $bucket"
+
+        if chezmoi state delete-bucket --bucket=$bucket 2>&1
+            set_color green
+            echo "✓ Successfully reset $bucket"
+            set_color normal
+        else
+            set_color red
+            echo "✗ Failed to reset $bucket"
+            set_color normal
+            set success false
+        end
+    end
+
+    # Final message
+    echo
+    if test $success = true
+        set_color green --bold
+        echo "✓ Chezmoi state reset complete!"
+        set_color normal
+        echo "Run 'chezmoi apply' to execute the scripts again"
+        return 0
+    else
+        set_color red
+        echo "Some operations failed"
+        set_color normal
+        return 1
+    end
+end
+
+# Completions for chezmoi_reset
+complete -c chezmoi_reset -f
+
+# Help option
+complete -c chezmoi_reset -s h -l help -d "Show help message"
+
+# Force option
+complete -c chezmoi_reset -s f -l force -d "Skip confirmation prompt"
+
+# Reset type arguments (only suggest if no other arguments provided)
+complete -c chezmoi_reset -n "not __fish_seen_subcommand_from once onchange all" -a "once" -d "Reset run_once_ scripts"
+complete -c chezmoi_reset -n "not __fish_seen_subcommand_from once onchange all" -a "onchange" -d "Reset run_onchange_ scripts"
+complete -c chezmoi_reset -n "not __fish_seen_subcommand_from once onchange all" -a "all" -d "Reset all script states"

--- a/home/dot_config/shell/config.bash
+++ b/home/dot_config/shell/config.bash
@@ -2,6 +2,8 @@
 # Bash configuration
 # This file should be sourced by ~/.bashrc or ~/.bash_profile
 
+# TODO: Fix duplicate config files for bash/zsh/fish by moving common parts to separate init script
+
 # Initialize Homebrew (macOS/Linux)
 if [ -f "/opt/homebrew/bin/brew" ]; then
     eval "$(/opt/homebrew/bin/brew shellenv)"

--- a/home/dot_config/shell/config.bash
+++ b/home/dot_config/shell/config.bash
@@ -2,6 +2,15 @@
 # Bash configuration
 # This file should be sourced by ~/.bashrc or ~/.bash_profile
 
+# Initialize Homebrew (macOS/Linux)
+if [ -f "/opt/homebrew/bin/brew" ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -f "/usr/local/bin/brew" ]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+elif [ -f "/home/linuxbrew/.linuxbrew/bin/brew" ]; then
+    eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+fi
+
 # Load all functions from shell/functions directory
 if [ -d "$HOME/.config/shell/functions" ]; then
 	for func_file in "$HOME/.config/shell/functions"/*; do

--- a/home/dot_config/shell/config.zsh
+++ b/home/dot_config/shell/config.zsh
@@ -3,6 +3,13 @@
 # Zsh configuration
 # This file should be sourced by ~/.zshrc
 
+# Initialize Homebrew (macOS)
+if [[ -f "/opt/homebrew/bin/brew" ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [[ -f "/usr/local/bin/brew" ]]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+fi
+
 # Load all functions from shell/functions directory
 if [[ -d "$HOME/.config/shell/functions" ]]; then
     for func_file in "$HOME/.config/shell/functions"/*; do


### PR DESCRIPTION
This pull request introduces improvements to shell configuration and script management, focusing on better Homebrew initialization across different shells and platforms, enhanced handling for pre-commit installation in non-standard environments, and the addition of a utility function for managing chezmoi script states.

### Shell configuration improvements

* Added Homebrew initialization logic to `config.bash`, `config.zsh`, and `config.fish` to ensure Homebrew is set up correctly on macOS and Linux, improving environment consistency for all shell users. (`home/dot_config/shell/config.bash` [[1]](diffhunk://#diff-f294e4308db6c31ec85f42558743a3968fb68eefdc5efc563f721330ee120748R5-R15) `home/dot_config/shell/config.zsh` [[2]](diffhunk://#diff-0460b73351c4665b85d6667b9b6cc65879b5a2b5c160929e0a2507feed7057e9R6-R12) `home/dot_config/fish/config.fish` [[3]](diffhunk://#diff-0e97ea561f9f71b260f358ad45338ab54b8b25829949b56a3138e52b67f03e7cR21-R27)

### Script and utility enhancements

* Added a new Fish shell function `chezmoi_reset.fish` to allow users to reset chezmoi run_once_ and run_onchange_ script states, with argument parsing, help output, confirmation prompts, and completions. (`home/dot_config/fish/functions/chezmoi_reset.fish` [home/dot_config/fish/functions/chezmoi_reset.fishR1-R136](diffhunk://#diff-8b94614317cbfe17c86dc4098835720771632eb851fca69c2296e254cef96c38R1-R136))
* Improved the pre-commit installation script for Linux to attempt running in the chezmoi source directory if not already in a git repository, increasing robustness in various environments. (`home/.chezmoiscripts/linux/run_once_install-precommit.sh.tmpl` [home/.chezmoiscripts/linux/run_once_install-precommit.sh.tmplL9-R19](diffhunk://#diff-36d78aaa77dfaf2d945c0ca8681a5273dc84179165a2fceda61ac2676047a2dcL9-R19))

### User experience and messaging

* Removed post-setup next-step instructions from the Fish shell setup script to streamline user messaging. (`home/.chezmoiscripts/darwin/run_once_before_10-setup-fish.sh.tmpl` [home/.chezmoiscripts/darwin/run_once_before_10-setup-fish.sh.tmplL101-L104](diffhunk://#diff-0665aacc02537c6c6249a69f409f97aeef8e5ea0f1a903d4a2a993b0db749e41L101-L104))