### PR TITLE
feat(yubikey): idempotent enrollment wizard (`yk-enroll`)

### DIFF
--- a/docs/yubikey.md
+++ b/docs/yubikey.md
@@ -91,13 +91,59 @@ yk-ssh-new
 `yk-ssh-new` now detects this case and prints the same instructions before
 attempting key generation.
 
+## Enrolling YubiKeys (recommended workflow)
+
+`yk-enroll` is the one-stop wizard for taking a fresh (or partially
+configured) YubiKey to the point where you can `ssh` and sign Git commits
+with it. It is **idempotent** — re-run it any time to verify what's
+already in place.
+
+```bash
+yk-enroll              # interactive: walks through every step
+yk-enroll --check      # read-only audit; never prompts or writes
+```
+
+The wizard runs five steps:
+
+1. **Preflight** — confirms `ykman` and a FIDO2-capable `ssh-keygen` are
+   on your PATH (catches the macOS Apple-OpenSSH trap from the previous
+   section).
+2. **Detect** — refuses to proceed unless **exactly one** YubiKey is
+   plugged in, so it's never ambiguous which key is being enrolled.
+3. **Capability check** — fails fast if firmware is too old for the
+   requested key type (suggests `--type ecdsa-sk` for fw <5.2.3).
+4. **FIDO2 PIN** — sets one if missing; reports it as set otherwise.
+5. **SSH key** — generates a resident `ed25519-sk` key at
+   `~/.ssh/id_ed25519_sk_<serial>`; skips if already present.
+
+It then prints the exact `gh ssh-key add` and `ssh-add` commands you
+should run.
+
+### Multiple YubiKeys
+
+A FIDO2 resident credential lives only on the YubiKey that minted it —
+there is no way to copy it to a second key. To use **all** your YubiKeys
+for SSH:
+
+1. Plug in **only the first** YubiKey, run `yk-enroll`.
+2. Repeat for each additional YubiKey. Each gets its own
+   `~/.ssh/id_ed25519_sk_<serial>` (private + public).
+3. Add **every resulting `.pub`** to GitHub (`gh ssh-key add` for each).
+4. From then on, any plugged-in YubiKey can authenticate / commit. SSH
+   picks whichever is touched.
+
+> **Don't try to "expand" an existing key onto a second YubiKey** — the
+> hardware doesn't allow it. Enrolling a second key is the supported
+> path, and `yk-enroll` makes it a one-command operation.
+
 ## Helpers (Bash/Zsh + Fish)
 
 | Bash/Zsh                | Fish                | Purpose                                                    |
 | ----------------------- | ------------------- | ---------------------------------------------------------- |
+| `yk-enroll`             | `yk_enroll`         | **Wizard**: end-to-end enrollment, idempotent              |
 | `yk-status`             | `yk_status`         | Firmware / form-factor / FIPS info per device              |
 | `yk-pick`               | `yk_pick`           | Pick one serial when multiple keys are connected           |
-| `yk-ssh-new`            | `yk_ssh_new`        | Generate `ed25519-sk` (or `ecdsa-sk`) on the YubiKey       |
+| `yk-ssh-new`            | `yk_ssh_new`        | Low-level: generate `ed25519-sk` / `ecdsa-sk` on the key   |
 | `yk-ssh-load`           | `yk_ssh_load`       | `ssh-add -K`: load resident keys from the YubiKey          |
 | `clipboard-copy`        | `clipboard_copy`    | Cross-platform clipboard helper used by `pubkey`           |
 | `pubkey`                | `pubkey`            | Print + copy the highest-priority pubkey from `~/.ssh`     |

