### PR TITLE
chore(release): re-pin reusable to v1.1.0 and wire App token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,10 @@ name: Release Please
 # `.github/workflows/release.yml` (the tag-triggered workflow that builds
 # log.sh artifacts, attests them, and publishes the immutable release).
 #
+# The release PR is opened by the DevSecNinja Release Please GitHub
+# App (not GITHUB_TOKEN) so required CI checks fire on the PR — see
+# DevSecNinja/.github docs/release-please-onboarding.md.
+#
 # Branch protection is fully respected: every release commit lands via
 # PR through normal CI. No bypass actor required.
 #
@@ -29,10 +33,12 @@ concurrency:
 
 jobs:
   release-please:
-    # NOTE: pinned to the PR branch in DevSecNinja/.github#33. Re-pin to
-    # the merged-on-main SHA once that PR lands.
     # renovate: datasource=github-tags depName=DevSecNinja/.github
-    uses: DevSecNinja/.github/.github/workflows/release-please.yml@7ed381a72cf3d86d34aa5db3818dd468968e46ce # feat/release-please-reusable
+    uses: DevSecNinja/.github/.github/workflows/release-please.yml@e7037884132e77504ca7f50a23e98f594d1c764b # v1.1.0
     permissions:
       contents: write
       pull-requests: write
+    with:
+      app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+    secrets:
+      app-private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Re-pins the central release-please reusable from the temporary feature-branch SHA (`7ed381a…`) to the freshly tagged `v1.1.0`, and adds the GitHub App credential wiring.

`v1.1.0` was cut 2026-05-01 by release-please itself in the `.github` repo (eating its own dog food). It bundles the App-token wiring (#37) and the Node 24 bump (#42).

## Why both changes together

- **The pin bump alone is cosmetic** — `v1.1.0` is the same code as the feature SHA but renamed.
- **The App credentials are the actual functional change.** Right now the next release-please PR in this repo would still open as `GITHUB_TOKEN`, which by GitHub design does not fire `pull_request: opened` events → CI never runs → branch protection blocks the merge. With App credentials in place, the next release-please run opens its PR as `devsecninja-release-please[bot]` → `pull_request: opened` fires → CI runs → branch protection is satisfied.

## Prerequisites

Already done per user confirmation. For reference (one-time, per repo):

- [x] App `DevSecNinja Release Please` (ID `3563533`) installed.
- [x] Variable `RELEASE_PLEASE_APP_ID` = `3563533`.
- [x] Secret `RELEASE_PLEASE_APP_PRIVATE_KEY` set.
- [x] Settings → Actions → "Allow GitHub Actions to create and approve pull requests".

## What happens after merge

1. Push to `main` triggers the caller workflow.
2. release-please scans Conventional Commits since `v0.1.4` and opens the next `chore(main): release …` PR — this time as the App.
3. CI runs on the new PR → branch protection green → merge → tag → existing tag-triggered `release.yml` builds + attests + publishes log.sh artifacts.