### PR TITLE
fix(log): color stderr writes when stdout is a pipe

### DIFF
--- a/home/dot_config/shell/functions/log.sh
+++ b/home/dot_config/shell/functions/log.sh
@@ -242,7 +242,6 @@ _log_use_color_for_fd() {
 		esac
 	fi
 
-	test -t 1 || return 1
 	test -t "$1" || return 1
 	case "${TERM:-}" in
 	"" | dumb) return 1 ;;


### PR DESCRIPTION
## Summary

`_log_use_color_for_fd` required both fd 1 and the target fd to be TTYs. Inside any pipeline (e.g. `cmd | while read l; do log_warn ...; done`, which is exactly what `dccd` does) fd 1 is a pipe even though stderr is still the user's terminal — so `log_warn` / `log_error` / `log_fatal` lost their color.

Drop the spurious `test -t 1` check; only the destination fd determines whether to emit ANSI codes.

## Repro

```sh
. ~/.config/shell/functions/log.sh
echo x | { read l; log_warn "no color before"; }              # stderr=tty, but no color
LOG_FORCE_TTY=1 sh -c '. ~/.config/shell/functions/log.sh; echo x | { read l; log_warn from-pipe; }'  # forced path also worked
```

After this fix the auto path matches the documented behaviour: WARN is bold yellow on stderr regardless of how stdout is plumbed (matches the dccd output the user reported).

## Tests

All 66 `log-*` bats tests still pass locally.