### PR TITLE
feat(scripts): adopt log.sh across chezmoi scripts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,6 +21,14 @@
 
 **Always run commands in this exact order**:
 
+> **IMPORTANT — Always wrap test/validation runs with a timeout.** Bats suites
+> can hang on interactive prompts, network calls, or chezmoi apply loops, and
+> a hung suite blocks the whole agent. Wrap every invocation with a hard cap,
+> e.g. `timeout 120 ./tests/bash/run-tests.sh --ci` or pass `timeout` to the
+> terminal tool. Recommended caps: single bats file ≤ 60s, full `--ci` run ≤
+> 300s. If the timeout fires, investigate the specific test rather than
+> increasing the cap.
+
 ### 1. Install Development Tools (Required First)
 
 ```bash

--- a/home/.chezmoiscripts/darwin/run_once_before_10-setup-fish-default-shell.sh.tmpl
+++ b/home/.chezmoiscripts/darwin/run_once_before_10-setup-fish-default-shell.sh.tmpl
@@ -10,29 +10,9 @@
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-WHITE='\033[1;37m'
-NC='\033[0m' # No Color
-
-# Logging functions
-log_info() {
-	echo -e "${WHITE}ℹ️  $*${NC}"
-}
-
-log_success() {
-	echo -e "${GREEN}✅ $*${NC}"
-}
-
-log_warning() {
-	echo -e "${YELLOW}⚠️  $*${NC}"
-}
-
-log_error() {
-	echo -e "${RED}❌ $*${NC}"
-}
+# shellcheck source=../../dot_config/shell/functions/log.sh
+. "{{ .chezmoi.sourceDir }}/dot_config/shell/functions/log.sh"
+LOG_TAG="setup-fish"
 
 # Only run on macOS
 # shellcheck disable=SC2050
@@ -41,7 +21,7 @@ if [[ "{{ .chezmoi.os }}" != "darwin" ]]; then
 	exit 0
 fi
 
-log_info "Setting up Fish shell on macOS..."
+log_state "Setting up Fish shell on macOS"
 
 # Detect Fish installation path
 # Apple Silicon Macs: /opt/homebrew/bin/fish
@@ -55,7 +35,7 @@ elif [[ -x "/usr/local/bin/fish" ]]; then
 	log_info "Detected Fish at: $FISH_PATH (Intel)"
 else
 	log_error "Fish shell not found at /opt/homebrew/bin/fish or /usr/local/bin/fish"
-	log_info "Please install Fish using: brew install fish"
+	log_hint "Please install Fish using: brew install fish"
 	exit 1
 fi
 
@@ -65,13 +45,13 @@ log_info "Found Fish version: $FISH_VERSION"
 
 # Check if Fish is already in /etc/shells
 if grep -q "^${FISH_PATH}$" /etc/shells 2>/dev/null; then
-	log_success "Fish is already in /etc/shells"
+	log_result "Fish is already in /etc/shells"
 else
-	log_warning "Fish is not in /etc/shells, adding it now..."
+	log_warn "Fish is not in /etc/shells, adding it now"
 	log_info "This requires sudo access"
 
 	if echo "$FISH_PATH" | sudo tee -a /etc/shells >/dev/null; then
-		log_success "Added $FISH_PATH to /etc/shells"
+		log_result "Added $FISH_PATH to /etc/shells"
 	else
 		log_error "Failed to add Fish to /etc/shells"
 		exit 1
@@ -84,18 +64,18 @@ log_info "Current shell: $CURRENT_SHELL"
 
 # Change default shell to Fish if not already set
 if [[ "$CURRENT_SHELL" == "$FISH_PATH" ]]; then
-	log_success "Fish is already your default shell"
+	log_result "Fish is already your default shell"
 else
-	log_warning "Changing default shell to Fish..."
+	log_warn "Changing default shell to Fish"
 
 	if chsh -s "$FISH_PATH"; then
-		log_success "Default shell changed to Fish"
-		log_info "Please restart your terminal for the changes to take effect"
+		log_result "Default shell changed to Fish"
+		log_hint "Please restart your terminal for the changes to take effect"
 	else
 		log_error "Failed to change default shell to Fish"
-		log_info "You can manually change it later with: chsh -s $FISH_PATH"
+		log_hint "You can manually change it later with: chsh -s $FISH_PATH"
 		exit 1
 	fi
 fi
 
-log_success "Fish shell setup completed successfully!"
+log_result "Fish shell setup completed successfully"

--- a/home/.chezmoiscripts/linux/run_once_before_00-setup.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_once_before_00-setup.sh.tmpl
@@ -4,11 +4,18 @@
 
 set -e
 
-echo "🚀 Running initial setup..."
+# Source the shared logging library from the chezmoi source dir (the
+# destination copy at ~/.config/shell/functions/log.sh isn't applied yet
+# at run_once_before_* time).
+# shellcheck source=../dot_config/shell/functions/log.sh
+. "{{ .chezmoi.sourceDir }}/dot_config/shell/functions/log.sh"
+LOG_TAG="setup"
+
+log_state "Running initial setup"
 
 # Create necessary directories
 mkdir -p "$HOME/.vim/undo"
 mkdir -p "$HOME/bin"
 mkdir -p "$HOME/projects"
 
-echo "✅ Initial setup complete!"
+log_result "Initial setup complete"

--- a/home/.chezmoiscripts/linux/run_once_before_01-install-ppas.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_once_before_01-install-ppas.sh.tmpl
@@ -7,76 +7,80 @@
 # Don't exit on error - we want to continue even if some PPAs fail
 set +e
 
+# shellcheck source=../../dot_config/shell/functions/log.sh
+. "{{ .chezmoi.sourceDir }}/dot_config/shell/functions/log.sh"
+LOG_TAG="install-ppas"
+
 # {{ if and (eq .chezmoi.os "linux") (eq .chezmoi.osRelease.id "ubuntu" "debian") }}
 # {{ if or .packages.linux.apt.ppas.light .packages.linux.apt.ppas.full }}
 
-echo "📦 Installing PPAs ({{ .installType }} mode)..."
+log_state "Installing PPAs ({{ .installType }} mode)"
 
 # Check if running with sudo privileges
 if [ "$EUID" -eq 0 ]; then
-    echo "⚠️  Running as root, sudo commands will execute directly"
-    SUDO_CMD=""
+	log_warn "Running as root, sudo commands will execute directly"
+	SUDO_CMD=""
 elif command -v sudo >/dev/null 2>&1; then
-    SUDO_CMD="sudo"
+	SUDO_CMD="sudo"
 else
-    echo "⚠️  Warning: sudo is not available and not running as root"
-    echo "   Skipping PPA installation as it requires elevated privileges"
-    exit 0
+	log_warn "sudo is not available and not running as root"
+	log_info "Skipping PPA installation as it requires elevated privileges"
+	exit 0
 fi
 
 # Check if running interactively
 if [ -t 0 ]; then
-    DEBIAN_FRONTEND_VALUE=""
+	DEBIAN_FRONTEND_VALUE=""
 else
-    DEBIAN_FRONTEND_VALUE="noninteractive"
+	DEBIAN_FRONTEND_VALUE="noninteractive"
 fi
 
 # Check if add-apt-repository is available
 if ! command -v add-apt-repository >/dev/null 2>&1; then
-    echo "📦 Installing software-properties-common for add-apt-repository..."
-    $SUDO_CMD apt-get update
-    if [ -n "$DEBIAN_FRONTEND_VALUE" ]; then
-        DEBIAN_FRONTEND=$DEBIAN_FRONTEND_VALUE $SUDO_CMD apt-get install -y software-properties-common
-    else
-        $SUDO_CMD apt-get install -y software-properties-common
-    fi
+	log_step "Installing software-properties-common for add-apt-repository"
+	$SUDO_CMD apt-get update
+	if [ -n "$DEBIAN_FRONTEND_VALUE" ]; then
+		DEBIAN_FRONTEND=$DEBIAN_FRONTEND_VALUE $SUDO_CMD apt-get install -y software-properties-common
+	else
+		$SUDO_CMD apt-get install -y software-properties-common
+	fi
 fi
 
 # Install light mode PPAs (always)
 # {{ range .packages.linux.apt.ppas.light }}
-echo "Adding PPA: {{ . }}"
+log_step "Adding PPA: {{ . }}"
 if $SUDO_CMD add-apt-repository -y {{ . | quote }}; then
-    echo "✅ Successfully added PPA: {{ . }}"
+	log_result "Successfully added PPA: {{ . }}"
 else
-    echo "⚠️  Warning: Failed to add PPA: {{ . }}"
-    echo "   Continuing with remaining PPAs..."
+	log_warn "Failed to add PPA: {{ . }}"
+	log_info "Continuing with remaining PPAs..."
 fi
 # {{ end }}
 
 # {{ if eq .installType "full" }}
 # Install full mode PPAs (additional)
 # {{ range .packages.linux.apt.ppas.full }}
-echo "Adding PPA: {{ . }}"
+log_step "Adding PPA: {{ . }}"
 if $SUDO_CMD add-apt-repository -y {{ . | quote }}; then
-    echo "✅ Successfully added PPA: {{ . }}"
+	log_result "Successfully added PPA: {{ . }}"
 else
-    echo "⚠️  Warning: Failed to add PPA: {{ . }}"
-    echo "   Continuing with remaining PPAs..."
+	log_warn "Failed to add PPA: {{ . }}"
+	log_info "Continuing with remaining PPAs..."
 fi
 # {{ end }}
 # {{ end }}
 
-echo "📦 Updating package lists after adding PPAs..."
+log_step "Updating package lists after adding PPAs"
 if [ -n "$DEBIAN_FRONTEND_VALUE" ]; then
-    DEBIAN_FRONTEND=$DEBIAN_FRONTEND_VALUE $SUDO_CMD apt-get update
+	DEBIAN_FRONTEND=$DEBIAN_FRONTEND_VALUE $SUDO_CMD apt-get update
 else
-    $SUDO_CMD apt-get update
+	$SUDO_CMD apt-get update
 fi
 
-echo "✅ PPA installation complete ({{ .installType }} mode)!"
+log_result "PPA installation complete ({{ .installType }} mode)"
 # {{ else }}
-echo "ℹ️  No PPAs defined, skipping PPA installation"
+log_info "No PPAs defined, skipping PPA installation"
 # {{ end }}
 # {{ else }}
-echo "ℹ️  PPA installation only supported on Ubuntu/Debian, skipping"
+log_info "PPA installation only supported on Ubuntu/Debian, skipping"
 # {{ end }}

--- a/home/.chezmoiscripts/linux/run_once_before_05-install-homebrew.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_once_before_05-install-homebrew.sh.tmpl
@@ -9,29 +9,10 @@
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-WHITE='\033[1;37m'
-NC='\033[0m' # No Color
-
-# Logging functions
-log_info() {
-	echo -e "${WHITE}ℹ️  $*${NC}"
-}
-
-log_success() {
-	echo -e "${GREEN}✅ $*${NC}"
-}
-
-log_warning() {
-	echo -e "${YELLOW}⚠️  $*${NC}"
-}
-
-log_error() {
-	echo -e "${RED}❌ $*${NC}"
-}
+# Source the shared logging library from the chezmoi source dir.
+# shellcheck source=../../dot_config/shell/functions/log.sh
+. "{{ .chezmoi.sourceDir }}/dot_config/shell/functions/log.sh"
+LOG_TAG="install-homebrew"
 
 # {{ if ne .installType "full" }}
 log_info "Skipping Homebrew installation (not in full mode)"
@@ -45,20 +26,20 @@ if [[ "$OS" != "linux" && "$OS" != "darwin" ]]; then
 	exit 0
 fi
 
-log_info "Checking for Homebrew installation..."
+log_step "Checking for Homebrew installation"
 
 # Check if Homebrew is already installed
 if command -v brew >/dev/null 2>&1; then
 	BREW_VERSION=$(brew --version | head -n1)
-	log_success "Homebrew is already installed: $BREW_VERSION"
+	log_result "Homebrew is already installed: $BREW_VERSION"
 	log_info "Location: $(which brew)"
 	exit 0
 fi
 
-log_warning "Homebrew not found. Installing Homebrew..."
+log_warn "Homebrew not found. Installing Homebrew..."
 
 # Check for required dependencies
-log_info "Checking for required dependencies..."
+log_step "Checking for required dependencies"
 MISSING_DEPS=()
 
 for cmd in curl git; do
@@ -69,32 +50,32 @@ done
 
 if [[ ${#MISSING_DEPS[@]} -gt 0 ]]; then
 	log_error "Missing required dependencies: ${MISSING_DEPS[*]}"
-	log_info "Please install them first:"
+	log_hint "Please install them first:"
 	# {{ if and (eq .chezmoi.os "linux") (eq .chezmoi.osRelease.id "ubuntu" "debian") }}
-	log_info "  sudo apt-get install -y ${MISSING_DEPS[*]}"
+	log_hint "  sudo apt-get install -y ${MISSING_DEPS[*]}"
 	# {{ else if and (eq .chezmoi.os "linux") (eq .chezmoi.osRelease.id "fedora" "rhel" "centos") }}
-	log_info "  sudo dnf install -y ${MISSING_DEPS[*]}"
+	log_hint "  sudo dnf install -y ${MISSING_DEPS[*]}"
 	# {{ end }}
 	exit 1
 fi
 
 # Check for sudo permissions (only relevant on Linux)
 # {{ if eq .chezmoi.os "linux" }}
-log_info "Checking for sudo permissions..."
+log_step "Checking for sudo permissions"
 if ! sudo -n true 2>/dev/null; then
-	log_warning "Sudo access not available without password prompt"
-	log_warning "Homebrew installation requires sudo permissions to create /home/linuxbrew/.linuxbrew"
+	log_warn "Sudo access not available without password prompt"
+	log_warn "Homebrew installation requires sudo permissions to create /home/linuxbrew/.linuxbrew"
 	log_info "On Linux, Homebrew is optional. Continuing without Homebrew..."
-	log_info "You can install Homebrew manually later if needed: https://brew.sh"
+	log_hint "You can install Homebrew manually later if needed: https://brew.sh"
 	exit 0
 fi
-log_success "Sudo permissions available"
+log_result "Sudo permissions available"
 # {{ end }}
 
 # Install Homebrew using official installation script
-log_info "Downloading and running Homebrew installation script from https://brew.sh"
+log_state "Downloading and running Homebrew installation script from https://brew.sh"
 # {{ if eq .chezmoi.os "linux" }}
-log_warning "This may require sudo access and may prompt for your password"
+log_warn "This may require sudo access and may prompt for your password"
 # {{ end }}
 
 # Set NONINTERACTIVE based on environment (interactive mode from Chezmoi config)
@@ -106,7 +87,7 @@ NONINTERACTIVE=1
 
 # Attempt Homebrew installation - optional on Linux, required on macOS
 if NONINTERACTIVE=$NONINTERACTIVE /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; then
-	log_success "Homebrew installed successfully!"
+	log_result "Homebrew installed successfully"
 
 	# Try to find Homebrew in standard locations (macOS and Linux)
 	BREW_PATH=""
@@ -136,34 +117,34 @@ if NONINTERACTIVE=$NONINTERACTIVE /bin/bash -c "$(curl -fsSL https://raw.githubu
 	# Verify installation
 	if command -v brew >/dev/null 2>&1; then
 		BREW_VERSION=$(brew --version | head -n1)
-		log_success "Verified Homebrew installation: $BREW_VERSION"
+		log_result "Verified Homebrew installation: $BREW_VERSION"
 
 		# Install recommended dependencies on Debian/Ubuntu
 		# {{ if and (eq .chezmoi.os "linux") (eq .chezmoi.osRelease.id "ubuntu" "debian") }}
-		log_info "Installing recommended Homebrew dependencies for Debian/Ubuntu..."
-		sudo apt-get install -y build-essential procps curl file git 2>/dev/null || log_warning "Some dependencies may not have installed"
+		log_step "Installing recommended Homebrew dependencies for Debian/Ubuntu"
+		sudo apt-get install -y build-essential procps curl file git 2>/dev/null || log_warn "Some dependencies may not have installed"
 		# {{ end }}
 
 		# Fix permissions for zsh completions to prevent compaudit warnings
 		# https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh
-		log_info "Securing Homebrew completion files for zsh..."
+		log_step "Securing Homebrew completion files for zsh"
 		if sudo chmod -R go-w "$(brew --prefix)/share" 2>/dev/null; then
-			log_success "Homebrew completion permissions secured"
+			log_result "Homebrew completion permissions secured"
 		else
-			log_warning "Could not secure completion permissions (non-critical)"
+			log_warn "Could not secure completion permissions (non-critical)"
 		fi
 	else
-		log_warning "Homebrew installation completed but brew command not found in PATH"
-		log_info "You may need to restart your shell or run:"
+		log_warn "Homebrew installation completed but brew command not found in PATH"
+		log_hint "You may need to restart your shell or run:"
 		# {{ if eq .chezmoi.os "darwin" }}
-		log_info "  eval \"\$(/opt/homebrew/bin/brew shellenv)\"    # macOS Apple Silicon"
-		log_info "  eval \"\$(/usr/local/bin/brew shellenv)\"       # macOS Intel"
+		log_hint "  eval \"\$(/opt/homebrew/bin/brew shellenv)\"    # macOS Apple Silicon"
+		log_hint "  eval \"\$(/usr/local/bin/brew shellenv)\"       # macOS Intel"
 		# {{ else }}
-		log_info "  eval \"\$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\""
-		log_info "  eval \"\$($HOME/.linuxbrew/bin/brew shellenv)\""
+		log_hint "  eval \"\$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\""
+		log_hint "  eval \"\$($HOME/.linuxbrew/bin/brew shellenv)\""
 		# {{ end }}
-		log_info "You may also need to secure completion permissions manually:"
-		log_info "  sudo chmod -R go-w \"\$(brew --prefix)/share\""
+		log_hint "You may also need to secure completion permissions manually:"
+		log_hint "  sudo chmod -R go-w \"\$(brew --prefix)/share\""
 		# {{ if eq .chezmoi.os "darwin" }}
 		log_error "Homebrew is required on macOS but installation verification failed"
 		exit 1
@@ -173,19 +154,19 @@ if NONINTERACTIVE=$NONINTERACTIVE /bin/bash -c "$(curl -fsSL https://raw.githubu
 		# {{ end }}
 	fi
 else
-	log_warning "Failed to install Homebrew"
+	log_warn "Failed to install Homebrew"
 	# {{ if eq .chezmoi.os "darwin" }}
 	log_error "Homebrew is required on macOS for package installation"
-	log_info "Please install Homebrew manually and try again:"
-	log_info "  Visit https://brew.sh for installation instructions"
+	log_hint "Please install Homebrew manually and try again:"
+	log_hint "  Visit https://brew.sh for installation instructions"
 	exit 1
 	# {{ else }}
 	log_info "This is often due to insufficient permissions on shared/WSL systems."
 	log_info "Homebrew is optional on Linux - continuing with dotfiles installation."
-	log_info "If you need Homebrew, you can install it manually later:"
-	log_info "  Visit https://brew.sh for installation instructions"
+	log_hint "If you need Homebrew, you can install it manually later:"
+	log_hint "  Visit https://brew.sh for installation instructions"
 	exit 0
 	# {{ end }}
 fi
 
-log_success "Homebrew setup completed successfully!"
+log_result "Homebrew setup completed successfully"

--- a/home/.chezmoiscripts/linux/run_once_install-lefthook.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_once_install-lefthook.sh.tmpl
@@ -10,69 +10,71 @@ set -e
 # This prevents mise from hanging in non-interactive environments (Codespaces, CI)
 export MISE_YES=1
 
+# shellcheck source=../../dot_config/shell/functions/log.sh
+. "{{ .chezmoi.sourceDir }}/dot_config/shell/functions/log.sh"
+LOG_TAG="install-lefthook"
+
 # shellcheck source=../../.chezmoihelpers/package-utils.sh
 source "{{ .chezmoi.sourceDir }}/.chezmoihelpers/package-utils.sh"
 
 if ! mise_required_for_current_install "{{ .chezmoi.sourceDir }}/.chezmoidata/packages.yaml"; then
-    echo "[SKIP] skipping lefthook setup: mise not required for this install type"
-    exit 0
+	log_info "skipping lefthook setup: mise not required for this install type"
+	exit 0
 fi
 
 # Check if we're in a git repository - if not, try to use chezmoi source directory
 if ! git rev-parse --git-dir >/dev/null 2>&1; then
-    # Try to use the chezmoi source directory if it's a git repository
-    if [ -d "{{ .chezmoi.sourceDir }}/.git" ]; then
-        echo "[INFO] Changing to chezmoi source directory..."
-        cd "{{ .chezmoi.sourceDir }}"
-    else
-        echo "[SKIP] Skipping lefthook installation (not in a git repository)"
-        exit 0
-    fi
+	# Try to use the chezmoi source directory if it's a git repository
+	if [ -d "{{ .chezmoi.sourceDir }}/.git" ]; then
+		log_step "Changing to chezmoi source directory"
+		cd "{{ .chezmoi.sourceDir }}"
+	else
+		log_info "Skipping lefthook installation (not in a git repository)"
+		exit 0
+	fi
 fi
 
 if command -v lefthook >/dev/null 2>&1; then
-    echo "[OK] lefthook already installed"
-    exit 0
+	log_result "lefthook already installed"
+	exit 0
 fi
 
 # {{ if or .devcontainer .codespaces }}
-echo "[INFO] Detected devcontainer/codespace environment - installing lefthook..."
+log_state "Detected devcontainer/codespace environment - installing lefthook"
 # {{ else if eq .installType "full" }}
-echo "[INFO] Installing lefthook on dev server..."
+log_state "Installing lefthook on dev server"
 # {{ end }}
-
-echo "[INFO] Installing lefthook..."
 
 # Prefer mise (already managed by this repo) so the lefthook version
 # matches .mise.toml.
 if command -v mise >/dev/null 2>&1; then
-    (cd "{{ .chezmoi.sourceDir }}" && mise install)
-    if ! command -v lefthook >/dev/null 2>&1 && ! mise which lefthook >/dev/null 2>&1; then
-        echo "[WARN] mise install completed, but lefthook is not available."
-        echo "[INFO] Check that lefthook is listed in .mise.toml, ensure mise shims are on PATH, and re-run: mise install"
-        exit 1
-    fi
+	(cd "{{ .chezmoi.sourceDir }}" && mise install)
+	if ! command -v lefthook >/dev/null 2>&1 && ! mise which lefthook >/dev/null 2>&1; then
+		log_warn "mise install completed, but lefthook is not available."
+		log_hint "Check that lefthook is listed in .mise.toml, ensure mise shims are on PATH, and re-run: mise install"
+		exit 1
+	fi
 else
-    echo "[WARN] mise is not installed; cannot install lefthook automatically."
-    echo "[INFO] Install mise (https://mise.jdx.dev/) and re-run, or install lefthook manually."
-    exit 0
+	log_warn "mise is not installed; cannot install lefthook automatically."
+	log_hint "Install mise (https://mise.jdx.dev/) and re-run, or install lefthook manually."
+	exit 0
 fi
 
-echo "[OK] lefthook installed successfully!"
+log_result "lefthook installed successfully"
 
 # Auto-enable hooks in devcontainer/codespace/dev server environments
 # {{ if or .devcontainer .codespaces (eq .installType "full") }}
 if [ -d "{{ .chezmoi.sourceDir }}/.git" ] || git rev-parse --git-dir >/dev/null 2>&1; then
-    echo "[INFO] Enabling lefthook hooks..."
-    if command -v lefthook >/dev/null 2>&1; then
-        cd "{{ .chezmoi.sourceDir }}" && lefthook install
-    elif command -v mise >/dev/null 2>&1 && mise which lefthook >/dev/null 2>&1; then
-        cd "{{ .chezmoi.sourceDir }}" && "$(mise which lefthook)" install
-    fi
-    echo "[OK] Lefthook hooks enabled!"
+	log_step "Enabling lefthook hooks"
+	if command -v lefthook >/dev/null 2>&1; then
+		cd "{{ .chezmoi.sourceDir }}" && lefthook install
+	elif command -v mise >/dev/null 2>&1 && mise which lefthook >/dev/null 2>&1; then
+		cd "{{ .chezmoi.sourceDir }}" && "$(mise which lefthook)" install
+	fi
+	log_result "Lefthook hooks enabled"
 else
-    echo "[INFO] To enable hooks later, run: lefthook install"
+	log_hint "To enable hooks later, run: lefthook install"
 fi
 # {{ else }}
-echo "[INFO] To enable hooks, run: lefthook install"
+log_hint "To enable hooks, run: lefthook install"
 # {{ end }}

--- a/home/.chezmoiscripts/linux/run_once_setup-gh-telemetry.sh
+++ b/home/.chezmoiscripts/linux/run_once_setup-gh-telemetry.sh
@@ -3,16 +3,21 @@
 # Sets telemetry to disabled in gh config if gh is installed.
 # See: https://cli.github.com/manual/gh_config_set
 
+# shellcheck source=home/dot_config/shell/functions/log.sh disable=SC1091
+. "${CHEZMOI_SOURCE_DIR}/dot_config/shell/functions/log.sh"
+# shellcheck disable=SC2034 # consumed by log.sh
+LOG_TAG="gh-telemetry"
+
 if ! command -v gh >/dev/null 2>&1; then
-	echo "[SKIP] gh CLI not found, skipping telemetry configuration"
+	log_info "gh CLI not found, skipping telemetry configuration"
 	exit 0
 fi
 
-echo ">> Disabling GitHub CLI telemetry..."
+log_state "Disabling GitHub CLI telemetry"
 gh config set telemetry disabled
 exit_code=$?
 if [ $exit_code -eq 0 ]; then
-	echo "[OK] GitHub CLI telemetry disabled"
+	log_result "GitHub CLI telemetry disabled"
 else
-	echo "[WARN] Failed to disable GitHub CLI telemetry (exit code: $exit_code)"
+	log_warn "Failed to disable GitHub CLI telemetry (exit code: $exit_code)"
 fi

--- a/home/.chezmoiscripts/linux/run_once_setup-lefthook.sh
+++ b/home/.chezmoiscripts/linux/run_once_setup-lefthook.sh
@@ -10,7 +10,12 @@ set -e
 # This prevents mise from hanging in non-interactive environments (Codespaces, CI)
 export MISE_YES=1
 
-echo "[INFO] Setting up lefthook..."
+# shellcheck source=home/dot_config/shell/functions/log.sh disable=SC1091
+. "${CHEZMOI_SOURCE_DIR}/dot_config/shell/functions/log.sh"
+# shellcheck disable=SC2034 # consumed by log.sh
+LOG_TAG="setup-lefthook"
+
+log_state "Setting up lefthook"
 
 # Get the Chezmoi source directory (where the dotfiles repo is)
 # The source path is the parent of CHEZMOI_SOURCE_DIR/home
@@ -21,18 +26,18 @@ else
 	if command -v chezmoi >/dev/null 2>&1; then
 		DOTFILES_ROOT="$(dirname "$(chezmoi source-path)")"
 	else
-		echo "[WARN] Cannot determine dotfiles repository location"
-		echo "Skipping lefthook setup (run manually from dotfiles repo)"
+		log_warn "Cannot determine dotfiles repository location"
+		log_hint "Skipping lefthook setup (run manually from dotfiles repo)"
 		exit 0
 	fi
 fi
 
-echo "[INFO] Dotfiles repository: $DOTFILES_ROOT"
+log_info "Dotfiles repository: $DOTFILES_ROOT"
 
 PACKAGE_UTILS="$DOTFILES_ROOT/home/.chezmoihelpers/package-utils.sh"
 if [ ! -f "$PACKAGE_UTILS" ]; then
-	echo "[WARN] Cannot find package utility helpers"
-	echo "Skipping lefthook setup"
+	log_warn "Cannot find package utility helpers"
+	log_hint "Skipping lefthook setup"
 	exit 0
 fi
 
@@ -40,14 +45,14 @@ fi
 source "$PACKAGE_UTILS"
 
 if ! mise_required_for_current_install "$DOTFILES_ROOT/home/.chezmoidata/packages.yaml"; then
-	echo "[SKIP] skipping lefthook setup: mise not required for this install type"
+	log_info "skipping lefthook setup: mise not required for this install type"
 	exit 0
 fi
 
 # Check if we have the required files in the dotfiles repo
 if [ ! -f "$DOTFILES_ROOT/.lefthook.toml" ] && [ ! -f "$DOTFILES_ROOT/lefthook.yml" ]; then
-	echo "[WARN] No lefthook configuration found in $DOTFILES_ROOT"
-	echo "Skipping lefthook setup"
+	log_warn "No lefthook configuration found in $DOTFILES_ROOT"
+	log_hint "Skipping lefthook setup"
 	exit 0
 fi
 
@@ -56,51 +61,50 @@ fi
 LEFTHOOK_PATH=""
 if command -v lefthook >/dev/null 2>&1; then
 	LEFTHOOK_PATH="$(command -v lefthook)"
-	echo "[OK] lefthook already installed ($(lefthook version 2>/dev/null || echo 'unknown'))"
+	log_result "lefthook already installed ($(lefthook version 2>/dev/null || echo 'unknown'))"
 elif command -v mise >/dev/null 2>&1; then
-	echo "[INFO] Installing mise-managed tools..."
+	log_step "Installing mise-managed tools"
 	if ! (cd "$DOTFILES_ROOT" && mise install >/dev/null 2>&1); then
-		echo "[WARN] mise install failed"
+		log_warn "mise install failed"
 	fi
 	if mise which lefthook >/dev/null 2>&1; then
 		LEFTHOOK_PATH="$(mise which lefthook)"
-		echo "[OK] lefthook installed via mise"
+		log_result "lefthook installed via mise"
 	fi
 fi
 
 if [ -z "$LEFTHOOK_PATH" ]; then
-	echo "[WARN] Could not install lefthook automatically."
-	echo "[INFO] Install mise (https://mise.jdx.dev/) and run: mise install"
+	log_warn "Could not install lefthook automatically."
+	log_hint "Install mise (https://mise.jdx.dev/) and run: mise install"
 	exit 0
 fi
 
 # Check if dotfiles repo is a git repository
 if [ ! -d "$DOTFILES_ROOT/.git" ]; then
-	echo "[WARN] Dotfiles directory is not a git repository"
-	echo "Skipping git hooks installation"
+	log_warn "Dotfiles directory is not a git repository"
+	log_hint "Skipping git hooks installation"
 	exit 0
 fi
 
 # Skip git hooks installation in CI environments
 if [ -n "$CI" ] || [ -n "$GITHUB_ACTIONS" ]; then
-	echo "[SKIP] Skipping git hooks installation in CI environment"
+	log_info "Skipping git hooks installation in CI environment"
 	exit 0
 fi
 
 # Install the git hooks in the dotfiles repository
-echo "[INFO] Installing git hooks in dotfiles repository..."
+log_step "Installing git hooks in dotfiles repository"
 cd "$DOTFILES_ROOT" || exit 1
 
 # Verify we're in a git repository before installing hooks
 if ! git rev-parse --git-dir >/dev/null 2>&1; then
-	echo "[WARN] Cannot access git repository"
-	echo "Skipping git hooks installation"
+	log_warn "Cannot access git repository"
+	log_hint "Skipping git hooks installation"
 	exit 0
 fi
 
 "$LEFTHOOK_PATH" install
 
-echo ""
-echo "[OK] Lefthook setup complete!"
-echo "[INFO] Hooks will run automatically on git commit in your dotfiles repo"
-echo "[INFO] To run manually: cd $DOTFILES_ROOT && lefthook run pre-commit --all-files"
+log_result "Lefthook setup complete"
+log_hint "Hooks will run automatically on git commit in your dotfiles repo"
+log_hint "To run manually: cd $DOTFILES_ROOT && lefthook run pre-commit --all-files"

--- a/home/.chezmoiscripts/linux/run_onchange_00-apt-upgrade.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_00-apt-upgrade.sh.tmpl
@@ -15,90 +15,78 @@
 
 # {{ if and (eq .chezmoi.os "linux") (or (eq .chezmoi.osRelease.id "ubuntu") (eq .chezmoi.osRelease.id "debian")) (not .isServer) }}
 
-set +e  # Continue on errors to avoid blocking chezmoi
+set +e # Continue on errors to avoid blocking chezmoi
 
-echo ""
-echo "================================================"
-echo ">> APT Package Upgrade"
-echo "================================================"
+# shellcheck source=../../dot_config/shell/functions/log.sh
+. "{{ .chezmoi.sourceDir }}/dot_config/shell/functions/log.sh"
+LOG_TAG="apt-upgrade"
+
+log_banner "APT Package Upgrade" STATE
 
 # Check if APT is available
 if ! command -v apt-get >/dev/null 2>&1; then
-    echo "[SKIP] APT not found on this system"
-    exit 0
+	log_info "APT not found on this system, skipping"
+	exit 0
 fi
 
-echo ""
-echo "[OK] APT package manager found"
+log_result "APT package manager found"
 
 # Check for sudo privileges
 if [ "$EUID" -eq 0 ]; then
-    SUDO_CMD=""
+	SUDO_CMD=""
 else
-    if ! command -v sudo >/dev/null 2>&1; then
-        echo "[WARN] sudo not available and not running as root"
-        echo "       Skipping APT upgrade (requires elevated privileges)"
-        exit 0
-    fi
-    SUDO_CMD="sudo"
+	if ! command -v sudo >/dev/null 2>&1; then
+		log_warn "sudo not available and not running as root"
+		log_info "Skipping APT upgrade (requires elevated privileges)"
+		exit 0
+	fi
+	SUDO_CMD="sudo"
 fi
 
 # Detection Phase: Check for updates
-echo ""
-echo "Detection Phase: Checking for updates..."
+log_state "Detection Phase: Checking for updates"
 
 # Update package lists first
 if ! $SUDO_CMD apt-get update >/dev/null 2>&1; then
-    echo "[WARN] Failed to update package lists"
-    echo "       Continuing anyway..."
+	log_warn "Failed to update package lists, continuing anyway"
 fi
 
 # Check if any upgrades are available
 upgrade_check=$($SUDO_CMD apt-get upgrade --dry-run 2>/dev/null | grep -c "^Inst")
 
 if [ "$upgrade_check" -eq 0 ]; then
-    echo "[OK] All packages are up to date"
-    exit 0
+	log_result "All packages are up to date"
+	exit 0
 fi
 
-echo "[OK] Found $upgrade_check package update(s) available"
+log_result "Found $upgrade_check package update(s) available"
 
 # Countdown Phase (skip in CI/non-interactive)
 countdown_seconds=3
 
 if [ -n "$CI" ] || [ ! -t 0 ]; then
-    echo ""
-    echo "[SKIP] Skipping countdown (CI/non-interactive environment)"
+	log_info "Skipping countdown (CI/non-interactive environment)"
 else
-    echo ""
-    echo "Execution Phase: Starting upgrade in $countdown_seconds seconds..."
-    echo "   Press Ctrl+C to cancel"
+	log_state "Execution Phase: Starting upgrade in $countdown_seconds seconds"
+	log_hint "Press Ctrl+C to cancel"
 
-    for i in $(seq $countdown_seconds -1 1); do
-        echo "   $i..."
-        sleep 1
-    done
-    echo "   GO!"
+	for i in $(seq $countdown_seconds -1 1); do
+		log_step "$i..."
+		sleep 1
+	done
+	log_step "GO!"
 fi
 
 # Execution Phase: Perform upgrade
-echo ""
-echo ">> Starting package upgrades..."
-echo ""
+log_state "Starting package upgrades"
 
 if $SUDO_CMD apt-get upgrade -y; then
-    echo ""
-    echo "================================================"
-    echo "[OK] APT upgrade completed successfully"
-    echo "================================================"
-    exit 0
+	log_banner "APT upgrade completed successfully" RESULT
+	exit 0
 else
-    exit_code=$?
-    echo ""
-    echo "================================================"
-    echo "[WARN] APT upgrade completed with errors (exit code: $exit_code)"
-    echo "================================================"
-    exit 0  # Don't fail chezmoi
+	exit_code=$?
+	log_warn "APT upgrade completed with errors (exit code: $exit_code)"
+	exit 0 # Don't fail chezmoi
 fi
 
 # {{ else }}

--- a/home/.chezmoiscripts/linux/run_onchange_01-brew-upgrade.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_01-brew-upgrade.sh.tmpl
@@ -14,31 +14,29 @@
 
 # {{ if and (or (eq .chezmoi.os "darwin") (eq .chezmoi.os "linux")) (not .isServer) }}
 
-set +e  # Continue on errors to avoid blocking chezmoi
+set +e # Continue on errors to avoid blocking chezmoi
 
-echo ""
-echo "================================================"
-echo ">> Homebrew Package Upgrade"
-echo "================================================"
+# shellcheck source=../../dot_config/shell/functions/log.sh
+. "{{ .chezmoi.sourceDir }}/dot_config/shell/functions/log.sh"
+LOG_TAG="brew-upgrade"
+
+log_banner "Homebrew Package Upgrade" STATE
 
 # Check if Homebrew is installed
 if ! command -v brew >/dev/null 2>&1; then
-    echo "[SKIP] Homebrew not found on this system"
-    exit 0
+	log_info "Homebrew not found on this system, skipping"
+	exit 0
 fi
 
-echo ""
-echo "[OK] Homebrew found: $(brew --version | head -n1)"
+log_result "Homebrew found: $(brew --version | head -n1)"
 
 # Detection Phase: Check for updates
-echo ""
-echo "Detection Phase: Checking for updates..."
+log_state "Detection Phase: Checking for updates"
 
 # Update Homebrew itself first (quietly)
-echo "   Updating Homebrew..."
+log_step "Updating Homebrew"
 if ! brew update >/dev/null 2>&1; then
-    echo "[WARN] Failed to update Homebrew"
-    echo "       Continuing anyway..."
+	log_warn "Failed to update Homebrew, continuing anyway"
 fi
 
 # Check if any packages have updates available
@@ -46,55 +44,43 @@ outdated=$(brew outdated --quiet 2>/dev/null)
 outdated_count=$(echo "$outdated" | grep -c .)
 
 if [ -z "$outdated" ] || [ "$outdated_count" -eq 0 ]; then
-    echo "[OK] All packages are up to date"
-    exit 0
+	log_result "All packages are up to date"
+	exit 0
 fi
 
-echo "[OK] Found $outdated_count package update(s) available:"
-echo "$outdated" | sed 's/^/       - /'
+log_result "Found $outdated_count package update(s) available"
+printf '%s\n' "$outdated" | log_data INFO "outdated packages"
 
 # Countdown Phase (skip in CI/non-interactive)
 countdown_seconds=3
 
 if [ -n "$CI" ] || [ ! -t 0 ]; then
-    echo ""
-    echo "[SKIP] Skipping countdown (CI/non-interactive environment)"
+	log_info "Skipping countdown (CI/non-interactive environment)"
 else
-    echo ""
-    echo "Execution Phase: Starting upgrade in $countdown_seconds seconds..."
-    echo "   Press Ctrl+C to cancel"
+	log_state "Execution Phase: Starting upgrade in $countdown_seconds seconds"
+	log_hint "Press Ctrl+C to cancel"
 
-    for i in $(seq $countdown_seconds -1 1); do
-        echo "   $i..."
-        sleep 1
-    done
-    echo "   GO!"
+	for i in $(seq $countdown_seconds -1 1); do
+		log_step "$i..."
+		sleep 1
+	done
+	log_step "GO!"
 fi
 
 # Execution Phase: Perform upgrade
-echo ""
-echo ">> Starting package upgrades..."
-echo ""
+log_state "Starting package upgrades"
 
 if brew upgrade; then
-    echo ""
+	# Optional: cleanup old versions
+	log_step "Cleaning up old versions"
+	brew cleanup
 
-    # Optional: cleanup old versions
-    echo ">> Cleaning up old versions..."
-    brew cleanup
-
-    echo ""
-    echo "================================================"
-    echo "[OK] Homebrew upgrade completed successfully"
-    echo "================================================"
-    exit 0
+	log_banner "Homebrew upgrade completed successfully" RESULT
+	exit 0
 else
-    exit_code=$?
-    echo ""
-    echo "================================================"
-    echo "[WARN] Homebrew upgrade completed with errors (exit code: $exit_code)"
-    echo "================================================"
-    exit 0  # Don't fail chezmoi
+	exit_code=$?
+	log_warn "Homebrew upgrade completed with errors (exit code: $exit_code)"
+	exit 0 # Don't fail chezmoi
 fi
 
 # {{ else }}

--- a/home/.chezmoiscripts/linux/run_onchange_02-mise-upgrade.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_02-mise-upgrade.sh.tmpl
@@ -15,40 +15,39 @@
 
 # {{ if and (or (eq .chezmoi.os "darwin") (eq .chezmoi.os "linux")) (not .isServer) }}
 
-set +e  # Continue on errors to avoid blocking chezmoi
+set +e # Continue on errors to avoid blocking chezmoi
 
-echo ""
-echo "================================================"
-echo ">> Mise Tool Upgrade"
-echo "================================================"
+# shellcheck source=../../dot_config/shell/functions/log.sh
+. "{{ .chezmoi.sourceDir }}/dot_config/shell/functions/log.sh"
+LOG_TAG="mise-upgrade"
+
+log_banner "Mise Tool Upgrade" STATE
 
 # shellcheck source=../../.chezmoihelpers/package-utils.sh
 source "{{ .chezmoi.sourceDir }}/.chezmoihelpers/package-utils.sh"
 
 if ! mise_required_for_current_install "{{ .chezmoi.sourceDir }}/.chezmoidata/packages.yaml"; then
-    echo "[SKIP] mise not required for this install type"
-    exit 0
+	log_info "mise not required for this install type, skipping"
+	exit 0
 fi
 
 # Check if mise is installed
 if ! command -v mise >/dev/null 2>&1; then
-    echo "[SKIP] mise not found on this system"
-    exit 0
+	log_info "mise not found on this system, skipping"
+	exit 0
 fi
 
-echo ""
-echo "[OK] mise found: $(mise --version 2>/dev/null | head -n1)"
+log_result "mise found: $(mise --version 2>/dev/null | head -n1)"
 
 # Detection Phase: Check for updates
-echo ""
-echo "Detection Phase: Checking for updates..."
+log_state "Detection Phase: Checking for updates"
 
 # Check if mise itself has updates
-echo "   Checking mise version..."
+log_step "Checking mise version"
 mise_self_update_check=$(mise self-update --check 2>/dev/null || echo "")
 
 # Check for outdated tools
-echo "   Checking for outdated tools..."
+log_step "Checking for outdated tools"
 outdated=$(mise outdated 2>/dev/null)
 outdated_count=$(echo "$outdated" | grep -E "^\S+" | wc -l | tr -d ' ')
 
@@ -56,72 +55,62 @@ outdated_count=$(echo "$outdated" | grep -E "^\S+" | wc -l | tr -d ' ')
 has_updates=false
 
 if [ -n "$mise_self_update_check" ] && echo "$mise_self_update_check" | grep -q "mise .* -> .*"; then
-    has_updates=true
-    echo "[OK] mise update available: $mise_self_update_check"
+	has_updates=true
+	log_result "mise update available: $mise_self_update_check"
 fi
 
 if [ -n "$outdated" ] && [ "$outdated_count" -gt 0 ]; then
-    has_updates=true
-    echo "[OK] Found $outdated_count tool update(s) available:"
-    echo "$outdated" | grep -E "^\S+" | sed 's/^/       - /'
+	has_updates=true
+	log_result "Found $outdated_count tool update(s) available"
+	printf '%s\n' "$outdated" | grep -E "^\S+" | log_data INFO "outdated tools"
 fi
 
 if [ "$has_updates" = false ]; then
-    echo "[OK] mise and all tools are up to date"
-    exit 0
+	log_result "mise and all tools are up to date"
+	exit 0
 fi
 
 # Countdown Phase (skip in CI/non-interactive)
 countdown_seconds=3
 
 if [ -n "$CI" ] || [ ! -t 0 ]; then
-    echo ""
-    echo "[SKIP] Skipping countdown (CI/non-interactive environment)"
+	log_info "Skipping countdown (CI/non-interactive environment)"
 else
-    echo ""
-    echo "Execution Phase: Starting upgrade in $countdown_seconds seconds..."
-    echo "   Press Ctrl+C to cancel"
+	log_state "Execution Phase: Starting upgrade in $countdown_seconds seconds"
+	log_hint "Press Ctrl+C to cancel"
 
-    for i in $(seq $countdown_seconds -1 1); do
-        echo "   $i..."
-        sleep 1
-    done
-    echo "   GO!"
+	for i in $(seq $countdown_seconds -1 1); do
+		log_step "$i..."
+		sleep 1
+	done
+	log_step "GO!"
 fi
 
 # Execution Phase: Perform upgrades
-echo ""
-echo ">> Starting upgrades..."
+log_state "Starting upgrades"
 
 # Update mise itself first
 if [ -n "$mise_self_update_check" ] && echo "$mise_self_update_check" | grep -q "mise .* -> .*"; then
-    echo ""
-    echo ">> Updating mise..."
-    if mise self-update -y 2>/dev/null; then
-        echo "[OK] mise updated successfully"
-    else
-        echo "[WARN] Failed to update mise (exit code: $?)"
-    fi
+	log_step "Updating mise"
+	if mise self-update -y 2>/dev/null; then
+		log_result "mise updated successfully"
+	else
+		log_warn "Failed to update mise (exit code: $?)"
+	fi
 fi
 
 # Upgrade all tools
 if [ "$outdated_count" -gt 0 ]; then
-    echo ""
-    echo ">> Upgrading tools..."
-    if mise upgrade 2>&1; then
-        echo ""
-        echo "[OK] Tool upgrades completed"
-    else
-        exit_code=$?
-        echo ""
-        echo "[WARN] Tool upgrades completed with errors (exit code: $exit_code)"
-    fi
+	log_step "Upgrading tools"
+	if mise upgrade 2>&1; then
+		log_result "Tool upgrades completed"
+	else
+		exit_code=$?
+		log_warn "Tool upgrades completed with errors (exit code: $exit_code)"
+	fi
 fi
 
-echo ""
-echo "================================================"
-echo "[OK] mise upgrade completed"
-echo "================================================"
+log_banner "mise upgrade completed" RESULT
 exit 0
 
 # {{ else }}

--- a/home/.chezmoiscripts/linux/run_onchange_10-install-packages.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_10-install-packages.sh.tmpl
@@ -9,83 +9,87 @@
 # Don't exit on error - we want to continue even if some packages fail
 set +e
 
-echo "🔧 Installing development tools ({{ .installType }} mode)..."
+# shellcheck source=../../dot_config/shell/functions/log.sh
+. "{{ .chezmoi.sourceDir }}/dot_config/shell/functions/log.sh"
+LOG_TAG="install-packages"
+
+log_state "Installing development tools ({{ .installType }} mode)"
 
 # Check if running with sudo privileges
 if [ "$EUID" -eq 0 ]; then
-    echo "⚠️  Running as root, commands will execute directly"
-    SUDO_CMD=""
+	log_warn "Running as root, commands will execute directly"
+	SUDO_CMD=""
 elif command -v sudo >/dev/null 2>&1; then
-    SUDO_CMD="sudo"
+	SUDO_CMD="sudo"
 else
-    echo "⚠️  Warning: sudo is not available and not running as root"
-    echo "   Skipping package installation as it requires elevated privileges"
-    exit 0
+	log_warn "sudo is not available and not running as root"
+	log_info "Skipping package installation as it requires elevated privileges"
+	exit 0
 fi
 
 # {{ if eq .chezmoi.os "linux" }}
 # {{ if eq .chezmoi.osRelease.id "ubuntu" "debian" }}
 
-echo "📦 Updating package lists..."
+log_step "Updating package lists"
 $SUDO_CMD apt-get update
 
-echo "📦 Installing packages with APT..."
+log_step "Installing packages with APT"
 # Install light mode packages (always)
 # {{ range .packages.linux.apt.light }}
-echo "Installing {{ . }}..."
+log_step "Installing {{ . }}"
 if $SUDO_CMD apt-get install -y {{ . | quote }}; then
-    echo "✅ Successfully installed {{ . }}"
+	log_result "Successfully installed {{ . }}"
 else
-    exit_code=$?
-    if [ $exit_code -eq 100 ]; then
-        echo "⚠️  Warning: Package {{ . }} not found in repositories"
-    else
-        echo "⚠️  Warning: Failed to install {{ . }} (exit code: $exit_code)"
-    fi
-    echo "   Continuing with remaining packages..."
+	exit_code=$?
+	if [ $exit_code -eq 100 ]; then
+		log_warn "Package {{ . }} not found in repositories"
+	else
+		log_warn "Failed to install {{ . }} (exit code: $exit_code)"
+	fi
+	log_info "Continuing with remaining packages..."
 fi
 # {{ end }}
 
 # {{ if eq .installType "full" }}
 # Install full mode packages (additional)
 # {{ range .packages.linux.apt.full }}
-echo "Installing {{ . }}..."
+log_step "Installing {{ . }}"
 if $SUDO_CMD apt-get install -y {{ . | quote }}; then
-    echo "✅ Successfully installed {{ . }}"
+	log_result "Successfully installed {{ . }}"
 else
-    exit_code=$?
-    if [ $exit_code -eq 100 ]; then
-        echo "⚠️  Warning: Package {{ . }} not found in repositories"
-    else
-        echo "⚠️  Warning: Failed to install {{ . }} (exit code: $exit_code)"
-    fi
-    echo "   Continuing with remaining packages..."
+	exit_code=$?
+	if [ $exit_code -eq 100 ]; then
+		log_warn "Package {{ . }} not found in repositories"
+	else
+		log_warn "Failed to install {{ . }} (exit code: $exit_code)"
+	fi
+	log_info "Continuing with remaining packages..."
 fi
 # {{ end }}
 # {{ end }}
 # {{ else if eq .chezmoi.osRelease.id "fedora" "rhel" "centos" }}
 
-echo "📦 Installing packages with DNF..."
+log_step "Installing packages with DNF"
 # Install light mode packages (always)
 # {{ range .packages.linux.dnf.light }}
-echo "Installing {{ . }}..."
+log_step "Installing {{ . }}"
 if $SUDO_CMD dnf install -y {{ . | quote }}; then
-    echo "✅ Successfully installed {{ . }}"
+	log_result "Successfully installed {{ . }}"
 else
-    echo "⚠️  Warning: Failed to install {{ . }}"
-    echo "   Continuing with remaining packages..."
+	log_warn "Failed to install {{ . }}"
+	log_info "Continuing with remaining packages..."
 fi
 # {{ end }}
 
 # {{ if eq .installType "full" }}
 # Install full mode packages (additional)
 # {{ range .packages.linux.dnf.full }}
-echo "Installing {{ . }}..."
+log_step "Installing {{ . }}"
 if $SUDO_CMD dnf install -y {{ . | quote }}; then
-    echo "✅ Successfully installed {{ . }}"
+	log_result "Successfully installed {{ . }}"
 else
-    echo "⚠️  Warning: Failed to install {{ . }}"
-    echo "   Continuing with remaining packages..."
+	log_warn "Failed to install {{ . }}"
+	log_info "Continuing with remaining packages..."
 fi
 # {{ end }}
 # {{ end }}
@@ -93,132 +97,124 @@ fi
 
 # Check if Homebrew packages are defined for Linux
 # {{ if or .packages.linux.brew.light .packages.linux.brew.full }}
-echo ""
 # Try to initialize Homebrew from standard locations if not already in PATH
 if ! command -v brew >/dev/null 2>&1; then
-    # Check standard Homebrew installation locations
-    if [ -x "/home/linuxbrew/.linuxbrew/bin/brew" ]; then
-        # Linux system-wide installation
-        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-    elif [ -x "$HOME/.linuxbrew/bin/brew" ]; then
-        # Linux user-local installation
-        eval "$($HOME/.linuxbrew/bin/brew shellenv)"
-    fi
+	# Check standard Homebrew installation locations
+	if [ -x "/home/linuxbrew/.linuxbrew/bin/brew" ]; then
+		# Linux system-wide installation
+		eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+	elif [ -x "$HOME/.linuxbrew/bin/brew" ]; then
+		# Linux user-local installation
+		eval "$($HOME/.linuxbrew/bin/brew shellenv)"
+	fi
 fi
 
 if command -v brew >/dev/null 2>&1; then
-    echo "📦 Installing packages with Homebrew..."
-    # {{ range .packages.linux.brew.light }}
-    echo "Installing {{ . }}..."
-    brew install {{ . | quote }}
-    # {{ end }}
-    # {{ if eq .installType "full" }}
-    # {{ range .packages.linux.brew.full }}
-    echo "Installing {{ . }}..."
-    brew install {{ . | quote }}
-    # {{ end }}
-    # {{ end }}
+	log_step "Installing packages with Homebrew"
+	# {{ range .packages.linux.brew.light }}
+	log_step "Installing {{ . }}"
+	brew install {{ . | quote }}
+	# {{ end }}
+	# {{ if eq .installType "full" }}
+	# {{ range .packages.linux.brew.full }}
+	log_step "Installing {{ . }}"
+	brew install {{ . | quote }}
+	# {{ end }}
+	# {{ end }}
 else
-    echo "⚠️  Homebrew not available. Skipping Homebrew packages:"
-    # {{ range .packages.linux.brew.light }}
-    echo "  - {{ . }} (not installed)"
-    # {{ end }}
-    # {{ if eq .installType "full" }}
-    # {{ range .packages.linux.brew.full }}
-    echo "  - {{ . }} (not installed)"
-    # {{ end }}
-    # {{ end }}
-    echo "ℹ️  You can install Homebrew later from https://brew.sh"
+	log_warn "Homebrew not available. Skipping Homebrew packages:"
+	# {{ range .packages.linux.brew.light }}
+	log_info "  - {{ . }} (not installed)"
+	# {{ end }}
+	# {{ if eq .installType "full" }}
+	# {{ range .packages.linux.brew.full }}
+	log_info "  - {{ . }} (not installed)"
+	# {{ end }}
+	# {{ end }}
+	log_hint "You can install Homebrew later from https://brew.sh"
 fi
 # {{ end }}
 # {{ else if eq .chezmoi.os "darwin" }}
 if ! command -v brew >/dev/null 2>&1; then
-    echo "❌ Homebrew not found. Please run the Homebrew installation script first."
-    echo "   The script should have run automatically if you're in full mode."
-    exit 1
+	log_error "Homebrew not found. Please run the Homebrew installation script first."
+	log_hint "The script should have run automatically if you're in full mode."
+	exit 1
 fi
 
-echo "📦 Installing packages with Homebrew..."
+log_step "Installing packages with Homebrew"
 # Install light mode packages (always)
 # {{ range .packages.darwin.brew.light }}
-echo "Installing {{ . }}..."
+log_step "Installing {{ . }}"
 brew install {{ . | quote }}
 # {{ end }}
 
 # {{ if eq .installType "full" }}
 # Install full mode packages (additional)
 # {{ range .packages.darwin.brew.full }}
-echo "Installing {{ . }}..."
+log_step "Installing {{ . }}"
 brew install {{ . | quote }}
 # {{ end }}
 # {{ end }}
 # {{ end }}
 
-echo "✅ Development tools installation complete ({{ .installType }} mode)!"
+log_result "Development tools installation complete ({{ .installType }} mode)"
 
 # Install VS Code extensions if code command is available
 # Skip in codespaces and dev containers as extensions are managed differently
 # {{ if and (not .codespaces) (not .devcontainer) }}
 if command -v code >/dev/null 2>&1; then
-    echo ""
-    echo "📦 Installing VS Code extensions..."
+	log_state "Installing VS Code extensions"
 
-    # Install common extensions
+	# Install common extensions
 # {{ range .extensions.common }}
-    echo -n "Checking {{ . }}... "
-    if code --list-extensions 2>/dev/null | grep -q "^{{ . }}$"; then
-        echo "[OK]"
-    else
-        echo "Installing..."
-        if code --install-extension {{ . | quote }} --force >/dev/null 2>&1; then
-            echo "  [OK] {{ . }} installed"
-        else
-            echo "  [FAILED] Could not install {{ . }}"
-        fi
-    fi
+	if code --list-extensions 2>/dev/null | grep -q "^{{ . }}$"; then
+		log_step "Extension {{ . }} already installed"
+	else
+		log_step "Installing extension {{ . }}"
+		if code --install-extension {{ . | quote }} --force >/dev/null 2>&1; then
+			log_result "Installed {{ . }}"
+		else
+			log_warn "Could not install {{ . }}"
+		fi
+	fi
 # {{ end }}
 
 # {{ if eq .chezmoi.os "linux" }}
-    # Install Linux-specific extensions
+	# Install Linux-specific extensions
 # {{ range .extensions.linux }}
-    echo -n "Checking {{ . }}... "
-    if code --list-extensions 2>/dev/null | grep -q "^{{ . }}$"; then
-        echo "[OK]"
-    else
-        echo "Installing..."
-        if code --install-extension {{ . | quote }} --force >/dev/null 2>&1; then
-            echo "  [OK] {{ . }} installed"
-        else
-            echo "  [FAILED] Could not install {{ . }}"
-        fi
-    fi
+	if code --list-extensions 2>/dev/null | grep -q "^{{ . }}$"; then
+		log_step "Extension {{ . }} already installed"
+	else
+		log_step "Installing extension {{ . }}"
+		if code --install-extension {{ . | quote }} --force >/dev/null 2>&1; then
+			log_result "Installed {{ . }}"
+		else
+			log_warn "Could not install {{ . }}"
+		fi
+	fi
 # {{ end }}
 # {{ else if eq .chezmoi.os "darwin" }}
-    # Install macOS-specific extensions
+	# Install macOS-specific extensions
 # {{ range .extensions.darwin }}
-    echo -n "Checking {{ . }}... "
-    if code --list-extensions 2>/dev/null | grep -q "^{{ . }}$"; then
-        echo "[OK]"
-    else
-        echo "Installing..."
-        if code --install-extension {{ . | quote }} --force >/dev/null 2>&1; then
-            echo "  [OK] {{ . }} installed"
-        else
-            echo "  [FAILED] Could not install {{ . }}"
-        fi
-    fi
+	if code --list-extensions 2>/dev/null | grep -q "^{{ . }}$"; then
+		log_step "Extension {{ . }} already installed"
+	else
+		log_step "Installing extension {{ . }}"
+		if code --install-extension {{ . | quote }} --force >/dev/null 2>&1; then
+			log_result "Installed {{ . }}"
+		else
+			log_warn "Could not install {{ . }}"
+		fi
+	fi
 # {{ end }}
 # {{ end }}
 
-    echo "[OK] VS Code extensions installation complete!"
+	log_result "VS Code extensions installation complete"
 else
-    echo ""
-    echo "[SKIP] VS Code not found, skipping extension installation"
+	log_info "VS Code not found, skipping extension installation"
 fi
 # {{ else }}
-echo ""
-echo "[SKIP] VS Code extensions skipped (codespace/devcontainer environment)"
+log_info "VS Code extensions skipped (codespace/devcontainer environment)"
 # {{ end }}
 
-echo ""
-echo "[COMPLETE] All installations finished!"
+log_banner "All installations finished" RESULT


### PR DESCRIPTION
Closes #237.

## What

Adopt the shared logging library [`log.sh`](home/dot_config/shell/functions/log.sh) across every chezmoi setup script in the repo, replacing ad-hoc `echo` statements (and per-file ANSI color helpers in some scripts) with consistent severity- and kind-aware output.

## Files converted

**Templates** (`*.sh.tmpl`, source via `{{ .chezmoi.sourceDir }}`):

- `home/.chezmoiscripts/linux/run_once_before_00-setup.sh.tmpl`
- `home/.chezmoiscripts/linux/run_once_before_01-install-ppas.sh.tmpl`
- `home/.chezmoiscripts/linux/run_once_before_05-install-homebrew.sh.tmpl`
- `home/.chezmoiscripts/linux/run_once_install-lefthook.sh.tmpl`
- `home/.chezmoiscripts/linux/run_onchange_00-apt-upgrade.sh.tmpl`
- `home/.chezmoiscripts/linux/run_onchange_01-brew-upgrade.sh.tmpl`
- `home/.chezmoiscripts/linux/run_onchange_02-mise-upgrade.sh.tmpl`
- `home/.chezmoiscripts/linux/run_onchange_10-install-packages.sh.tmpl`
- `home/.chezmoiscripts/darwin/run_once_before_10-setup-fish-default-shell.sh.tmpl`

**Plain scripts** (source via `${CHEZMOI_SOURCE_DIR}`):

- `home/.chezmoiscripts/linux/run_once_setup-gh-telemetry.sh`
- `home/.chezmoiscripts/linux/run_once_setup-lefthook.sh`

## Patterns established

```sh
# In .sh.tmpl files:
. "{{ .chezmoi.sourceDir }}/dot_config/shell/functions/log.sh"
LOG_TAG="install-packages"

