### PR TITLE
ci: drop redundant push:main trigger and remove unreachable notify-irm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,9 @@
 name: CI
 
+# PR-only (plus dispatch). Branch protection makes the merge commit
+# identical to the last PR head, so re-running on push to main is
+# duplicate work. See DevSecNinja/.github docs/workflow-trigger-conventions.md.
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -486,29 +487,3 @@ jobs:
           files: test-results.xml
           check_name: 'Pester Test Results'
           comment_mode: off
-
-  # --- Page on main-branch CI failure (homelab IRM pager) ---
-  notify-irm:
-    name: Notify Grafana IRM
-    needs:
-      - validate
-      - test-devcontainer
-      - test-install
-      - test-coder-install
-      - test-light-server
-      - test-dev-server
-      - test-windows
-      - test-windows-coder
-      - test-bash-scripts
-      - test-powershell-scripts
-    if: ${{ always() && github.ref == 'refs/heads/main' && github.event_name == 'push' }}
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-    steps:
-      - name: Notify Grafana IRM
-        uses: DevSecNinja/.github/.github/actions/notify-irm@b2509636243e456253c938184dfe1855d6401e6d # main
-        with:
-          webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
-          # `needs.*.result` is system-controlled, safe to interpolate.
-          job-failed: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}


### PR DESCRIPTION
## Why

`ci.yaml` runs on every PR commit AND again on push to main. With branch protection ensuring the merge commit is identical to the last PR head, the post-merge run is duplicate work — and a small flurry of commits causes CI, docs, and label-sync to all churn.

## What

- Drop `push: branches: [main]` from `ci.yaml`. PR-only (plus `workflow_dispatch`).
- Remove the `notify-irm` job: gated on `github.ref == 'refs/heads/main' && github.event_name == 'push'`, so without push:main it's unreachable. Pages on PR-validation workflows are low-value anyway (PRs cannot merge if checks fail). Pages on deploy/release workflows still fire on main breakage.

The existing workflow-level concurrency block already cancels superseded runs.

## Followup

A forthcoming doc in `DevSecNinja/.github` will codify this as an org-wide convention.

Mirrors DevSecNinja/truenas-apps#325.