### PR TITLE
feat(git): add 'sco' alias for auto-stash checkout

### DIFF
--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -46,6 +46,18 @@
 	amend = commit --amend --no-edit
 	config-list = config --list --show-origin
 	ignored = ls-files --ignored --exclude-standard --others
+	# Auto-stash, checkout, then pop the stash (mirrors merge/rebase autoStash).
+	# Usage: git sco <branch>
+	sco = "!f() { \
+		if git diff-index --quiet HEAD -- && [ -z \"$(git ls-files --others --exclude-standard)\" ]; then \
+			git checkout \"$@\"; \
+		else \
+			msg=\"auto-stash before checkout $*\"; \
+			git stash push --include-untracked -m \"$msg\" >/dev/null && \
+			git checkout \"$@\" && \
+			git stash pop; \
+		fi; \
+	}; f"
 
 # {{ if and (eq .chezmoi.os "darwin") (not .codespaces) }}
 [credential]


### PR DESCRIPTION
## Summary

Adds a `git sco` alias that auto-stashes (including untracked files) before checking out a branch, then pops the stash afterwards. Skips the stash dance when the working tree is already clean.

## Why

`merge.autoStash` and `rebase.autoStash` already cover `git pull` / `git rebase`, but git has **no** native `checkout.autoStash` equivalent. The closest built-in is `git checkout --merge <branch>`, which performs a 3-way merge of dirty changes into the target branch and can produce conflicts — usually not what's wanted.

## Usage

```fish
git sco main
git sco -b new-feature
```

If `git stash pop` hits a conflict after checkout, the stash is preserved (standard git behavior) so it can be resolved and dropped manually.