### PR TITLE
Add WSL detection

### DIFF
--- a/home/.chezmoi.yaml.tmpl
+++ b/home/.chezmoi.yaml.tmpl
@@ -28,7 +28,8 @@
 {{-   writeToStdout "💡 Tip: you can re-enter your name and email with `chezmoi init --data=false`.\n" -}}
 {{- end -}}
 {{- $remoteContainers:= env "REMOTE_CONTAINERS" | not | not -}}
-{{- $devcontainer:= or $remoteContainers (stat "/.dockerenv") -}}
+{{- $devcontainer:= or $remoteContainers (stat "/.dockerenv") | not | not -}}
+{{- $wsl:= and (lookPath "wslinfo") (output "wslinfo" "--version" | trim | ne "") | not | not -}}
 
 {{- /* Determine installation type based on hostname */ -}}
 {{- $installType := "full" -}}
@@ -72,6 +73,7 @@ data:
   name: {{ $name | quote }}
   codespaces: {{ $codespaces }}
   devcontainer: {{ $devcontainer }}
+  wsl: {{ $wsl }}
   ci: {{ $ci }}
   email: {{ $email | quote }}
   installType: {{ $installType | quote }}

--- a/home/.chezmoiscripts/windows/run_once_install-wsl.ps1
+++ b/home/.chezmoiscripts/windows/run_once_install-wsl.ps1
@@ -68,8 +68,12 @@ else {
     # Check if Debian is installed
     $debianInstalled = $false
     try {
-        $distros = wsl.exe --list --quiet 2>$null | Where-Object { $_ -match '\S' }
-        $debianInstalled = $distros -match "Debian"
+        $distros = wsl.exe --list --quiet 2>$null
+        # Convert from UTF-16 if needed and clean up
+        $distroList = $distros | ForEach-Object { 
+            $_.Trim() -replace '\x00', '' -replace '\r', '' 
+        } | Where-Object { $_ -match '\S' }
+        $debianInstalled = $distroList -match "^Debian"
     }
     catch {
         # Ignore errors

--- a/home/dot_config/powershell/functions.ps1
+++ b/home/dot_config/powershell/functions.ps1
@@ -44,7 +44,12 @@ function Invoke-ChezmoiSigning {
 
     # Signs PowerShell scripts in the Chezmoi source directory
     $chezmoiSourceDir = chezmoi source-path
-    $signingScript = Join-Path $chezmoiSourceDir "home" | Join-Path -ChildPath "dot_config" | Join-Path -ChildPath "powershell" | Join-Path -ChildPath "scripts" | Join-Path -ChildPath "Sign-PowerShellScripts.ps1"
+    if ($LASTEXITCODE -ne 0 -or -not $chezmoiSourceDir) {
+        Write-Host "Error: Failed to get Chezmoi source directory" -ForegroundColor Red
+        return
+    }
+
+    $signingScript = Join-Path -Path $chezmoiSourceDir -ChildPath "dot_config\powershell\scripts\Sign-PowerShellScripts.ps1"
 
     if (-not (Test-Path $signingScript)) {
         Write-Host "Error: Sign-PowerShellScripts.ps1 not found at $signingScript" -ForegroundColor Red


### PR DESCRIPTION
This pull request introduces improvements and fixes related to environment detection and script robustness in the Chezmoi configuration and PowerShell scripts. The main changes enhance detection of development environments (such as WSL and devcontainers), improve reliability in checking for Debian installation in WSL, and add error handling to the PowerShell signing function.

**Environment detection improvements:**

* Improved detection of devcontainer environments by refining the logic for setting the `$devcontainer` variable in `.chezmoi.yaml.tmpl`. This ensures more accurate identification of containerized development environments.
* Added detection of WSL environments by introducing the `$wsl` variable using `wslinfo`, and included this value in the exported data for use in templates and scripts. [[1]](diffhunk://#diff-3daf4dce76c5dd0b869d48048cc0f17a14bec9834bdf804dd1412aefdac4a267L31-R32) [[2]](diffhunk://#diff-3daf4dce76c5dd0b869d48048cc0f17a14bec9834bdf804dd1412aefdac4a267R76)

**Windows/WSL script robustness:**

* Enhanced the WSL Debian installation check in `run_once_install-wsl.ps1` by normalizing and cleaning up the output from `wsl.exe --list --quiet`, ensuring more reliable detection even with encoding issues.

**PowerShell function reliability:**

* Improved the `Invoke-ChezmoiSigning` function to handle errors when retrieving the Chezmoi source directory and simplified the construction of the signing script path, preventing failures when the source path is unavailable.