# In plain .sh chezmoiscripts:
. "${CHEZMOI_SOURCE_DIR}/dot_config/shell/functions/log.sh"
# shellcheck disable=SC2034 # consumed by log.sh
LOG_TAG="setup-lefthook"
```

Substitution table used:

| Before | After |
| --- | --- |
| `echo "🚀 Running setup..."` | `log_state "Running setup"` |
| `echo "✅ Done!"` / `log_success "..."` | `log_result "Done"` |
| `echo "⚠️ ..." >&2` / `log_warning "..."` | `log_warn "..."` |
| `echo "❌ ..." >&2` / `log_error "..."` | `log_error "..."` |
| `echo "[INFO] msg"` | `log_info "msg"` |
| `echo "==== Phase ===="` | `log_banner "Phase" STATE` |
| `echo "$list" \| sed 's/^/   - /'` | piped through `log_data INFO "header"` |

The `home/.chezmoiscripts/linux/run_once_before_05-install-homebrew.sh.tmpl` and `darwin/...-fish-default-shell.sh.tmpl` files previously defined their own `RED/GREEN/YELLOW/WHITE/NC` color codes and `log_info/success/warning/error` helpers — those are removed in favor of `log.sh`.

## Out of scope

Per-issue scope, this PR only converts chezmoi scripts. The remaining echo-using files (`home/install.sh`, `install.sh`, `.github/scripts/*.sh`, user-facing utilities under `home/dot_config/shell/functions/*.sh`) can be tackled in follow-ups.

## Validation

- `bats tests/bash/test-chezmoi-scripts.bats tests/bash/validate-chezmoi.bats tests/bash/validate-shell-scripts.bats tests/bash/validate-fish-config.bats` — **49/49 pass**
- `lefthook run pre-commit` (staged files) — shellcheck + shfmt + executable-bit all green
- All converted templates render correctly via `chezmoi execute-template` and pass `bash -n`

## Side note

This PR also adds a top-level instruction to `.github/copilot-instructions.md` reminding the agent to **always wrap test/validation runs with a hard timeout** (≤ 60s for a single bats file, ≤ 300s for full `--ci`). A pre-existing local hang in `test-chezmoi-apply.bats` (chezmoi prompts when the destination already has a managed config) made it worth codifying.
