### PR TITLE
fix(yubikey): zsh leak in `yk-status`, device type, clearer macOS FIDO2 error

### DIFF
--- a/docs/yubikey.md
+++ b/docs/yubikey.md
@@ -16,7 +16,7 @@ and the smart-card daemon needed for OATH:
 
 | OS        | Package(s)                                  |
 | --------- | ------------------------------------------- |
-| macOS     | `ykman` (Homebrew)                          |
+| macOS     | `ykman`, `openssh` (Homebrew — Apple's bundled OpenSSH lacks FIDO2) |
 | Debian/Ubuntu | `yubikey-manager`, `pcscd`, `scdaemon`  |
 | Fedora    | `yubikey-manager`, `pcsc-lite`              |
 | Windows   | `Yubico.YubikeyManagerCLI` (winget)         |
@@ -62,6 +62,34 @@ cd "$(chezmoi source-path)" \
   && git pull
 chezmoi apply
 ```
+
+### macOS: "No FIDO SecurityKeyProvider specified"
+
+If `yk-ssh-new` fails with:
+
+```
+No FIDO SecurityKeyProvider specified
+Key enrollment failed: invalid format
+```
+
+…you're running Apple's bundled `/usr/bin/ssh-keygen`, which is built
+without libfido2. Install Homebrew's OpenSSH (it's added to the YubiKey
+package set, so a re-apply does it for you) and put it ahead of `/usr/bin`
+on your PATH:
+
+```bash
+brew install openssh
+# Apple Silicon
+export PATH="/opt/homebrew/bin:$PATH"
+# Intel
+export PATH="/usr/local/bin:$PATH"
+
+ssh -V       # expect OpenSSH_9.x — *not* OpenSSH_9.x p1, LibreSSL …
+yk-ssh-new
+```
+
+`yk-ssh-new` now detects this case and prints the same instructions before
+attempting key generation.
 
 ## Helpers (Bash/Zsh + Fish)
 

--- a/home/.chezmoidata/packages.yaml
+++ b/home/.chezmoidata/packages.yaml
@@ -66,6 +66,7 @@ packages:
       # Installed only when useYubiKey is true.
       yubikey:
         - ykman
+        - openssh # macOS bundled OpenSSH lacks FIDO2 / SecurityKeyProvider
       # TODO: Homebrew: add support for casks * app store apps
       # Move them under brew (brew.brew and brew.cask and brew.app-store)
       # casks:

--- a/home/dot_config/fish/functions/yk_ssh_new.fish
+++ b/home/dot_config/fish/functions/yk_ssh_new.fish
@@ -46,6 +46,35 @@ function yk_ssh_new --description "Generate a hardware-backed SSH key on a YubiK
         return 1
     end
 
+    # macOS guard: Apple's bundled OpenSSH lacks libfido2 / SecurityKeyProvider.
+    if test (uname) = Darwin
+        set -l sshkeygen_path (command -v ssh-keygen)
+        if test "$sshkeygen_path" = /usr/bin/ssh-keygen; or test "$sshkeygen_path" = /usr/sbin/ssh-keygen
+            echo "Error: Apple's bundled ssh-keygen at $sshkeygen_path lacks FIDO2 support." >&2
+            echo "       The error 'No FIDO SecurityKeyProvider specified' / 'invalid format'" >&2
+            echo "       comes from this. Install Homebrew's OpenSSH and put it ahead of /usr/bin:" >&2
+            echo "" >&2
+            echo "         brew install openssh" >&2
+            set -l brew_prefix ""
+            if command -q brew
+                set brew_prefix (brew --prefix 2>/dev/null)
+            else if test -x /opt/homebrew/bin/brew
+                set brew_prefix /opt/homebrew
+            else if test -x /usr/local/bin/brew
+                set brew_prefix /usr/local
+            end
+            if test -n "$brew_prefix"
+                echo "         fish_add_path -m $brew_prefix/bin" >&2
+            else
+                echo "         fish_add_path -m /opt/homebrew/bin   # Apple Silicon" >&2
+                echo "         fish_add_path -m /usr/local/bin      # Intel" >&2
+            end
+            echo "" >&2
+            echo "       Then re-run yk_ssh_new." >&2
+            return 1
+        end
+    end
+
     mkdir -p (dirname $output)
     chmod 700 (dirname $output) 2>/dev/null
 

--- a/home/dot_config/shell/functions/yk-ssh-new.sh
+++ b/home/dot_config/shell/functions/yk-ssh-new.sh
@@ -91,6 +91,41 @@ EOF
 		return 1
 	fi
 
+	# macOS guard: Apple's bundled OpenSSH is built without libfido2, so
+	# `ssh-keygen -t ed25519-sk` fails with:
+	#     No FIDO SecurityKeyProvider specified
+	#     Key enrollment failed: invalid format
+	# We need Homebrew's openssh ahead of /usr/bin on PATH.
+	if [[ "$(uname)" == "Darwin" ]]; then
+		local sshkeygen_path
+		sshkeygen_path="$(command -v ssh-keygen)"
+		if [[ "$sshkeygen_path" == /usr/bin/ssh-keygen || "$sshkeygen_path" == /usr/sbin/ssh-keygen ]]; then
+			echo "Error: Apple's bundled ssh-keygen at $sshkeygen_path lacks FIDO2 support." >&2
+			echo "       The error 'No FIDO SecurityKeyProvider specified' / 'invalid format'" >&2
+			echo "       comes from this. Install Homebrew's OpenSSH and put it ahead of /usr/bin:" >&2
+			echo "" >&2
+			echo "         brew install openssh" >&2
+			# Detect the right brew prefix for the hint.
+			local brew_prefix=""
+			if command -v brew >/dev/null 2>&1; then
+				brew_prefix="$(brew --prefix 2>/dev/null)"
+			elif [[ -x /opt/homebrew/bin/brew ]]; then
+				brew_prefix="/opt/homebrew"
+			elif [[ -x /usr/local/bin/brew ]]; then
+				brew_prefix="/usr/local"
+			fi
+			if [[ -n "$brew_prefix" ]]; then
+				echo "         export PATH=\"$brew_prefix/bin:\$PATH\"" >&2
+			else
+				echo "         export PATH=\"/opt/homebrew/bin:\$PATH\"   # Apple Silicon" >&2
+				echo "         export PATH=\"/usr/local/bin:\$PATH\"      # Intel" >&2
+			fi
+			echo "" >&2
+			echo "       Then re-run yk-ssh-new." >&2
+			return 1
+		fi
+	fi
+
 	case "$type" in
 	ed25519-sk | ecdsa-sk) ;;
 	*)

--- a/home/dot_config/shell/functions/yk-status.sh
+++ b/home/dot_config/shell/functions/yk-status.sh
@@ -2,8 +2,7 @@
 # yk-status - One-glance health check for connected YubiKey(s)
 #
 # Lists every connected YubiKey (by serial) and prints firmware, form factor,
-# and enabled applications. Highlights FIPS devices and warns on firmware
-# below 5.7 (where some newer features like ed25519 PIV are unavailable).
+# device type, and whether it is a FIPS device. Warns on firmware below 5.7.
 #
 # Usage: yk-status [--json] [--serial <SN>]
 #
@@ -12,8 +11,22 @@
 #   - Works with multiple YubiKeys connected simultaneously.
 
 yk-status() {
+	# Declare ALL locals once at the function top. zsh's `local` is
+	# function-scoped, and re-declaring an already-declared local inside a
+	# loop iteration causes zsh to print the assignment (a typeset side
+	# effect). Bash doesn't have this quirk; declaring once works in both.
 	local json=false
 	local target_serial=""
+	local serials=""
+	local first=true
+	local serial=""
+	local info=""
+	local device_type=""
+	local fw=""
+	local form_factor=""
+	local fips="false"
+	local major=""
+	local minor=""
 
 	while [[ $# -gt 0 ]]; do
 		case $1 in
@@ -42,8 +55,6 @@ yk-status() {
 		return 1
 	fi
 
-	# Collect serials. `ykman list` prints one device per line including serial.
-	local serials
 	if ! serials="$(ykman list --serials 2>/dev/null)"; then
 		echo "Error: failed to list YubiKeys (is one inserted?)" >&2
 		return 1
@@ -57,39 +68,36 @@ yk-status() {
 		serials="$target_serial"
 	fi
 
-	local first=true
 	if [[ "$json" == true ]]; then
 		printf '['
 	fi
 
 	while IFS= read -r serial; do
 		[[ -z "$serial" ]] && continue
-		local info
 		info="$(ykman --device "$serial" info 2>/dev/null)" || {
 			echo "Error: failed to query device $serial" >&2
 			continue
 		}
-		local fw form_factor fips
+		device_type="$(echo "$info" | awk -F': *' 'tolower($1) ~ /device type/ {print $2; exit}')"
 		fw="$(echo "$info" | awk -F': *' 'tolower($1) ~ /firmware version/ {print $2; exit}')"
 		form_factor="$(echo "$info" | awk -F': *' 'tolower($1) ~ /form factor/ {print $2; exit}')"
 		fips="false"
-		if echo "$info" | grep -qiE 'fips'; then
+		if echo "$device_type" | grep -qiE 'fips'; then
 			fips="true"
 		fi
 
 		if [[ "$json" == true ]]; then
 			[[ "$first" == false ]] && printf ','
 			first=false
-			printf '{"serial":"%s","firmware":"%s","form_factor":"%s","fips":%s}' \
-				"$serial" "${fw:-unknown}" "${form_factor:-unknown}" "$fips"
+			printf '{"serial":"%s","device_type":"%s","firmware":"%s","form_factor":"%s","fips":%s}' \
+				"$serial" "${device_type:-unknown}" "${fw:-unknown}" "${form_factor:-unknown}" "$fips"
 		else
 			echo "YubiKey #$serial"
+			echo "  Device type: ${device_type:-unknown}"
 			echo "  Firmware:    ${fw:-unknown}"
 			echo "  Form factor: ${form_factor:-unknown}"
 			echo "  FIPS:        $fips"
-			# Warn about features that need >= 5.7
 			if [[ -n "$fw" ]]; then
-				local major minor
 				major="${fw%%.*}"
 				minor="${fw#*.}"
 				minor="${minor%%.*}"

--- a/tests/bash/yk-status.bats
+++ b/tests/bash/yk-status.bats
@@ -109,3 +109,58 @@ Form factor: Keychain (USB-C)"
 	[[ "$output" =~ "YubiKey #22" ]]
 	[[ ! "$output" =~ "YubiKey #11" ]]
 }
+
+@test "yk-status: shows device type in output" {
+	mock_ykman
+	export YKMAN_SERIALS="12345"
+	export YKMAN_INFO_12345="Device type: YubiKey 5C NFC FIPS
+Firmware version: 5.7.4
+Form factor: Keychain (USB-C)"
+	run yk-status
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "Device type: YubiKey 5C NFC FIPS" ]]
+}
+
+@test "yk-status: --json includes device_type" {
+	mock_ykman
+	export YKMAN_SERIALS="12345"
+	export YKMAN_INFO_12345="Device type: YubiKey 5 NFC
+Firmware version: 5.7.4"
+	run yk-status --json
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ \"device_type\":\"YubiKey\ 5\ NFC\" ]]
+}
+
+@test "yk-status: zsh does not leak local declarations across iterations" {
+	# Regression test for: with multiple YubiKeys connected, zsh printed
+	# `info=$'...'`, `fw=...`, `major=...`, `minor=...` lines on every
+	# iteration after the first because `local` was re-declared inside the
+	# read loop. The fix is to declare all locals once at the function top.
+	if ! command -v zsh >/dev/null 2>&1; then
+		skip "zsh not installed"
+	fi
+	mock_ykman
+	export YKMAN_SERIALS="11
+22
+33"
+	export YKMAN_INFO_11="Device type: YubiKey 5C NFC FIPS
+Firmware version: 5.7.4"
+	export YKMAN_INFO_22="Device type: YubiKey 5C NFC FIPS
+Firmware version: 5.4.3"
+	export YKMAN_INFO_33="Device type: YubiKey 5C
+Firmware version: 5.2.4"
+	run zsh -c "
+		source '${BATS_TEST_DIRNAME}/../../home/dot_config/shell/functions/yk-status.sh'
+		yk-status
+	"
+	[ "$status" -eq 0 ]
+	# These leak markers appeared on the broken version; verify they're gone.
+	[[ ! "$output" =~ info=\$\' ]]
+	[[ ! "$output" =~ fw=5\.7\.4$ ]]
+	[[ ! "$output" =~ ^major=5$ ]]
+	[[ ! "$output" =~ ^minor=[0-9]+$ ]]
+	# Sanity check that all three keys still rendered.
+	[[ "$output" =~ "YubiKey #11" ]]
+	[[ "$output" =~ "YubiKey #22" ]]
+	[[ "$output" =~ "YubiKey #33" ]]
+}


### PR DESCRIPTION
Closes #289.

## What

Three small, related fixes uncovered while running the YubiKey helpers on macOS with three keys connected:

1. **`yk-status`: zsh `local`-leak with multiple keys** — moved every `local` to the top of the function so zsh stops re-emitting `info=$'…'`, `fw=…`, `major=…`, `minor=…` for each loop iteration after the first. Bash is unaffected.
2. **`yk-status`: show device type** — added a `Device type:` line in text output and a `device_type` field in `--json`. Also derive FIPS strictly from the device-type string (more reliable than `FIPS approved:` on older firmware).
3. **`yk-ssh-new` (bash + fish): clearer macOS FIDO2 error** — explicit guard that detects `/usr/bin/ssh-keygen` (Apple's bundled OpenSSH lacks libfido2) and prints actionable instructions before `ssh-keygen` fails with `No FIDO SecurityKeyProvider specified` / `Key enrollment failed: invalid format`. Includes a `brew --prefix`-aware PATH hint.

Plus: `openssh` added to `darwin.brew.yubikey` so a re-apply on macOS auto-installs Homebrew's OpenSSH alongside `ykman`.

## Verify

```bash
# zsh no-leak regression
zsh -c "source home/dot_config/shell/functions/yk-status.sh && yk-status"

# bats
./tests/bash/run-tests.sh --test yk-status.bats --test yk-ssh-new.bats
```

New tests:
- `yk-status: shows device type in output`
- `yk-status: --json includes device_type`
- `yk-status: zsh does not leak local declarations across iterations`

All YubiKey bats files green locally; lefthook (shellcheck/shfmt/cog-verify) clean.

## Files

- `home/dot_config/shell/functions/yk-status.sh` — locals hoisted, device_type, JSON field
- `home/dot_config/shell/functions/yk-ssh-new.sh` — macOS guard
- `home/dot_config/fish/functions/yk_ssh_new.fish` — macOS guard
- `home/.chezmoidata/packages.yaml` — `openssh` in `darwin.brew.yubikey`
- `docs/yubikey.md` — macOS FIDO2 PATH note
- `tests/bash/yk-status.bats` — three new tests