--- a/home/dot_config/fish/functions/yk_enroll.fish
+++ b/home/dot_config/fish/functions/yk_enroll.fish
@@ -1,0 +1,149 @@
+function yk_enroll --description "Idempotent YubiKey enrollment wizard"
+    argparse --name=yk_enroll h/help check 't/type=' no-resident no-verify-required -- $argv
+    or return 1
+
+    if set -q _flag_help
+        echo "Usage: yk_enroll [OPTIONS]"
+        echo "Idempotent YubiKey enrollment wizard. Re-run any time to verify state."
+        echo ""
+        echo "Options:"
+        echo "  --check                Read-only audit; never prompt or write."
+        echo "  --type {ed25519-sk|ecdsa-sk}"
+        echo "                         SSH key type (default: ed25519-sk)."
+        echo "  --no-verify-required   Skip PIN-on-every-use for SSH (touch only)."
+        echo "  --no-resident          Don't store SSH credential on the key."
+        return 0
+    end
+
+    set -l check_only false
+    set -q _flag_check; and set check_only true
+    set -l type ed25519-sk
+    set -q _flag_type; and set type $_flag_type
+    set -l verify_required true
+    set -q _flag_no_verify_required; and set verify_required false
+    set -l resident true
+    set -q _flag_no_resident; and set resident false
+
+    # ----- Step 1: preflight ------------------------------------------------
+    echo "" >&2
+    echo "[1/5] Preflight" >&2
+    if not command -q ykman
+        echo "  'ykman' not found. Install with: brew install ykman" >&2
+        return 1
+    end
+    echo "  ykman found: "(command -v ykman) >&2
+    if not command -q ssh-keygen
+        echo "  ssh-keygen not found." >&2
+        return 1
+    end
+    if test (uname) = Darwin
+        set -l sshk (command -v ssh-keygen)
+        if test "$sshk" = /usr/bin/ssh-keygen; or test "$sshk" = /usr/sbin/ssh-keygen
+            echo "  Apple's bundled $sshk lacks FIDO2. Run: brew install openssh" >&2
+            echo "  Then put Homebrew bin ahead of /usr/bin and re-run yk_enroll." >&2
+            return 1
+        end
+    end
+    echo "  ssh-keygen found: "(command -v ssh-keygen) >&2
+
+    # ----- Step 2: detect a single YubiKey ---------------------------------
+    echo "" >&2
+    echo "[2/5] Detect YubiKey" >&2
+    set -l serials (ykman list --serials 2>/dev/null)
+    if test (count $serials) -eq 0
+        echo "  No YubiKey detected. Plug one in and re-run." >&2
+        return 1
+    end
+    if test (count $serials) -gt 1
+        echo "  Multiple YubiKeys connected ("(count $serials)"). Enrollment must be unambiguous." >&2
+        echo "  Unplug all but the one to enroll, then re-run. Detected:" >&2
+        for s in $serials
+            echo "    - $s" >&2
+        end
+        return 1
+    end
+    set -l serial $serials[1]
+    set -l info (ykman --device $serial info 2>/dev/null)
+    set -l device_type (printf '%s\n' $info | awk -F': *' 'tolower($1) ~ /device type/ {print $2; exit}')
+    set -l fw (printf '%s\n' $info | awk -F': *' 'tolower($1) ~ /firmware version/ {print $2; exit}')
+    test -z "$device_type"; and set device_type "YubiKey"
+    test -z "$fw"; and set fw "?"
+    echo "  $device_type (serial $serial, firmware $fw)" >&2
+
+    # ----- Step 3: capability check ----------------------------------------
+    echo "" >&2
+    echo "[3/5] Capability check" >&2
+    if test "$type" = ed25519-sk
+        set -l major (string split . -- $fw)[1]
+        set -l minor (string split . -- $fw)[2]
+        if test -n "$major" -a -n "$minor"
+            if test "$major" -lt 5; or begin; test "$major" -eq 5; and test "$minor" -lt 2; end
+                echo "  Firmware $fw is too old for ed25519-sk (need >=5.2.3)." >&2
+                echo "  Re-run with: yk_enroll --type ecdsa-sk" >&2
+                return 1
+            end
+        end
+    end
+    echo "  $type supported on firmware $fw" >&2
+
+    # ----- Step 4: FIDO2 PIN -----------------------------------------------
+    echo "" >&2
+    echo "[4/5] FIDO2 PIN" >&2
+    set -l fido_info (ykman --device $serial fido info 2>/dev/null)
+    set -l pin_set false
+    if printf '%s\n' $fido_info | grep -qiE 'PIN is set|PIN.*set'
+        if not printf '%s\n' $fido_info | grep -qiE 'PIN is not set'
+            set pin_set true
+        end
+    end
+    if test "$pin_set" = true
+        echo "  FIDO2 PIN is set." >&2
+    else if test "$check_only" = true
+        echo "  FIDO2 PIN is NOT set. (skipped: --check)" >&2
+    else
+        echo "  No FIDO2 PIN set. Setting one now (you'll be prompted)..." >&2
+        echo "  Tip: 6-8+ chars, anything you can re-type under stress." >&2
+        if not ykman --device $serial fido access change-pin
+            echo "  Failed to set FIDO2 PIN." >&2
+            return 1
+        end
+        echo "  FIDO2 PIN set." >&2
+    end
+
+    # ----- Step 5: SSH key -------------------------------------------------
+    echo "" >&2
+    echo "[5/5] SSH key" >&2
+    set -l type_under (string replace -a - _ -- $type)
+    set -l out_path "$HOME/.ssh/id_$type_under"_"$serial"
+    if test -e "$out_path"
+        echo "  Resident SSH key already enrolled: $out_path" >&2
+    else if test "$check_only" = true
+        echo "  No SSH key at $out_path. (skipped: --check)" >&2
+    else
+        echo "  Generating $type SSH key on YubiKey $serial..." >&2
+        set -l new_args --type $type --output $out_path
+        test "$resident" = false; and set new_args $new_args --no-resident
+        test "$verify_required" = false; and set new_args $new_args --no-verify-required
+        if not yk_ssh_new $new_args
+            echo "  SSH key generation failed." >&2
+            return 1
+        end
+        echo "  Enrolled: $out_path" >&2
+    end
+
+    # ----- Summary ----------------------------------------------------------
+    set -l hostshort (hostname -s 2>/dev/null; or hostname)
+    echo "" >&2
+    echo "Done. Next steps for serial $serial:" >&2
+    if test -e "$out_path.pub"
+        echo "  1. Add to GitHub:    gh ssh-key add $out_path.pub --title \"$hostshort-yk-$serial\"" >&2
+        echo "  2. Add to ssh-agent: ssh-add $out_path" >&2
+        if test "$resident" = true
+            echo "  3. On new machines:  ssh-add -K   # reload all resident keys from this YubiKey" >&2
+        end
+        echo "" >&2
+        echo "  Multi-key tip: re-run yk_enroll with each YubiKey plugged in (one" >&2
+        echo "  at a time), add every resulting .pub to GitHub, and any of them" >&2
+        echo "  can then sign / SSH." >&2
+    end
+end

