### PR TITLE
fix(yubikey): detect modern ykman PIN status format

### DIFF
--- a/home/dot_config/fish/functions/yk_enroll.fish
+++ b/home/dot_config/fish/functions/yk_enroll.fish
@@ -94,12 +94,15 @@ function yk_enroll --description "Idempotent YubiKey enrollment wizard"
     # YubiKey 5 FIPS ships with factory default FIDO2 PIN '123456'; the
     # non-FIPS YubiKey 5 ships with no PIN. Always nudge users to rotate
     # on FIPS keys, and --rotate-pin forces a rotation regardless.
+    # ykman PIN reporting varies between versions:
+    #   - legacy:  'PIN is set' / 'PIN is not set'
+    #   - modern:  'PIN: 8 attempt(s) remaining' / 'PIN: Not set'
     echo "" >&2
     echo "[4/5] FIDO2 PIN" >&2
     set -l fido_info (ykman --device $serial fido info 2>/dev/null)
     set -l pin_set false
-    if printf '%s\n' $fido_info | grep -qiE 'PIN is set|PIN.*set'
-        if not printf '%s\n' $fido_info | grep -qiE 'PIN is not set'
+    if printf '%s\n' $fido_info | grep -qiE 'PIN is set|PIN:[[:space:]]*[0-9]+[[:space:]]+attempt|PIN:[[:space:]]*configured'
+        if not printf '%s\n' $fido_info | grep -qiE 'PIN is not set|PIN:[[:space:]]*not[[:space:]]+(set|configured)'
             set pin_set true
         end
     end

--- a/home/dot_config/shell/functions/yk-enroll.sh
+++ b/home/dot_config/shell/functions/yk-enroll.sh
@@ -143,15 +143,25 @@ EOF
 
 	# ----- Step 4: FIDO2 PIN -------------------------------------------------
 	# Note: YubiKey 5 FIPS series ships with a *factory default* FIDO2 PIN of
-	# 123456 — `ykman fido info` reports 'PIN is set' even on a brand-new
-	# device. The non-FIPS YubiKey 5 ships with no PIN at all. So on FIPS
-	# keys we always nudge the user to rotate, and `--rotate-pin` forces a
+	# 123456 — `ykman fido info` reports 'PIN is set' (older ykman) or
+	# 'PIN: 8 attempt(s) remaining' (ykman ≥5) even on a brand-new device.
+	# The non-FIPS YubiKey 5 ships with no PIN at all. So on FIPS keys we
+	# always nudge the user to rotate, and `--rotate-pin` forces a
 	# rotation prompt regardless of detected state.
 	_yk_step "4/5" "FIDO2 PIN"
 	local fido_info
 	fido_info="$(ykman --device "$serial" fido info 2>/dev/null || true)"
 	local pin_set=false
-	if grep -qiE 'PIN is set|PIN.*set' <<<"$fido_info" && ! grep -qiE 'PIN is not set' <<<"$fido_info"; then
+	# Positive signals (any of these means the PIN is set):
+	#   - legacy ykman:  'PIN is set'
+	#   - modern ykman:  'PIN: 8 attempt(s) remaining' (any number; the
+	#                    'remaining' wording only appears once a PIN is set)
+	#   - modern ykman:  'PIN: Configured'
+	# Negative signals override (in case the line contains both):
+	#   - 'PIN is not set'
+	#   - 'PIN: Not set' / 'PIN: not configured'
+	if grep -qiE 'PIN is set|PIN:[[:space:]]*[0-9]+[[:space:]]+attempt|PIN:[[:space:]]*configured' <<<"$fido_info" &&
+		! grep -qiE 'PIN is not set|PIN:[[:space:]]*not[[:space:]]+(set|configured)' <<<"$fido_info"; then
 		pin_set=true
 	fi
 	local is_fips=false

