### PR TITLE
fix(yubikey): drop hostname from suggested GitHub-key title

### DIFF
--- a/home/dot_config/fish/functions/yk_enroll.fish
+++ b/home/dot_config/fish/functions/yk_enroll.fish
@@ -187,11 +187,13 @@ function yk_enroll --description "Idempotent YubiKey enrollment wizard"
         echo "Not done: $out_path.pub does not exist. Re-run yk_enroll." >&2
         return 1
     end
-    set -l hostshort (hostname -s 2>/dev/null; or hostname)
-    set -l suggested_title "$device_type @ $hostshort"
-    if test -z "$device_type"
-        set suggested_title "YubiKey @ $hostshort"
-    end
+    # A YubiKey is portable across machines, so the suggested GitHub-key
+    # title intentionally omits the hostname. Last 4 digits of the serial
+    # disambiguate when you have multiple identical-looking devices.
+    set -l serial_short (string sub -s -4 -- $serial)
+    set -l device_label "$device_type"
+    test -z "$device_label"; and set device_label "YubiKey"
+    set -l suggested_title "$device_label (·$serial_short)"
     echo "" >&2
     echo "Done. Next steps for serial $serial:" >&2
     echo "  1. Add to GitHub:" >&2

--- a/home/dot_config/shell/functions/yk-enroll.sh
+++ b/home/dot_config/shell/functions/yk-enroll.sh
@@ -257,9 +257,11 @@ EOF
 	fi
 	echo
 	echo "Done. Next steps for serial $serial:"
-	local hostshort
-	hostshort="$(hostname -s 2>/dev/null || hostname)"
-	local suggested_title="${device_type:-YubiKey} @ ${hostshort}"
+	# A YubiKey is portable across machines, so the suggested GitHub-key
+	# title intentionally omits the hostname. Last 4 digits of the serial
+	# disambiguate when you have multiple identical-looking devices.
+	local serial_short="${serial: -4}"
+	local suggested_title="${device_type:-YubiKey} (·${serial_short})"
 	echo "  1. Add to GitHub:"
 	echo "       gh ssh-key add ${out_path}.pub --title \"${suggested_title}\""
 	echo "     (or use the GitHub UI — pick any title that helps you recognise the key)"

--- a/tests/bash/yk-enroll.bats
+++ b/tests/bash/yk-enroll.bats
@@ -134,8 +134,10 @@ Firmware version: 5.7.4"
 	[ -f "$TEST_HOME/.ssh/id_ed25519_sk_12345.pub" ]
 	[[ "$output" =~ "gh ssh-key add" ]]
 	[[ "$output" =~ "id_ed25519_sk_12345.pub" ]]
-	# Suggested title uses the device type, not "<host>-yk-<serial>".
-	[[ "$output" =~ "YubiKey 5C NFC FIPS @ " ]]
+	# Suggested title uses device type + last 4 of serial; no hostname
+	# (a YubiKey is portable, so a host-prefixed title is misleading).
+	[[ "$output" =~ "YubiKey 5C NFC FIPS (·2345)" ]]
+	[[ ! "$output" =~ "@ " ]]
 	# yk-ssh-new's "Next steps" footer must NOT appear (yk-enroll prints
 	# its own Done block and passes --no-summary to yk-ssh-new).
 	[[ ! "$output" =~ "Next steps:" ]]


### PR DESCRIPTION
YubiKeys are portable across machines, so prefixing the suggested GitHub-key title with the current host is misleading — the user immediately renamed it after enrollment.

Suggested title now uses device type + last 4 of the serial:

```
gh ssh-key add … --title "YubiKey 5C NFC FIPS (·3479)"
```

The dot prefix makes the suffix scan as "last-4 of serial" instead of "a four-digit number that means something on its own". Multiple identical-looking YubiKeys still distinguishable.

Bash + fish updated. Existing happy-path bats test updated to assert the new format and that `@ ` (host marker) is absent. 18/18 green.