--- a/home/dot_config/shell/functions/yk-enroll.sh
+++ b/home/dot_config/shell/functions/yk-enroll.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+# yk-enroll - Idempotent end-to-end YubiKey enrollment wizard
+#
+# Walks through every step needed to make a YubiKey usable for SSH:
+#   1. Preflight (ykman + FIDO2-capable ssh-keygen)
+#   2. Detect exactly one connected YubiKey
+#   3. Show device info + firmware sanity check
+#   4. Ensure a FIDO2 PIN is set
+#   5. Ensure a resident SSH key exists, named per serial
+#   6. Print next steps (gh ssh-key add, ssh-add)
+#
+# Re-running is safe: every step checks current state and skips work that
+# has already been done. Use --check for a read-only audit.
+#
+# Multi-key story:
+#   Each YubiKey is its own authenticator — there is no way to clone a
+#   resident SSH credential between keys. To use multiple YubiKeys with
+#   SSH, run `yk-enroll` once per key (unplug the others), then add every
+#   resulting `*.pub` to GitHub. Any plugged-in YubiKey can then sign or
+#   authenticate.
+#
+# Usage:
+#   yk-enroll                      # interactive wizard
+#   yk-enroll --check              # read-only verify
+#   yk-enroll --type ecdsa-sk      # for fw <5.2.3
+#   yk-enroll --no-verify-required # touch only, no PIN required for SSH
+
+yk-enroll() {
+	local check_only=false
+	local type="ed25519-sk"
+	local verify_required=true
+	local resident=true
+
+	while [[ $# -gt 0 ]]; do
+		case $1 in
+		--check)
+			check_only=true
+			shift
+			;;
+		--type)
+			type="$2"
+			shift 2
+			;;
+		--no-verify-required)
+			verify_required=false
+			shift
+			;;
+		--no-resident)
+			resident=false
+			shift
+			;;
+		-h | --help)
+			cat <<EOF
+Usage: yk-enroll [OPTIONS]
+Idempotent YubiKey enrollment wizard. Re-run any time to verify state.
+
+Options:
+  --check                Read-only audit; never prompt or write.
+  --type {ed25519-sk|ecdsa-sk}
+                         SSH key type (default: ed25519-sk).
+  --no-verify-required   Skip PIN-on-every-use for SSH (touch only).
+  --no-resident          Don't store SSH credential on the key (no ssh-add -K).
+EOF
+			return 0
+			;;
+		*)
+			echo "Error: unknown option: $1" >&2
+			return 1
+			;;
+		esac
+	done
+
+	# ----- Step 1: preflight -------------------------------------------------
+	_yk_step "1/5" "Preflight"
+	if ! command -v ykman >/dev/null 2>&1; then
+		_yk_fail "  'ykman' not found. Install with: brew install ykman  (or pipx install yubikey-manager)"
+		return 1
+	fi
+	_yk_ok "  ykman found: $(command -v ykman)"
+	if ! command -v ssh-keygen >/dev/null 2>&1; then
+		_yk_fail "  ssh-keygen not found."
+		return 1
+	fi
+	if [[ "$(uname)" == "Darwin" ]]; then
+		local sshk
+		sshk="$(command -v ssh-keygen)"
+		if [[ "$sshk" == /usr/bin/ssh-keygen || "$sshk" == /usr/sbin/ssh-keygen ]]; then
+			_yk_fail "  Apple's bundled $sshk lacks FIDO2 (libfido2). Run: brew install openssh"
+			_yk_fail "  Then put Homebrew bin ahead of /usr/bin on PATH and re-run yk-enroll."
+			return 1
+		fi
+	fi
+	_yk_ok "  ssh-keygen found: $(command -v ssh-keygen)"
+
+	# ----- Step 2: detect a single YubiKey -----------------------------------
+	_yk_step "2/5" "Detect YubiKey"
+	local serials
+	serials="$(ykman list --serials 2>/dev/null || true)"
+	if [[ -z "$serials" ]]; then
+		_yk_fail "  No YubiKey detected. Plug one in and re-run."
+		return 1
+	fi
+	local count
+	count="$(printf '%s\n' "$serials" | grep -c .)"
+	if [[ "$count" -gt 1 ]]; then
+		_yk_fail "  Multiple YubiKeys connected ($count). Enrollment must be unambiguous."
+		_yk_fail "  Unplug all but the one to enroll, then re-run. Detected:"
+		while IFS= read -r s; do echo "    - $s" >&2; done <<<"$serials"
+		return 1
+	fi
+	local serial
+	serial="$(printf '%s\n' "$serials" | head -n1)"
+	local info
+	info="$(ykman --device "$serial" info 2>/dev/null || true)"
+	local device_type fw
+	device_type="$(awk -F': *' 'tolower($1) ~ /device type/ {print $2; exit}' <<<"$info")"
+	fw="$(awk -F': *' 'tolower($1) ~ /firmware version/ {print $2; exit}' <<<"$info")"
+	_yk_ok "  ${device_type:-YubiKey} (serial $serial, firmware ${fw:-?})"
+
+	# ----- Step 3: firmware / capability check -------------------------------
+	_yk_step "3/5" "Capability check"
+	if [[ "$type" == "ed25519-sk" ]]; then
+		# ed25519-sk needs >=5.2.3
+		local major minor
+		major="$(awk -F. '{print $1}' <<<"$fw")"
+		minor="$(awk -F. '{print $2}' <<<"$fw")"
+		if [[ -n "$major" && -n "$minor" ]] && {
+			[[ "$major" -lt 5 ]] || { [[ "$major" -eq 5 ]] && [[ "$minor" -lt 2 ]]; }
+		}; then
+			_yk_fail "  Firmware $fw is too old for ed25519-sk (need >=5.2.3)."
+			_yk_fail "  Re-run with: yk-enroll --type ecdsa-sk"
+			return 1
+		fi
+	fi
+	_yk_ok "  $type supported on firmware ${fw:-?}"
+
+	# ----- Step 4: FIDO2 PIN -------------------------------------------------
+	_yk_step "4/5" "FIDO2 PIN"
+	local fido_info
+	fido_info="$(ykman --device "$serial" fido info 2>/dev/null || true)"
+	local pin_set=false
+	if grep -qiE 'PIN is set|PIN.*set' <<<"$fido_info" && ! grep -qiE 'PIN is not set' <<<"$fido_info"; then
+		pin_set=true
+	fi
+	if [[ "$pin_set" == true ]]; then
+		_yk_ok "  FIDO2 PIN is set."
+	else
+		if [[ "$check_only" == true ]]; then
+			_yk_warn "  FIDO2 PIN is NOT set. (skipped: --check)"
+		else
+			echo "  No FIDO2 PIN set. Setting one now (you'll be prompted)..." >&2
+			echo "  Tip: 6-8+ chars, anything you can re-type under stress." >&2
+			if ! ykman --device "$serial" fido access change-pin; then
+				_yk_fail "  Failed to set FIDO2 PIN."
+				return 1
+			fi
+			_yk_ok "  FIDO2 PIN set."
+		fi
+	fi
+
+	# ----- Step 5: SSH key ---------------------------------------------------
+	_yk_step "5/5" "SSH key"
+	local out_path="$HOME/.ssh/id_${type//-/_}_${serial}"
+	if [[ -e "$out_path" ]]; then
+		_yk_ok "  Resident SSH key already enrolled: $out_path"
+	else
+		if [[ "$check_only" == true ]]; then
+			_yk_warn "  No SSH key at $out_path. (skipped: --check)"
+		else
+			echo "  Generating $type SSH key on YubiKey $serial..." >&2
+			# Delegate to yk-ssh-new (already loaded as a function or sourced).
+			if ! command -v yk-ssh-new >/dev/null 2>&1 &&
+				! declare -F yk-ssh-new >/dev/null 2>&1; then
+				# Try sourcing it from the standard location.
+				# shellcheck disable=SC1091
+				. "$HOME/.config/shell/functions/yk-ssh-new.sh" 2>/dev/null || true
+			fi
+			local new_args=(--type "$type" --output "$out_path")
+			[[ "$resident" == false ]] && new_args+=(--no-resident)
+			[[ "$verify_required" == false ]] && new_args+=(--no-verify-required)
+			if ! yk-ssh-new "${new_args[@]}"; then
+				_yk_fail "  SSH key generation failed."
+				return 1
+			fi
+			_yk_ok "  Enrolled: $out_path"
+		fi
+	fi
+
+	# ----- Summary -----------------------------------------------------------
+	echo
+	echo "Done. Next steps for serial $serial:"
+	if [[ -e "${out_path}.pub" ]]; then
+		echo "  1. Add to GitHub:    gh ssh-key add ${out_path}.pub --title \"$(hostname -s 2>/dev/null || hostname)-yk-${serial}\""
+		echo "  2. Add to ssh-agent: ssh-add ${out_path}"
+		[[ "$resident" == true ]] && echo "  3. On new machines:  ssh-add -K   # reload all resident keys from this YubiKey"
+		echo
+		echo "  Multi-key tip: re-run yk-enroll with each YubiKey plugged in (one"
+		echo "  at a time), add every resulting .pub to GitHub, and any of them"
+		echo "  can then sign / SSH."
+	fi
+}
+
+# --- internal pretty-printers ------------------------------------------------
+_yk_step() { printf '\n[%s] %s\n' "$1" "$2" >&2; }
+_yk_ok() { printf '%s\n' "$1" >&2; }
+_yk_fail() { printf '%s\n' "$1" >&2; }
+_yk_warn() { printf '%s\n' "$1" >&2; }
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	yk-enroll "$@"
+fi