--- a/tests/bash/yk-enroll.bats
+++ b/tests/bash/yk-enroll.bats
@@ -310,3 +310,46 @@ EOF
 	[[ "$output" =~ "was not created" ]]
 	[ ! -f "$TEST_HOME/.ssh/id_ed25519_sk_35984479" ]
 }
+
+@test "yk-enroll: detects modern ykman PIN format ('PIN: 8 attempt(s) remaining')" {
+	# Regression: real-world ykman 5.x output is
+	#   PIN:                          8 attempt(s) remaining
+	# The old regex 'PIN is set|PIN.*set' missed this entirely, so the
+	# wizard treated a configured PIN as 'PIN is not set' and tried to
+	# set a new one (which then prompted for the *current* PIN, very
+	# confusing).
+	mock_ykman
+	export YKMAN_SERIALS="35984479"
+	export YKMAN_INFO_35984479="Device type: YubiKey 5C NFC FIPS
+Firmware version: 5.7.4"
+	export YKMAN_FIDO_35984479="FIPS approved:                True
+AAGUID:                       79f3c8ba-9e35-484b-8f47-53a5a0f5c630
+PIN:                          8 attempt(s) remaining
+Minimum PIN length:           8
+Always Require UV:            On
+Credential storage remaining: 99
+Enterprise Attestation:       Enabled"
+	mkdir -p "$TEST_HOME/.ssh"
+	echo existing >"$TEST_HOME/.ssh/id_ed25519_sk_35984479"
+	echo existing >"$TEST_HOME/.ssh/id_ed25519_sk_35984479.pub"
+	run yk-enroll
+	[ "$status" -eq 0 ]
+	# Must NOT think the PIN is missing.
+	[[ ! "$output" =~ "No FIDO2 PIN set" ]]
+	[[ ! "$output" =~ "Setting one now" ]]
+	# It's a FIPS key, so the FIPS warning fires (correctly).
+	[[ "$output" =~ "factory default PIN" ]]
+}
+
+@test "yk-enroll: detects modern ykman 'PIN: Not set' as no PIN" {
+	mock_ykman
+	export YKMAN_SERIALS="12345"
+	export YKMAN_INFO_12345="Device type: YubiKey 5C NFC
+Firmware version: 5.7.4"
+	export YKMAN_FIDO_12345="AAGUID:                       deadbeef
+PIN:                          Not set
+Minimum PIN length:           4"
+	run yk-enroll --check
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "FIDO2 PIN is NOT set" ]]
+}


### PR DESCRIPTION
Reported in chat. Real-world ykman 5.x output:

```
$ ykman fido info
FIPS approved:                True
AAGUID:                       79f3c8ba-9e35-484b-8f47-53a5a0f5c630
PIN:                          8 attempt(s) remaining
Minimum PIN length:           8
...
```

Our `PIN is set|PIN.*set` regex was written for legacy ykman that printed `PIN is set, with N attempts remaining`. Modern format doesn't contain the word "set" at all, so `yk-enroll` misidentified a configured PIN as missing and tried to set a new one — which then prompted for the *current* PIN. Very confusing on a freshly-rotated FIPS key.

## Fix

Detect both formats:

| Signal | Pattern |
|--------|---------|
| Positive | `PIN is set` (legacy) |
| Positive | `PIN: <N> attempt(s) remaining` (modern; only printed once a PIN exists) |
| Positive | `PIN: Configured` (some intermediate ykman versions) |
| Negative (overrides) | `PIN is not set` (legacy) |
| Negative (overrides) | `PIN: Not set` / `PIN: not configured` (modern) |

Same change in bash + fish (`yk-enroll` / `yk_enroll`).

## Tests

2 new bats cases (18 total green):
- `detects modern ykman PIN format ('PIN: 8 attempt(s) remaining')` — uses the user's exact reported output, asserts the wizard does NOT try to set a new PIN, and asserts the FIPS factory-default warning still fires.
- `detects modern ykman 'PIN: Not set' as no PIN` — under `--check`, asserts `FIDO2 PIN is NOT set`.