### PR TITLE
feat(yubikey): auto-install ykman via packages.yaml when useYubiKey is true

### DIFF
--- a/docs/yubikey.md
+++ b/docs/yubikey.md
@@ -9,6 +9,20 @@ It's also designed to **survive the migration off 1Password**: the
 1Password SSH agent integration is gated behind the `useYubiKey` chezmoi
 variable and stays the default until you flip it.
 
+## What gets installed
+
+When `useYubiKey: true`, `chezmoi apply` also installs `ykman` (yubikey-manager)
+and the smart-card daemon needed for OATH:
+
+| OS        | Package(s)                                  |
+| --------- | ------------------------------------------- |
+| macOS     | `ykman` (Homebrew)                          |
+| Debian/Ubuntu | `yubikey-manager`, `pcscd`, `scdaemon`  |
+| Fedora    | `yubikey-manager`, `pcsc-lite`              |
+| Windows   | `Yubico.YubikeyManagerCLI` (winget)         |
+
+Set `useYubiKey: false` (the default) and none of these are touched.
+
 ## Quick start
 
 ```bash

--- a/home/.chezmoidata/packages.yaml
+++ b/home/.chezmoidata/packages.yaml
@@ -26,16 +26,26 @@ packages:
         - zsh
       full:
         - gh # GitHub CLI
+      # Installed only when useYubiKey is true.
+      yubikey:
+        - yubikey-manager # provides `ykman` CLI
+        - pcscd # smart-card daemon (required for OATH)
+        - scdaemon
     brew:
       light: []
       full:
         - go-task
         - mise
+      yubikey:
+        - ykman
 
     # DNF packages (Fedora/RHEL/CentOS)
     dnf:
       light: []
       full: []
+      yubikey:
+        - yubikey-manager
+        - pcsc-lite
 
   # macOS packages
   darwin:
@@ -53,6 +63,9 @@ packages:
         - go-task
         - mise
         - python@3
+      # Installed only when useYubiKey is true.
+      yubikey:
+        - ykman
       # TODO: Homebrew: add support for casks * app store apps
       # Move them under brew (brew.brew and brew.cask and brew.app-store)
       # casks:
@@ -107,6 +120,9 @@ packages:
         - JanDeDobbeleer.OhMyPosh
         - Microsoft.WSL
         - Task.Task
+      # Installed only when useYubiKey is true.
+      yubikey:
+        - Yubico.YubikeyManagerCLI
 
     # PowerShell modules (installed via PowerShellGet)
     powershell_modules:

--- a/home/.chezmoiscripts/linux/run_onchange_10-install-packages.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_10-install-packages.sh.tmpl
@@ -86,6 +86,23 @@ else
 fi
 # {{ end }}
 # {{ end }}
+
+# {{ if .useYubiKey }}
+# YubiKey extras (apt) — installed when useYubiKey is true
+# {{ range .packages.linux.apt.yubikey }}
+log_step "Installing {{ . }} (yubikey)"
+if $SUDO_CMD apt-get install -y {{ . | quote }}; then
+	log_result "Successfully installed {{ . }}"
+else
+	exit_code=$?
+	if [ $exit_code -eq 100 ]; then
+		log_warn "Package {{ . }} not found in repositories"
+	else
+		log_warn "Failed to install {{ . }} (exit code: $exit_code)"
+	fi
+fi
+# {{ end }}
+# {{ end }}
 # {{ else if eq .chezmoi.osRelease.id "fedora" "rhel" "centos" }}
 
 log_step "Installing packages with DNF"
@@ -112,6 +129,18 @@ else
 fi
 # {{ end }}
 # {{ end }}
+
+# {{ if .useYubiKey }}
+# YubiKey extras (dnf) — installed when useYubiKey is true
+# {{ range .packages.linux.dnf.yubikey }}
+log_step "Installing {{ . }} (yubikey)"
+if $SUDO_CMD dnf install -y {{ . | quote }}; then
+	log_result "Successfully installed {{ . }}"
+else
+	log_warn "Failed to install {{ . }}"
+fi
+# {{ end }}
+# {{ end }}
 # {{ end }}
 
 # Check if Homebrew packages are defined for Linux
@@ -135,6 +164,11 @@ if command -v brew >/dev/null 2>&1; then
 	# {{ end }}
 	# {{ if eq .installType "full" }}
 	# {{ range .packages.linux.brew.full }}
+	brew_install_quiet {{ . | quote }}
+	# {{ end }}
+	# {{ end }}
+	# {{ if .useYubiKey }}
+	# {{ range .packages.linux.brew.yubikey }}
 	brew_install_quiet {{ . | quote }}
 	# {{ end }}
 	# {{ end }}
@@ -167,6 +201,13 @@ brew_install_quiet {{ . | quote }}
 # {{ if eq .installType "full" }}
 # Install full mode packages (additional)
 # {{ range .packages.darwin.brew.full }}
+brew_install_quiet {{ . | quote }}
+# {{ end }}
+# {{ end }}
+
+# {{ if .useYubiKey }}
+# YubiKey extras (darwin brew) — installed when useYubiKey is true
+# {{ range .packages.darwin.brew.yubikey }}
 brew_install_quiet {{ . | quote }}
 # {{ end }}
 # {{ end }}

--- a/home/.chezmoiscripts/windows/run_onchange_install-packages.ps1.tmpl
+++ b/home/.chezmoiscripts/windows/run_onchange_install-packages.ps1.tmpl
@@ -54,6 +54,25 @@ if ($LASTEXITCODE -eq 0 -and $result -match {{ . | quote }}) {
 # {{ end }}
 # {{ end }}
 
+# {{ if .useYubiKey }}
+# YubiKey extras — installed when useYubiKey is true
+# {{ range .packages.windows.winget.yubikey }}
+Write-Host "Checking {{ . }} (yubikey)..." -NoNewline
+$result = winget list --id {{ . | quote }} --exact 2>&1
+if ($LASTEXITCODE -eq 0 -and $result -match {{ . | quote }}) {
+    Write-Host " [OK]" -ForegroundColor Green
+} else {
+    Write-Host " Installing..." -ForegroundColor Yellow
+    winget install --id {{ . | quote }} --exact --silent --accept-package-agreements --accept-source-agreements | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "  [OK] {{ . }} installed" -ForegroundColor Green
+    } else {
+        Write-Host "  [FAILED] Could not install {{ . }}" -ForegroundColor Red
+    }
+}
+# {{ end }}
+# {{ end }}
+
 Write-Host "`nDevelopment tools installation complete ({{ .installType }} mode)!" -ForegroundColor Green
 
 # Install VS Code extensions if code command is available