--- a/tests/bash/yk-enroll.bats
+++ b/tests/bash/yk-enroll.bats
@@ -1,0 +1,222 @@
+#!/usr/bin/env bats
+# Tests for yk-enroll
+
+setup() {
+	load "${BATS_TEST_DIRNAME}/../../home/dot_config/shell/functions/yk-enroll.sh"
+	# yk-enroll calls yk-ssh-new internally; load it so it's resolvable.
+	load "${BATS_TEST_DIRNAME}/../../home/dot_config/shell/functions/yk-ssh-new.sh"
+	TEST_BIN_DIR="$(mktemp -d)"
+	TEST_HOME="$(mktemp -d)"
+	export TEST_BIN_DIR TEST_HOME
+	export ORIGINAL_PATH="$PATH"
+	export ORIGINAL_HOME="$HOME"
+	export HOME="$TEST_HOME"
+	export PATH="$TEST_BIN_DIR:$ORIGINAL_PATH"
+
+	# Default ssh-keygen mock — writes a fake pubkey.
+	cat >"$TEST_BIN_DIR/ssh-keygen" <<'EOF'
+#!/bin/bash
+out=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		-f) out="$2"; shift 2 ;;
+		*) shift ;;
+	esac
+done
+: >"$out"
+echo "ssh-ed25519-sk AAAAfake user@host" >"${out}.pub"
+exit 0
+EOF
+	chmod +x "$TEST_BIN_DIR/ssh-keygen"
+}
+
+teardown() {
+	[ -n "$ORIGINAL_PATH" ] && export PATH="$ORIGINAL_PATH"
+	[ -n "$ORIGINAL_HOME" ] && export HOME="$ORIGINAL_HOME"
+	[ -n "$TEST_BIN_DIR" ] && [ -d "$TEST_BIN_DIR" ] && rm -rf "$TEST_BIN_DIR"
+	[ -n "$TEST_HOME" ] && [ -d "$TEST_HOME" ] && rm -rf "$TEST_HOME"
+}
+
+# Mock ykman supporting:
+#   list --serials                       -> $YKMAN_SERIALS
+#   --device <sn> info                   -> $YKMAN_INFO_<sn>
+#   --device <sn> fido info              -> $YKMAN_FIDO_<sn>
+#   --device <sn> fido access change-pin -> exit 0 unless YKMAN_PIN_FAIL=1
+mock_ykman() {
+	cat >"$TEST_BIN_DIR/ykman" <<'EOF'
+#!/bin/bash
+if [[ "$1 $2" == "list --serials" ]]; then
+	printf '%s\n' $YKMAN_SERIALS
+	exit 0
+fi
+if [[ "$1" == "--device" ]]; then
+	serial="$2"
+	shift 2
+	case "$1 $2" in
+		"info ")
+			varname="YKMAN_INFO_${serial}"
+			printf '%s\n' "${!varname}"
+			;;
+		"fido info")
+			varname="YKMAN_FIDO_${serial}"
+			printf '%s\n' "${!varname}"
+			;;
+		"fido access")
+			if [[ "$3" == "change-pin" ]]; then
+				[[ -n "$YKMAN_PIN_FAIL" ]] && exit 1
+				exit 0
+			fi
+			;;
+	esac
+fi
+exit 0
+EOF
+	chmod +x "$TEST_BIN_DIR/ykman"
+}
+
+@test "yk-enroll: help" {
+	run yk-enroll --help
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "Idempotent YubiKey enrollment wizard" ]]
+}
+
+@test "yk-enroll: errors when ykman missing" {
+	export PATH="/nonexistent"
+	run yk-enroll
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "'ykman' not found" ]]
+}
+
+@test "yk-enroll: errors when no YubiKey detected" {
+	mock_ykman
+	export YKMAN_SERIALS=""
+	run yk-enroll
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "No YubiKey detected" ]]
+}
+
+@test "yk-enroll: errors with multiple keys connected" {
+	mock_ykman
+	export YKMAN_SERIALS="11
+22"
+	run yk-enroll
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "Multiple YubiKeys connected" ]]
+	[[ "$output" =~ "- 11" ]]
+	[[ "$output" =~ "- 22" ]]
+}
+
+@test "yk-enroll: rejects ed25519-sk on firmware <5.2.3" {
+	mock_ykman
+	export YKMAN_SERIALS="55"
+	export YKMAN_INFO_55="Device type: YubiKey 4
+Firmware version: 4.3.7"
+	run yk-enroll
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "too old for ed25519-sk" ]]
+	[[ "$output" =~ "yk-enroll --type ecdsa-sk" ]]
+}
+
+@test "yk-enroll: full happy path enrolls a fresh key" {
+	mock_ykman
+	export YKMAN_SERIALS="12345"
+	export YKMAN_INFO_12345="Device type: YubiKey 5C NFC FIPS
+Firmware version: 5.7.4"
+	export YKMAN_FIDO_12345="PIN is set, with 8 attempts remaining."
+	run yk-enroll
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "[1/5] Preflight" ]]
+	[[ "$output" =~ "[2/5] Detect YubiKey" ]]
+	[[ "$output" =~ "YubiKey 5C NFC FIPS (serial 12345" ]]
+	[[ "$output" =~ "FIDO2 PIN is set" ]]
+	[[ "$output" =~ "Enrolled: " ]]
+	[ -f "$TEST_HOME/.ssh/id_ed25519_sk_12345" ]
+	[ -f "$TEST_HOME/.ssh/id_ed25519_sk_12345.pub" ]
+	[[ "$output" =~ "gh ssh-key add" ]]
+	[[ "$output" =~ "id_ed25519_sk_12345.pub" ]]
+}
+
+@test "yk-enroll: idempotent — skips key generation when file exists" {
+	mock_ykman
+	export YKMAN_SERIALS="12345"
+	export YKMAN_INFO_12345="Device type: YubiKey 5C NFC FIPS
+Firmware version: 5.7.4"
+	export YKMAN_FIDO_12345="PIN is set, with 8 attempts remaining."
+	mkdir -p "$TEST_HOME/.ssh"
+	echo "existing" >"$TEST_HOME/.ssh/id_ed25519_sk_12345"
+	echo "existing-pub" >"$TEST_HOME/.ssh/id_ed25519_sk_12345.pub"
+	# Make ssh-keygen explode if it's actually called — proves we skipped.
+	cat >"$TEST_BIN_DIR/ssh-keygen" <<'EOF'
+#!/bin/bash
+echo "ssh-keygen should not have run on idempotent path" >&2
+exit 99
+EOF
+	chmod +x "$TEST_BIN_DIR/ssh-keygen"
+	run yk-enroll
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "already enrolled" ]]
+}
+
+@test "yk-enroll: --check is read-only when PIN missing and key missing" {
+	mock_ykman
+	export YKMAN_SERIALS="12345"
+	export YKMAN_INFO_12345="Device type: YubiKey 5C NFC
+Firmware version: 5.7.4"
+	export YKMAN_FIDO_12345="PIN is not set."
+	# Make ssh-keygen and change-pin explode — --check must not call them.
+	cat >"$TEST_BIN_DIR/ssh-keygen" <<'EOF'
+#!/bin/bash
+echo "ssh-keygen called under --check" >&2; exit 99
+EOF
+	chmod +x "$TEST_BIN_DIR/ssh-keygen"
+	export YKMAN_PIN_FAIL=1
+	run yk-enroll --check
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "FIDO2 PIN is NOT set" ]]
+	[[ "$output" =~ "skipped: --check" ]]
+	[[ "$output" =~ "No SSH key at " ]]
+	[ ! -f "$TEST_HOME/.ssh/id_ed25519_sk_12345" ]
+}
+
+@test "yk-enroll: sets PIN when not present" {
+	mock_ykman
+	export YKMAN_SERIALS="12345"
+	export YKMAN_INFO_12345="Device type: YubiKey 5C NFC
+Firmware version: 5.7.4"
+	export YKMAN_FIDO_12345="PIN is not set."
+	run yk-enroll
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "Setting one now" ]]
+	[[ "$output" =~ "FIDO2 PIN set" ]]
+}
+
+@test "yk-enroll: errors when change-pin fails" {
+	mock_ykman
+	export YKMAN_SERIALS="12345"
+	export YKMAN_INFO_12345="Device type: YubiKey 5C NFC
+Firmware version: 5.7.4"
+	export YKMAN_FIDO_12345="PIN is not set."
+	export YKMAN_PIN_FAIL=1
+	run yk-enroll
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "Failed to set FIDO2 PIN" ]]
+}
+
+@test "yk-enroll: per-serial filename for multi-key setup" {
+	mock_ykman
+	export YKMAN_INFO_11="Device type: YubiKey 5C NFC
+Firmware version: 5.7.4"
+	export YKMAN_INFO_22="Device type: YubiKey 5C
+Firmware version: 5.4.3"
+	export YKMAN_FIDO_11="PIN is set."
+	export YKMAN_FIDO_22="PIN is set."
+	export YKMAN_SERIALS="11"
+	run yk-enroll
+	[ "$status" -eq 0 ]
+	[ -f "$TEST_HOME/.ssh/id_ed25519_sk_11" ]
+	export YKMAN_SERIALS="22"
+	run yk-enroll
+	[ "$status" -eq 0 ]
+	[ -f "$TEST_HOME/.ssh/id_ed25519_sk_22" ]
+	[ -f "$TEST_HOME/.ssh/id_ed25519_sk_11" ]
+}


