### PR TITLE
Minor fixes

### DIFF
--- a/home/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json
+++ b/home/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json
@@ -32,6 +32,12 @@
         "list":
         [
             {
+                "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+                "hidden": false,
+                "name": "PowerShell",
+                "source": "Windows.Terminal.PowershellCore"
+            },
+            {
                 "commandline": "%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
                 "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
                 "hidden": false,
@@ -42,12 +48,6 @@
                 "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
                 "hidden": false,
                 "name": "Command Prompt"
-            },
-            {
-                "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
-                "hidden": false,
-                "name": "PowerShell",
-                "source": "Windows.Terminal.PowershellCore"
             },
             {
                 "guid": "{b453ae62-4e3d-5e58-b989-0a998ec441b8}",

--- a/home/dot_config/shell/config.bash
+++ b/home/dot_config/shell/config.bash
@@ -2,8 +2,6 @@
 # Bash configuration
 # This file should be sourced by ~/.bashrc or ~/.bash_profile
 
-# TODO: Fix duplicate config files for bash/zsh/fish by moving common parts to separate init script
-
 # Load all completions and evals from completions.d/
 if [ -d "$HOME/.config/shell/completions.d" ]; then
 	for comp_file in "$HOME/.config/shell/completions.d"/*.bash; do

--- a/home/dot_wslconfig
+++ b/home/dot_wslconfig
@@ -5,6 +5,9 @@
 # Limits VM memory to use no more than 4 GB, this can be set as whole numbers using GB or MB
 memory=4GB
 
+[user]
+default=jean-paul
+
 [experimental]
 # Sparse VHD enables automatic disk space clean up
 sparseVhd=true


### PR DESCRIPTION
This pull request contains a few minor configuration changes across different environment setup files. The most notable updates are the addition of a default user in the WSL configuration and a minor cleanup in the Bash configuration script.

Configuration updates:

* Added a `[user]` section with a `default` user set to `jean-paul` in the `.wslconfig` file.

Minor cleanups:

* Removed a completed or obsolete TODO comment from `config.bash` to tidy up the configuration script.

Windows Terminal settings adjustment:

* Moved the PowerShell profile entry in `settings.json` to a different position within the `list` array, but no functional changes were made to the profile itself. [[1]](diffhunk://#diff-2e7ede81edb1b6d899e63f85ce09545198088657e3171a93d40ea331c5af8e28R34-R39) [[2]](diffhunk://#diff-2e7ede81edb1b6d899e63f85ce09545198088657e3171a93d40ea331c5af8e28L46-L51)