### PR DESCRIPTION
Closes #285. Independent of #282 and #284 — can be merged in any order.

Wires `ykman` (and the smart-card daemon needed for OATH) into the existing package-install pipeline, gated on the `useYubiKey` chezmoi variable from #280. After flipping the toggle and running `chezmoi apply`, the `yk-*` helpers find their dependencies without a manual install step.

### Packages added (only installed when `useYubiKey: true`)

| OS / manager        | Packages                                  |
| ------------------- | ----------------------------------------- |
| Linux apt           | `yubikey-manager`, `pcscd`, `scdaemon`    |
| Linux dnf           | `yubikey-manager`, `pcsc-lite`            |
| Linux brew (opt.)   | `ykman`                                   |
| macOS brew          | `ykman`                                   |
| Windows winget      | `Yubico.YubikeyManagerCLI`                |

### What's in
- `home/.chezmoidata/packages.yaml`: new `yubikey:` sub-group on each OS package manager. The existing `light:` / `full:` lists are untouched.
- `home/.chezmoiscripts/linux/run_onchange_10-install-packages.sh.tmpl`: extra ranges gated by `{{ if .useYubiKey }}` for apt, dnf, linux brew and darwin brew.
- `home/.chezmoiscripts/windows/run_onchange_install-packages.ps1.tmpl`: extra range gated by `{{ if .useYubiKey }}` for winget.
- `docs/yubikey.md`: new "What gets installed" section.

### How to play with it
```bash
chezmoi edit-config-template   # set useYubiKey: true
chezmoi apply                   # ykman + pcscd get installed
yk-status                       # works
```

### Validation
- Rendered both Linux and Windows install scripts via `chezmoi execute-template` with `useYubiKey=true` and `=false`; verified no yubikey lines appear when `false`.
- `lefthook run pre-commit` clean (no shell files changed).
- Existing test suite unchanged; pre-existing `chezmoi 2.70.2` version-skew failures are not introduced by this PR.

### Notes
- `useYubiKey` defaults to `false`, so users who haven't migrated off 1Password keep their current behaviour.
- On Linux you may need to `sudo systemctl enable --now pcscd` once after install for the OATH applet to be reachable.