### PR TITLE
docs(log): explain log_data and clarify helper selection

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -12,17 +12,47 @@ The implementation lives in
 ```sh
 . "${HOME}/.config/shell/functions/log.sh"
 
-log_info   "starting"
-log_state  "Deploying app"          # cyan, info-priority
-log_result "30 deployed, 0 failed"  # green
-log_hint   "Re-run to fix"          # magenta
-log_step   "Pulling images"         # dim
+log_info   "starting"                # plain fact
+log_state  "Deploying app"           # cyan, action in progress
+log_result "30 deployed, 0 failed"   # green, outcome
+log_hint   "Re-run to fix"           # magenta, suggested next step
+log_step   "Pulling images"          # dim, numbered/wizard step
 log_warn   "fallback used"
 log_error  "connection failed"
-log_banner "Phase 1 complete" RESULT
 log_kv     duration=12s app=adguard status=ok
-printf '%s\n' "$payload" | log_data INFO config
+log_banner "Phase 1 complete" RESULT
+
+# Wrap noisy subcommand output so each line stays grep-able and
+# visually grouped under one header line:
+docker compose pull 2>&1 | log_data INFO "Pulling images for adguard"
 ```
+
+## Choosing a helper
+
+Reach for the helper that best matches **what you're saying**, not just the
+severity:
+
+| You want to log…                                | Helper                            |
+| ----------------------------------------------- | --------------------------------- |
+| A plain informational fact                      | `log_info`                        |
+| The action the script is currently taking       | `log_state "Deploying app"`       |
+| The outcome of an operation (counts, totals)    | `log_result "30 deployed, 0 failed"` |
+| A suggestion for the reader                     | `log_hint "Re-run with -v"`       |
+| One step in a numbered / wizard-style sequence  | `log_step "Pulling images"`       |
+| A noteworthy event that isn't a problem         | `log_notice`                      |
+| A recoverable problem / fallback engaged        | `log_warn`                        |
+| A failed operation; script may continue         | `log_error`                       |
+| A failure the script will exit on               | `log_fatal`                       |
+| An implementation detail (off by default)       | `log_debug` / `log_trace`         |
+| Telemetry as flat key/value pairs               | `log_kv k=v k=v …`                |
+| Multi-line payload (YAML/JSON/command output)   | `… \| log_data KIND "header"`     |
+| Unbroken divider between groups                 | `log_sep`                         |
+| Titled divider for a phase change               | `log_rule KIND "phase 1"`         |
+| Boxed/wrapped title for a top-level boundary    | `log_banner "Done" RESULT`        |
+
+`STATE` / `RESULT` / `HINT` / `STEP` are info-priority kinds — they never
+change filtering behaviour, only color and label. Use them so `grep RESULT`
+finds outcomes and `grep HINT` finds suggestions.
 
 ## Severity levels vs kinds
 
@@ -161,7 +191,24 @@ log_kv "msg=hello world" status=ok           # values with spaces auto-quoted
 
 Reads the payload from stdin. On a TTY the payload lines are prefixed with
 `│ ` so they visually belong to the previous header line; in `LOG_FILE` the
