### PR TITLE
refactor(release): use central release-publish composite action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,8 @@ jobs:
     permissions:
       contents: write
       # Required by actions/attest-build-provenance to mint the OIDC token
-      # used as the Sigstore signing identity.
+      # used as the Sigstore signing identity. Must stay declared in the
+      # caller workflow (not the composite) — see the action's README.
       id-token: write
       attestations: write
     steps:
@@ -29,43 +30,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-
-      - name: Install mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
-        with:
-          install: true
-          cache: true
-          # renovate: datasource=github-releases depName=jdx/mise
-          version: "2026.4.9"
-
-      - name: Generate release notes
-        env:
-          TAG: ${{ github.ref_name }}
-          REPO: ${{ github.repository }}
-        run: |
-          mise exec -- git-cliff --latest --strip all > /tmp/release-notes.md
-          {
-            printf '\n---\n\n'
-            printf '## log.sh distribution\n\n'
-            printf 'This release includes a vendorable copy of `log.sh`. See '
-            printf '[docs/logging.md](https://github.com/%s/blob/%s/docs/logging.md#consuming-logsh-from-other-repositories) ' \
-              "${REPO}" "${TAG}"
-            printf 'for the consumption snippet.\n\n'
-            printf '```sh\n'
-            printf 'curl -fsSL https://github.com/%s/releases/download/%s/log.sh -o scripts/lib/log.sh\n' \
-              "${REPO}" "${TAG}"
-            printf 'curl -fsSL https://github.com/%s/releases/download/%s/log.sh.sha256 -o scripts/lib/log.sh.sha256\n' \
-              "${REPO}" "${TAG}"
-            printf '( cd scripts/lib && sha256sum -c log.sh.sha256 )\n'
-            printf '```\n\n'
-            printf '### Verifying provenance\n\n'
-            printf 'Each binary asset is attested via [GitHub Artifact Attestations](https://docs.github.com/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds). '
-            printf 'Verify with the GitHub CLI:\n\n'
-            printf '```sh\n'
-            printf 'gh attestation verify ./log.sh --repo %s\n' "${REPO}"
-            printf 'gh attestation verify ./log-sh-%s.tar.gz --repo %s\n' "${TAG}" "${REPO}"
-            printf '```\n'
-          } >> /tmp/release-notes.md
 
       - name: Build log.sh release artifacts
         run: ./script/build-log-sh-release.sh "${{ github.ref_name }}" "${GITHUB_WORKSPACE}/dist"
@@ -81,6 +45,8 @@ jobs:
         # via Sigstore. Verifiable with `gh attestation verify <file>`.
         # Sidecar .sha256 files are intentionally not attested — their
         # integrity is already proven by re-hashing the content they cover.
+        # Stays in the caller (not the composite) so the OIDC subject is
+        # this repo, not DevSecNinja/.github.
         # renovate: datasource=github-tags depName=actions/attest-build-provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
@@ -88,21 +54,22 @@ jobs:
             dist/log.sh
             dist/log-sh-${{ github.ref_name }}.tar.gz
 
-      - name: Create immutable GitHub Release
-        # Single-shot upload: notes, title, and all four assets in one
-        # `gh release create` call so the release can be marked immutable
-        # in repo Settings → General → Releases without conflicting with
-        # later edits/uploads.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
-          REPO: ${{ github.repository }}
-        run: |
-          gh release create "${TAG}" \
-            --repo "${REPO}" \
-            --title "${TAG}" \
-            --notes-file /tmp/release-notes.md \
-            "dist/log.sh" \
-            "dist/log.sh.sha256" \
-            "dist/log-sh-${TAG}.tar.gz" \
-            "dist/log-sh-${TAG}.tar.gz.sha256"
+      - name: Publish release
+        # Composite action provides: git-cliff notes generation, optional
+        # preset notes block, and a single-shot Immutable-Releases compatible
+        # `gh release create`. See the action's README for the rationale.
+        #
+        # NOTE: pinned to the PR branch in DevSecNinja/.github#32. Re-pin
+        # to the merged-on-main SHA once that PR lands.
+        # renovate: datasource=github-tags depName=DevSecNinja/.github
+        uses: DevSecNinja/.github/actions/release-publish@1f5bcf20495c36c07f1040a4f79a8053a4649cdb # feat/release-publish-action
+        with:
+          # renovate: datasource=github-releases depName=jdx/mise
+          mise-version: "2026.4.9"
+          tag: ${{ github.ref_name }}
+          extra-notes: log-sh
+          assets: |
+            dist/log.sh
+            dist/log.sh.sha256
+            dist/log-sh-${{ github.ref_name }}.tar.gz
+            dist/log-sh-${{ github.ref_name }}.tar.gz.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,11 +58,8 @@ jobs:
         # Composite action provides: git-cliff notes generation, optional
         # preset notes block, and a single-shot Immutable-Releases compatible
         # `gh release create`. See the action's README for the rationale.
