### PR TITLE
ci(sign-powershell): open PR instead of pushing to protected main

### DIFF
--- a/.github/workflows/sign-powershell.yml
+++ b/.github/workflows/sign-powershell.yml
@@ -68,24 +68,60 @@ jobs:
             echo "Changes detected - scripts were signed"
           fi
 
-      - name: Commit signed scripts
-        if: steps.check_changes.outputs.changes == 'true' && github.event_name != 'pull_request'
+      # Branch protection on `main` blocks direct pushes from
+      # `github-actions[bot]`, and we deliberately do NOT sign on pull_request
+      # events (any PR author would otherwise get their scripts signed with
+      # the maintainer's certificate). Instead, after a push to `main`, open a
+      # follow-up PR with the signed files via the preinstalled `gh` CLI so
+      # the change still goes through the protected-branch flow. The PR is
+      # created with the default GITHUB_TOKEN, so the bot's commit will not
+      # retrigger workflows on push (preventing signing loops). When the PR
+      # is merged, this workflow re-runs but finds no diff and exits as a
+      # no-op.
+      - name: Open PR with signed scripts
+        if: steps.check_changes.outputs.changes == 'true'
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          HEAD_SHA: ${{ github.sha }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "*.ps1"
-          git commit -m "chore: sign PowerShell scripts [skip ci]"
-          git push
+          set -euo pipefail
 
-      - name: Comment on PR
-        if: steps.check_changes.outputs.changes == 'true' && github.event_name == 'pull_request'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '✅ PowerShell scripts have been signed. Please pull the latest changes after merge.'
-            })
+          BRANCH="chore/sign-powershell-scripts"
+          TITLE="chore: sign PowerShell scripts"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Recreate the branch from the current main so each run produces a
+          # clean, single-commit PR rather than accumulating history.
+          git checkout -B "$BRANCH"
+          git add '**/*.ps1'
+          git commit -m "$TITLE"
+          git push --force-with-lease origin "$BRANCH"
+
+          # If a PR for this branch already exists (previous run not yet
+          # merged), gh pr create exits non-zero. Reuse the existing PR in
+          # that case — the force-push above already updated its contents.
+          BODY=$(cat <<EOF
+          Automated signing of PowerShell scripts after merge to \`main\`.
+
+          Triggered by: $HEAD_COMMIT_MESSAGE
+          Commit: $HEAD_SHA
+
+          Merging this PR replaces the direct push the workflow used to
+          perform, which is blocked by branch protection on \`main\`.
+          EOF
+          )
+
+          if ! gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "$TITLE" \
+              --body "$BODY" \
+              --label automated \
+              --label chore; then
+            echo "PR already exists for $BRANCH; updated via force-push."
+            gh pr view "$BRANCH" --json number,url
+          fi

--- a/.github/workflows/sign-powershell.yml
+++ b/.github/workflows/sign-powershell.yml
@@ -56,72 +56,30 @@ jobs:
             exit 1
           }
 
-      - name: Check for changes
-        id: check_changes
-        shell: bash
-        run: |
-          if git diff --quiet; then
-            echo "changes=false" >> $GITHUB_OUTPUT
-            echo "No changes detected - all scripts already signed"
-          else
-            echo "changes=true" >> $GITHUB_OUTPUT
-            echo "Changes detected - scripts were signed"
-          fi
-
       # Branch protection on `main` blocks direct pushes from
       # `github-actions[bot]`, and we deliberately do NOT sign on pull_request
       # events (any PR author would otherwise get their scripts signed with
       # the maintainer's certificate). Instead, after a push to `main`, open a
-      # follow-up PR with the signed files via the preinstalled `gh` CLI so
-      # the change still goes through the protected-branch flow. The PR is
-      # created with the default GITHUB_TOKEN, so the bot's commit will not
-      # retrigger workflows on push (preventing signing loops). When the PR
-      # is merged, this workflow re-runs but finds no diff and exits as a
-      # no-op.
+      # follow-up PR with the signed files so the change still goes through
+      # the protected-branch flow. The PR is created with the default
+      # GITHUB_TOKEN, so the bot's commit will not retrigger workflows on
+      # push (preventing signing loops). When the PR is merged, this workflow
+      # re-runs but the composite finds no diff and exits as a no-op.
       - name: Open PR with signed scripts
-        if: steps.check_changes.outputs.changes == 'true'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-          HEAD_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
+        # renovate: datasource=github-tags depName=DevSecNinja/.github
+        uses: DevSecNinja/.github/actions/open-pr@6764c0fb5ffc25207571b159dc255c8f77922c62 # main
+        with:
+          branch: chore/sign-powershell-scripts
+          title: 'chore: sign PowerShell scripts'
+          paths: '**/*.ps1'
+          labels: |
+            automated
+            chore
+          body: |
+            Automated signing of PowerShell scripts after merge to `main`.
 
-          BRANCH="chore/sign-powershell-scripts"
-          TITLE="chore: sign PowerShell scripts"
+            Triggered by: ${{ github.event.head_commit.message }}
+            Commit: ${{ github.sha }}
 
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          # Recreate the branch from the current main so each run produces a
-          # clean, single-commit PR rather than accumulating history.
-          git checkout -B "$BRANCH"
-          git add '**/*.ps1'
-          git commit -m "$TITLE"
-          git push --force-with-lease origin "$BRANCH"
-
-          # If a PR for this branch already exists (previous run not yet
-          # merged), gh pr create exits non-zero. Reuse the existing PR in
-          # that case — the force-push above already updated its contents.
-          BODY=$(cat <<EOF
-          Automated signing of PowerShell scripts after merge to \`main\`.
-
-          Triggered by: $HEAD_COMMIT_MESSAGE
-          Commit: $HEAD_SHA
-
-          Merging this PR replaces the direct push the workflow used to
-          perform, which is blocked by branch protection on \`main\`.
-          EOF
-          )
-
-          if ! gh pr create \
-              --base main \
-              --head "$BRANCH" \
-              --title "$TITLE" \
-              --body "$BODY" \
-              --label automated \
-              --label chore; then
-            echo "PR already exists for $BRANCH; updated via force-push."
-            gh pr view "$BRANCH" --json number,url
-          fi
+            Merging this PR replaces the direct push the workflow used to
+            perform, which is blocked by branch protection on `main`.


### PR DESCRIPTION
## Summary

Fixes the broken [`Sign PowerShell Scripts`](https://github.com/DevSecNinja/dotfiles/actions/workflows/sign-powershell.yml) workflow. After merging #253, the post-merge signing run failed because branch protection on `main` blocks the `github-actions[bot]` from pushing the signed-script commit directly.

You explicitly **don't** want to:

1. Weaken or bypass branch protection on `main`.
2. Sign on `pull_request` events — third-party PR authors would otherwise get their `.ps1` files signed with your code-signing certificate.
3. Pull in a third-party action just for opening a PR.

## Approach

Mirror the release-please pattern: open a follow-up PR with the signed scripts instead of pushing directly. Implemented with the **preinstalled `gh` CLI** (no third-party action) using the default `GITHUB_TOKEN`.

## Changes

- Replace the `Commit signed scripts` (direct `git push`) step with a `gh pr create` step.
  - Recreates the `chore/sign-powershell-scripts` branch from each run's main, force-pushes, and opens (or updates, if one is already open) the PR.
- Drop the now-unreachable `Comment on PR` step — the workflow only triggers on `push` to `main`.
- Add a comment block in the workflow explaining the design (no bypass, no signing loop, no PR-author signing, no third-party action).

## Why this is safe

- **Branch protection stays fully enforced.** The bot opens a PR; you merge it like any other change. No bypass actor (matches the “no bypass actor” pattern used for release-please).
- **PRs are still not signed.** Trigger remains `push` on `main` only.
- **No infinite signing loop.** PRs created with the default `GITHUB_TOKEN` do not retrigger workflows on push. When the auto-PR is merged, the workflow re-runs, sees no diff, and exits as a no-op.
- **No new third-party dependency.** Only first-party tooling: `git` + `gh`, both preinstalled on `windows-latest`.

## One-time setup needed

Repository **Settings → Actions → General → Workflow permissions** must have **“Allow GitHub Actions to create and approve pull requests”** enabled. (Likely already on if release-please is creating PRs in this repo.)

## Verification

After merging, push any `.ps1` change to `main` and confirm:

1. The workflow signs the scripts.
2. A `chore: sign PowerShell scripts` PR is opened on branch `chore/sign-powershell-scripts`.
3. Merging that PR causes the workflow to re-run with no diff (no-op).