### PR TITLE
fix(release): notify IRM on workflow_dispatch reruns

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,11 @@ jobs:
     name: Notify Grafana IRM
     needs:
       - release
-    if: ${{ always() && github.event_name == 'push' }}
+    # Run on both tag-push and workflow_dispatch so manual reruns
+    # also page. `always()` ensures we still notify on a failed
+    # release job; the action itself decides resolved vs firing
+    # based on the `release` job's `result`.
+    if: ${{ always() }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,20 +24,11 @@ name: Release
 # Drafts are mutable, so the upload + notes-edit + publish sequence
 # is compatible with Immutable Releases (which only constrain the
 # Release once *published*).
-#
-# `workflow_dispatch` is exposed so failed runs can be retried
-# manually by tag without a fresh release-please bump.
 
 on:
   push:
     tags:
       - "v*"
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag to (re)publish, e.g. v0.2.0"
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -58,15 +49,13 @@ jobs:
       id-token: write
       attestations: write
     env:
-      # Tag from either trigger. `github.ref_name` is the short tag name
-      # for `push: tags` (e.g. "v0.2.0") and the branch for dispatch,
-      # so the dispatch input takes precedence when set.
-      TAG: ${{ inputs.tag || github.ref_name }}
+      # Short tag name for the `push: tags` trigger (e.g. "v0.2.0").
+      TAG: ${{ github.ref_name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ inputs.tag || github.ref_name }}
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -91,7 +80,7 @@ jobs:
         with:
           subject-path: |
             dist/log.sh
-            dist/log-sh-${{ inputs.tag || github.ref_name }}.tar.gz
+            dist/log-sh-${{ github.ref_name }}.tar.gz
 
       - name: Compose release notes (release-please body + log.sh snippet)
         env:
@@ -156,10 +145,9 @@ jobs:
     name: Notify Grafana IRM
     needs:
       - release
-    # Run on both tag-push and workflow_dispatch so manual reruns
-    # also page. `always()` ensures we still notify on a failed
-    # release job; the action itself decides resolved vs firing
-    # based on the `release` job's `result`.
+    # `always()` plus the `release` job dependency keeps the firing
+    # condition meaningful; the action itself derives resolved-vs-firing
+    # from `needs.release.result`.
     if: ${{ always() }}
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
## Why

When v0.2.0 was published via `workflow_dispatch`, `Notify Grafana IRM` was skipped. The cause is the `github.event_name == 'push'` gate I added in #263, which was meant to suppress paging on dispatch reruns but ended up silencing every dispatch-driven publish.

## What

Drop the event-name gate; keep `if: always()` plus the `release` job dependency. The notify-irm action itself derives resolved-vs-firing from the `release` job's `result`, so this is enough.

## Follow-up

Once we're confident the dispatch path is solid, we can remove `workflow_dispatch` entirely (per discussion) so the only path to publish is a tag push from release-please.