### PR TITLE
chore(ci): bump notify-irm action to b2509636

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -507,7 +507,7 @@ jobs:
       contents: read
     steps:
       - name: Notify Grafana IRM
-        uses: DevSecNinja/.github/.github/actions/notify-irm@a877d35266a54e54ef043e60a290ed76b4d7b34e # main
+        uses: DevSecNinja/.github/.github/actions/notify-irm@b2509636243e456253c938184dfe1855d6401e6d # main
         with:
           webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
           # `needs.*.result` is system-controlled, safe to interpolate.

--- a/.github/workflows/devcontainer-prebuild.yaml
+++ b/.github/workflows/devcontainer-prebuild.yaml
@@ -208,7 +208,7 @@ jobs:
       contents: read
     steps:
       - name: Notify Grafana IRM
-        uses: DevSecNinja/.github/.github/actions/notify-irm@a877d35266a54e54ef043e60a290ed76b4d7b34e # main
+        uses: DevSecNinja/.github/.github/actions/notify-irm@b2509636243e456253c938184dfe1855d6401e6d # main
         with:
           webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
           # `needs.*.result` is system-controlled, safe to interpolate.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -78,7 +78,7 @@ jobs:
       contents: read
     steps:
       - name: Notify Grafana IRM
-        uses: DevSecNinja/.github/.github/actions/notify-irm@a877d35266a54e54ef043e60a290ed76b4d7b34e # main
+        uses: DevSecNinja/.github/.github/actions/notify-irm@b2509636243e456253c938184dfe1855d6401e6d # main
         with:
           webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
           # `needs.*.result` is system-controlled, safe to interpolate.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,7 +54,7 @@ jobs:
       contents: read
     steps:
       - name: Notify Grafana IRM
-        uses: DevSecNinja/.github/.github/actions/notify-irm@a877d35266a54e54ef043e60a290ed76b4d7b34e # main
+        uses: DevSecNinja/.github/.github/actions/notify-irm@b2509636243e456253c938184dfe1855d6401e6d # main
         with:
           webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
           # `needs.*.result` is system-controlled, safe to interpolate.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
       contents: read
     steps:
       - name: Notify Grafana IRM
-        uses: DevSecNinja/.github/.github/actions/notify-irm@a877d35266a54e54ef043e60a290ed76b4d7b34e # main
+        uses: DevSecNinja/.github/.github/actions/notify-irm@b2509636243e456253c938184dfe1855d6401e6d # main
         with:
           webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
           # `needs.*.result` is system-controlled, safe to interpolate.

--- a/.github/workflows/sign-powershell.yml
+++ b/.github/workflows/sign-powershell.yml
@@ -108,7 +108,7 @@ jobs:
       contents: read
     steps:
       - name: Notify Grafana IRM
-        uses: DevSecNinja/.github/.github/actions/notify-irm@a877d35266a54e54ef043e60a290ed76b4d7b34e # main
+        uses: DevSecNinja/.github/.github/actions/notify-irm@b2509636243e456253c938184dfe1855d6401e6d # main
         with:
           webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
           # `needs.*.result` is system-controlled, safe to interpolate.


### PR DESCRIPTION
Bumps the `notify-irm` composite action pin from `a877d352` to `b2509636` to pick up [DevSecNinja/.github#53](https://github.com/DevSecNinja/.github/pull/53), which removes `${{ }}` templates from `description:` blocks in `action.yml`.

The previous pin failed at action-load time with:

```
Unrecognized function: 'always'.
```

because GitHub Actions evaluates `${{ }}` expressions inside `description:` blocks, and the embedded usage example contained `always()` (only valid in workflow `if:` contexts).

6 workflows updated: `ci.yaml`, `devcontainer-prebuild.yaml`, `docs.yml`, `release.yml`, `release-please.yml`, `sign-powershell.yml`.