-prefix is `| ` (ASCII).
+prefix is `| ` (ASCII). The whole block shares **one timestamp**, which is
+what groups it.
+
+The primary use case is wrapping the output of another command without
+losing the rest of the log's structure:
+
+```sh
+docker compose pull 2>&1 | log_data INFO "Pulling images for adguard"
+```
+
+```text
+2026-04-30 19:36:02 INFO   [deploy] Pulling images for adguard
+2026-04-30 19:36:02 INFO   [deploy] │ [+] Pulling 6/6
+2026-04-30 19:36:02 INFO   [deploy] │  ✔ adguard-redis Pulled    0.3s
+2026-04-30 19:36:02 INFO   [deploy] │  ✔ adguard Pulled          0.4s
+```
+
+It also works for any payload variable:
 
 ```sh
 printf '%s\n' "$yaml" | log_data INFO "config"

--- a/home/dot_config/shell/functions/log.sh
+++ b/home/dot_config/shell/functions/log.sh
@@ -7,16 +7,42 @@
 # Quick start
 # -----------
 #   . "${HOME}/.config/shell/functions/log.sh"
-#   log_info   "starting"
-#   log_state  "Deploying app"          # cyan, info-priority
-#   log_result "30 deployed, 0 failed"  # green
-#   log_hint   "Re-run to fix"          # magenta
-#   log_step   "Pulling images"         # dim
-#   log_warn   "fallback used"
-#   log_error  "connection failed"
-#   log_banner "Phase 1 complete" RESULT
-#   log_kv     duration=12s app=adguard status=ok
-#   printf '%s\n' "$payload" | log_data INFO config
+#   log_info   "starting"                # plain fact
+#   log_state  "Deploying app"           # cyan, action in progress
+#   log_result "30 deployed, 0 failed"   # green, outcome
+#   log_hint   "Re-run to fix"           # magenta, suggested next step
+#   log_step   "Pulling images"          # dim, numbered/wizard step
+#   log_warn   "fallback used"           # bold yellow
+#   log_error  "connection failed"       # bold red
+#   log_kv     duration=12s app=adguard status=ok      # logfmt key/value
+#   docker compose pull 2>&1 | log_data INFO "Pulling images for adguard"
+#   log_rule   STATE "phase 1"           # titled divider
+#   log_banner "Phase 1 complete" RESULT # boxed/wrapped title
+#
+# Choosing a helper
+# -----------------
+# Severity (filterable):
+#   log_trace / log_debug   - implementation detail, off by default
+#   log_info                - default informational fact
+#   log_notice              - noteworthy but not a problem
+#   log_warn                - recoverable problem, fallback engaged
+#   log_error               - operation failed; script may continue
+#   log_fatal               - operation failed; script will exit
+# Kinds (info-priority, never filtered, used for visual scanning):
+#   log_state               - what the script is currently doing
+#   log_result              - outcome of an operation (counts, totals)
+#   log_hint                - actionable suggestion for the reader
+#   log_step                - numbered or sequential step in a flow
+# Structured / structural:
+#   log_kv  k=v k=v ...     - one logfmt line of flat key/value pairs
+#   log_data KIND "hdr"     - header + multi-line payload from stdin;
+#                             continuation lines are prefixed with `│ `
+#                             (stdio) / `| ` (file). Use this whenever you
+#                             need to wrap the noisy output of another
+#                             command so each line stays grep-able.
+#   log_sep                 - unbroken divider (one row of one character)
+#   log_rule  KIND "title"  - titled divider, e.g. `──── title ────────`
+#   log_banner "title" KIND - boxed / wrapped title for phase boundaries
 #
 # Severity vs kind
 # ----------------
@@ -644,6 +670,18 @@ log_step() { _log_emit INFO STEP "$*"; }
 # ----------------------------------------------------------------------------
 # Public: log_kv (logfmt)
 # ----------------------------------------------------------------------------
+#
+# Emit one INFO line composed of `key=value` pairs in logfmt syntax. Values
+# containing whitespace, embedded `"`, or newlines are auto-quoted and the
+# inner quotes/backslashes escaped. Bare arguments without `=` are passed
+# through verbatim, which is useful for a leading message:
+#
+#   log_kv "deploy ok" duration=12s app=adguard status=ok
+#   # -> 2026-04-29 20:27:28 INFO   deploy ok duration=12s app=adguard status=ok
+#
+# Use this for telemetry-style lines that another tool (jq, awk, Grafana
+# Loki, etc.) will parse. For a single multi-line payload (YAML/JSON/command
+# output), use log_data instead.
 
 log_kv() {
 	# Each argument is a key=value pair. Quote values with whitespace or "=".
@@ -677,6 +715,32 @@ log_kv() {
 # ----------------------------------------------------------------------------
 # Public: log_data (read payload from stdin)
 # ----------------------------------------------------------------------------
+#
+# Usage:
+#   log_data <SEVERITY-or-KIND> <header message...>      # payload on stdin
+#
+# Reads the entire payload from stdin and emits one header line followed by
+# one continuation line per payload line. On a TTY (and non-JSON stdio)
+# continuation lines are prefixed with `│ `; in LOG_FILE the prefix is the
+# ASCII `| ` so the file stays grep-friendly. The whole block shares one
+# timestamp, which is what visually groups it.
+#
+# Typical use is wrapping the noisy output of a subcommand:
+#
+#   docker compose pull 2>&1 | log_data INFO "Pulling images for adguard"
+#   # 2026-04-29 20:27:28 INFO   [deploy] Pulling images for adguard
+#   # 2026-04-29 20:27:28 INFO   [deploy] │ [+] Pulling 6/6
+#   # 2026-04-29 20:27:28 INFO   [deploy]  │  ✔ adguard Pulled    0.4s
+#
+# Or printing a structured payload from a variable:
+#
+#   printf '%s\n' "$yaml" | log_data STATE "effective config"
+#
+# In LOG_FORMAT=json mode the entire payload is collapsed into a single JSON
+# object's `data` field (with embedded newlines preserved as the literal
+# two-char `\n` sequence) so the entry remains one JSON Line. Pass any
+# severity (INFO, WARN, ERROR, ...) or kind (STATE, RESULT, ...) as the
+# first argument to set both color and syslog priority.
 
 log_data() {
 	# log_data <KIND> <message...>
@@ -700,6 +764,30 @@ log_data() {
 # ----------------------------------------------------------------------------
 # Public: banners & rules
 # ----------------------------------------------------------------------------
+#
+# Three structural helpers, ordered by visual weight:
+#
+#   log_sep    [KIND]            unbroken divider, one row of one character.
+#                                Use to separate adjacent log groups.
+#                                  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#
+#   log_rule   [KIND] <title>    titled divider, four leading chars + title
+#                                + remainder. Use to mark a phase change
+#                                inside a script without taking three lines.
+#                                  ──── phase 1 ───────────────────────────
+#
+#   log_banner <title> [KIND]    full banner: separator, title, separator
+#                                (or a UTF-8 box, depending on
+#                                LOG_BANNER_STYLE). Use sparingly for
+#                                top-level phase boundaries — start of run,
+#                                end of run, fatal failure, etc.
+#                                  ┌──────────────────────────────────────┐
+#                                  │ Setup complete                       │
+#                                  └──────────────────────────────────────┘
+#
+# All three respect LOG_BANNER_STYLE (unicode|ascii|heavy|box|rule),
+# LOG_RULE_WIDTH, LOG_RULE_CHAR, and the LANG=C / no-TTY / LOG_FILE / json
+# fallbacks documented near the top of this file.
 
 log_sep() {
 	_b_kind="${1:-INFO}"


### PR DESCRIPTION
## Summary

While migrating the `truenas-apps` deploy script to `log.sh` I reached for a custom `log_pipe` wrapper before realising that `log_data` already does exactly the right thing — wrap the multi-line output of a subcommand under one timestamped header with a `│ ` continuation prefix per line.

The library docs under-emphasised `log_data` (the example used a cryptic `printf '%s\n' "$payload" | log_data INFO config`), and there was no decision guide explaining when to reach for which helper. This PR fixes that across the in-source docstring and `docs/logging.md`.

## Changes

### `log.sh` header docstring
- **Quick start**: every helper now has a one-line "what this is for" comment, and the `log_data` example is the realistic `docker compose pull 2>&1 | log_data INFO "Pulling images for adguard"` rather than `printf '%s\n' "$payload" | log_data INFO config`.
- **New "Choosing a helper" section**: maps intent → helper for severities (`info` / `notice` / `warn` / `error` / `fatal` / `debug` / `trace`), kinds (`state` / `result` / `hint` / `step`), and structural helpers (`kv` / `data` / `sep` / `rule` / `banner`).

### `log.sh` per-helper section comments
- **`log_kv`**: now explains the auto-quoting rules, when to use it for telemetry, and how it differs from `log_data`.
- **`log_data`**: full description of the `│ ` (stdio) / `| ` (file) continuation rendering, the shared timestamp behaviour, and **two worked examples** — the `docker compose pull` pipe and a `printf "$yaml" | log_data STATE "effective config"` payload. Mentions the JSON-mode `data` collapse.
- **`log_sep` / `log_rule` / `log_banner`**: now show ASCII-art samples of each style so the difference between *unbroken divider*, *titled divider*, and *full banner* is obvious; explicitly recommends `log_banner` only for top-level boundaries.

### `docs/logging.md`
- **Quick start** rewritten with the practical pipe example as the highlight.
- **New "Choosing a helper" decision table** — `you want to log… → use X` — mirrors the in-source guide so readers find the right helper from intent rather than browsing the API.
- **`log_data` subsection** now leads with the `docker compose pull` example and the rendered `│ `-prefixed output, before the original "payload from a variable" example.

## Why

The motivating bug: in `truenas-apps#267` I added a custom `log_pipe` helper to wrap `docker compose pull` output, only to discover in `truenas-apps#268` that `log_data` was already there and rendered better. The docs didn't make that discoverable.

## Verification

- `shellcheck home/dot_config/shell/functions/log.sh` — clean
- `shfmt --diff home/dot_config/shell/functions/log.sh` — clean
- `./tests/bash/run-tests.sh --test log-structured.bats` — all 13 tests pass
- Comment / docs-only change; no behaviour change.