-        #
-        # NOTE: pinned to the PR branch in DevSecNinja/.github#32. Re-pin
-        # to the merged-on-main SHA once that PR lands.
         # renovate: datasource=github-tags depName=DevSecNinja/.github
-        uses: DevSecNinja/.github/actions/release-publish@1f5bcf20495c36c07f1040a4f79a8053a4649cdb # feat/release-publish-action
+        uses: DevSecNinja/.github/actions/release-publish@ee0804b737700aeecd6d1b1bc85ab57107c880e3 # main
         with:
           # renovate: datasource=github-releases depName=jdx/mise
           mise-version: "2026.4.9"


### PR DESCRIPTION
## Summary

Slims `.github/workflows/release.yml` from **80 lines → 47 lines** by replacing the inline mise-install + git-cliff + custom-notes + `gh release create` steps with a single call to the new central composite action **`DevSecNinja/.github/actions/release-publish`** (proposed in DevSecNinja/.github#32).

```diff
-      - name: Install mise (...)
-      - name: Generate release notes (... 27 lines of printf ...)
-      - ... build + verify + attest stay inline ...
-      - name: Create immutable GitHub Release (... 12 lines of gh release create ...)
+      - ... build + verify + attest stay inline (caller-side, OIDC-bound) ...
+      - name: Publish release
+        uses: DevSecNinja/.github/actions/release-publish@<sha>
+        with:
+          mise-version: "2026.4.9"
+          tag: ${{ github.ref_name }}
+          extra-notes: log-sh
+          assets: |
+            dist/log.sh
+            dist/log.sh.sha256
+            dist/log-sh-${{ github.ref_name }}.tar.gz
+            dist/log-sh-${{ github.ref_name }}.tar.gz.sha256
```

## Behaviour preserved

| Concern | Before | After |
| --- | --- | --- |
| Notes generation | `git-cliff --latest --strip all` inline | Same flags, enforced by composite |
| `log.sh` consumption snippet | Inline `printf` block | `extra-notes: log-sh` preset in composite |
| Build step | `script/build-log-sh-release.sh` in this job | Unchanged (stays in caller) |
| `attest-build-provenance` | In this job | **Stays in this job** (OIDC must be caller's — see action README) |
| Asset upload | Single-shot `gh release create` with 4 assets | Same call shape, in composite |
| Concurrency / permissions | Same | Same |

## Why is the build/attest still inline?

`actions/attest-build-provenance` mints the OIDC token **of the job that runs it**. If we moved it into the composite (which lives in `DevSecNinja/.github`), the attestation would be signed against `DevSecNinja/.github` instead of `DevSecNinja/dotfiles`, and `gh attestation verify ... --repo DevSecNinja/dotfiles` would fail. This is the lesson recorded in [`.github/skills/commit-and-release/SKILL.md`](.github/skills/commit-and-release/SKILL.md#L350-L355) — now also encoded in the composite's README.

## ⚠️ Action SHA pin

Currently pinned to the PR branch SHA (`1f5bcf2`) of DevSecNinja/.github#32. **Re-pin to the merged-on-main SHA after that PR merges**, then bump+release as the validation pass.

## Validation plan

1. Merge DevSecNinja/.github#32
2. Re-pin this workflow's `uses:` line to the merge-commit SHA
3. Cut a `chore(version): v0.1.4` patch via `task release:bump -- --patch`
4. Verify: release notes look identical, all 4 assets present, `gh attestation verify ./log.sh --repo DevSecNinja/dotfiles` still passes

## Related

- DevSecNinja/.github#32 — adds the composite