### PR DESCRIPTION
Closes #292.

> **Stacked on #290** — diff is cleanest once #290 lands. Standalone changes here: only `yk-enroll.sh`, `yk_enroll.fish`, the bats file, and the docs section.

## What

Adds `yk-enroll` (bash) and `yk_enroll` (fish): a single-command wizard that takes a YubiKey from "fresh out of the blister pack" to "ready to commit/SSH" without the user having to remember each step.

```
yk-enroll              # interactive
yk-enroll --check      # read-only audit
```

Five steps, every one idempotent:

1. **Preflight** — `ykman` + FIDO2-capable `ssh-keygen` (catches the Apple-OpenSSH trap from #290 up front).
2. **Detect** — refuses unless exactly one YubiKey is plugged in (lists serials and bails otherwise, so the operation is always unambiguous).
3. **Capability** — refuses `ed25519-sk` on firmware <5.2.3 with a `--type ecdsa-sk` hint.
4. **PIN** — sets a FIDO2 PIN via `ykman fido access change-pin` if missing; reports state otherwise.
5. **SSH key** — generates a resident `ed25519-sk` at `~/.ssh/id_ed25519_sk_<serial>` if not already there (delegates to `yk-ssh-new`).

Then prints the exact `gh ssh-key add` + `ssh-add` lines to copy-paste, plus a multi-key tip.

## Multi-YubiKey story

Per-serial filenames make multi-YubiKey setups trivial. Enroll each key once (one plugged in at a time), add every resulting `.pub` to GitHub, and any plugged-in YubiKey can sign / authenticate from then on. The docs explicitly cover the "can I expand a key onto a second YubiKey?" question (answer: no, that's the whole point of FIDO2 hardware-backing — enroll per key).

## Verify

```bash
./tests/bash/run-tests.sh --test yk-enroll.bats
```

11 bats cases:

- help, missing `ykman`, no key detected, multiple keys connected
- firmware <5.2.3 rejected with ecdsa-sk hint
- happy path enrolls fresh key + writes pubkey at expected path
- **idempotent**: re-run with key file present → ssh-keygen never invoked
- `--check`: PIN missing + key missing → both reported, neither written
- PIN missing → `change-pin` invoked → success / failure paths
- per-serial filename: enrolling YubiKey A then B leaves both `_<a>` and `_<b>` files

## Files

- `home/dot_config/shell/functions/yk-enroll.sh` (new, executable, 5-step wizard)
- `home/dot_config/fish/functions/yk_enroll.fish` (new)
- `tests/bash/yk-enroll.bats` (new, 11 cases)
- `docs/yubikey.md` (new "Enrolling YubiKeys" section + helpers-table update)