### PR TITLE
fix(yubikey): vertical yk-status, pubkey zsh nomatch, GitHub UI link, drop stale yk-ssh-load files

### DIFF
--- a/docs/yubikey.md
+++ b/docs/yubikey.md
@@ -247,6 +247,8 @@ yk-enroll
 #    what gets you the green "Verified" badge on signed commits.
 gh ssh-key add ~/.ssh/id_ed25519_sk_<serial>.pub --type authentication --title "<title>"
 gh ssh-key add ~/.ssh/id_ed25519_sk_<serial>.pub --type signing       --title "<title>"
+# Or via the GitHub UI:
+#   https://github.com/settings/keys
 
 # 3) chezmoi picks up the new key:
 #      ~/.ssh/config gets per-serial IdentityFile lines (via glob)

--- a/home/.chezmoiremove.tmpl
+++ b/home/.chezmoiremove.tmpl
@@ -1,0 +1,8 @@
+{{- /* Files chezmoi should remove from the destination on apply, even though */ -}}
+{{- /* they're no longer in the source state. Useful when a helper is dropped */ -}}
+{{- /* and we don't want stale copies lingering in the user's home.           */ -}}
+{{- /*                                                                         */ -}}
+{{- /* yk-ssh-load was removed in PR #303 (made obsolete by per-serial SSH    */ -}}
+{{- /* config glob and IdentitiesOnly yes from PR #302). On Unix:             */ -}}
+.config/shell/functions/yk-ssh-load.sh
+.config/fish/functions/yk_ssh_load.fish

--- a/home/dot_config/fish/functions/work_checklist.fish
+++ b/home/dot_config/fish/functions/work_checklist.fish
@@ -16,6 +16,7 @@ function work_checklist --description "Print manual post-install checklist for w
     echo "        For each ~/.ssh/id_ed25519_sk_<serial>.pub:"
     echo "          gh ssh-key add <path> --type authentication --title \"<title>\""
     echo "          gh ssh-key add <path> --type signing       --title \"<title>\""
+    echo "        Or via the GitHub UI:  https://github.com/settings/keys"
     echo "        Signing isn't useful without the second one (no Verified badge)."
     echo ""
     echo "  [ ] Wire git for SSH commit signing"

--- a/home/dot_config/fish/functions/yk_enroll.fish
+++ b/home/dot_config/fish/functions/yk_enroll.fish
@@ -199,8 +199,10 @@ function yk_enroll --description "Idempotent YubiKey enrollment wizard"
     echo "  1. Add to GitHub (BOTH types — needed for SSH and the Verified badge):" >&2
     echo "       gh ssh-key add $out_path.pub --type authentication --title \"$suggested_title\"" >&2
     echo "       gh ssh-key add $out_path.pub --type signing       --title \"$suggested_title\"" >&2
-    echo "     (or use the GitHub UI — each YubiKey needs to be added under SSH and" >&2
-    echo "      Signing keys; same pubkey, different list.)" >&2
+    echo "     Or via the GitHub UI:" >&2
+    echo "       https://github.com/settings/keys" >&2
+    echo "     (each YubiKey needs to be added under both SSH and Signing keys;" >&2
+    echo "      same pubkey content, two list entries.)" >&2
     echo "" >&2
     echo "  2. Wire git for SSH commit signing (writes ~/.config/git/allowed_signers):" >&2
     echo "       chezmoi apply       # picks up the new key in ~/.ssh/config + git config" >&2

--- a/home/dot_config/fish/functions/yk_git_sign_setup.fish
+++ b/home/dot_config/fish/functions/yk_git_sign_setup.fish
@@ -122,6 +122,8 @@ function yk_git_sign_setup --description "Configure git to sign commits with you
     echo "Required next step: upload each pubkey to GitHub as both an"
     echo "  authentication AND signing key (signing isn't useful otherwise):"
     for key in $keys
-        echo "    gh ssh-key add $key --type signing --title \"<descriptive title>\""
+        echo "    gh ssh-key add $key --type authentication --title \"<descriptive title>\""
+        echo "    gh ssh-key add $key --type signing       --title \"<descriptive title>\""
     end
+    echo "  Or via the GitHub UI:  https://github.com/settings/keys"
 end

--- a/home/dot_config/fish/functions/yk_ssh_new.fish
+++ b/home/dot_config/fish/functions/yk_ssh_new.fish
@@ -112,6 +112,7 @@ function yk_ssh_new --description "Generate a hardware-backed SSH key on a YubiK
     echo
     echo "Next steps:"
     echo "  1. Add to GitHub:    gh ssh-key add $output.pub --title \"<descriptive title>\""
+    echo "     Or via the GitHub UI:  https://github.com/settings/keys"
     echo "  2. Test it:          ssh -T git@github.com  # AddKeysToAgent in ~/.ssh/config handles ssh-add automatically"
     if not set -q _flag_no_resident
         echo "  3. On new machines:  ssh-add -K   # reload from YubiKey"

--- a/home/dot_config/fish/functions/yk_status.fish
+++ b/home/dot_config/fish/functions/yk_status.fish
@@ -80,22 +80,29 @@ function yk_status --description "One-glance health check for connected YubiKey(
         else
             set -l label "$device_type"
             test -z "$label"; and set label "YubiKey"
-            set -l heading "$label  ·  serial $serial  ·  fw $fw"
-            test "$fips" = true; and set heading "$heading  ·  FIPS"
-            echo "$heading"
+            # Heading: device type only. Detail lines are vertical so a
+            # glance at the column gives every fact.
+            echo "$label"
+            echo "  Serial:        $serial"
+            echo "  Firmware:      $fw"
+            if test "$fips" = true
+                echo "  FIPS:          yes"
+            else
+                echo "  FIPS:          no"
+            end
             echo "  Form factor:   $form_factor"
             switch $pin_set
                 case true
                     echo "  FIDO2 PIN:     [OK] set"
                 case false
-                    echo "  FIDO2 PIN:     [WARN] not set    (run \`yk_enroll\`)"
+                    echo "  FIDO2 PIN:     [WARN] not set    (run yk_enroll)"
                 case '*'
                     echo "  FIDO2 PIN:     [?]  could not query (ykman fido info failed)"
             end
             if test -n "$ssh_key"
                 echo "  SSH key:       [OK] $ssh_pub"
             else
-                echo "  SSH key:       [WARN] not enrolled  (run \`yk_enroll\`)"
+                echo "  SSH key:       [WARN] not enrolled  (run yk_enroll)"
             end
             if test -n "$fw"
                 set -l major (string split . -- $fw)[1]

--- a/home/dot_config/shell/aliases.sh
+++ b/home/dot_config/shell/aliases.sh
@@ -62,22 +62,24 @@ alias motd='fastfetch'
 # Discovers both the legacy un-suffixed `id_<type>_sk.pub` and per-serial
 # `id_<type>_sk_<serial>.pub` files written by `yk-enroll`.
 pubkey() {
+	# Use find for glob expansion so unmatched patterns don't error out
+	# under zsh (which has NOMATCH on by default and aborts the function
+	# on `for x in $unmatched_glob`).
 	_pubkey_key=""
-	# Prefer hardware-backed FIDO2 keys: per-serial files first (newest
-	# wins via natural sort), then legacy un-suffixed, then non-FIDO2 keys.
+	# Prefer hardware-backed FIDO2 keys: per-serial files first, then
+	# legacy un-suffixed, then non-FIDO2.
 	for _pubkey_pattern in \
-		"$HOME/.ssh/id_ed25519_sk_"*.pub \
-		"$HOME/.ssh/id_ed25519_sk.pub" \
-		"$HOME/.ssh/id_ecdsa_sk_"*.pub \
-		"$HOME/.ssh/id_ecdsa_sk.pub" \
-		"$HOME/.ssh/id_ed25519.pub" \
-		"$HOME/.ssh/id_rsa.pub"; do
-		for _pubkey_candidate in $_pubkey_pattern; do
-			if [ -f "$_pubkey_candidate" ]; then
-				_pubkey_key="$_pubkey_candidate"
-				break 2
-			fi
-		done
+		"id_ed25519_sk_*" \
+		"id_ed25519_sk" \
+		"id_ecdsa_sk_*" \
+		"id_ecdsa_sk" \
+		"id_ed25519" \
+		"id_rsa"; do
+		_pubkey_candidate="$(find "$HOME/.ssh" -maxdepth 1 -name "${_pubkey_pattern}.pub" -type f 2>/dev/null | sort | head -n1)"
+		if [ -n "$_pubkey_candidate" ] && [ -f "$_pubkey_candidate" ]; then
+			_pubkey_key="$_pubkey_candidate"
+			break
+		fi
 	done
 	unset _pubkey_pattern _pubkey_candidate
 	if [ -z "$_pubkey_key" ]; then

--- a/home/dot_config/shell/functions/work-checklist.sh
+++ b/home/dot_config/shell/functions/work-checklist.sh
@@ -33,6 +33,7 @@ or per-user MFA enrollment). Tick each one off after running install.sh.
         For each ~/.ssh/id_ed25519_sk_<serial>.pub:
           gh ssh-key add <path> --type authentication --title "<title>"
           gh ssh-key add <path> --type signing       --title "<title>"
+        Or via the GitHub UI:  https://github.com/settings/keys
         Signing isn't useful without the second one (no Verified badge).
 
   [ ] Wire git for SSH commit signing

--- a/home/dot_config/shell/functions/yk-enroll.sh
+++ b/home/dot_config/shell/functions/yk-enroll.sh
@@ -265,8 +265,10 @@ EOF
 	echo "  1. Add to GitHub (BOTH types — needed for SSH and the Verified badge):"
 	echo "       gh ssh-key add ${out_path}.pub --type authentication --title \"${suggested_title}\""
 	echo "       gh ssh-key add ${out_path}.pub --type signing       --title \"${suggested_title}\""
-	echo "     (or use the GitHub UI — each YubiKey needs to be added under SSH and"
-	echo "      Signing keys; same pubkey, different list.)"
+	echo "     Or via the GitHub UI:"
+	echo "       https://github.com/settings/keys"
+	echo "     (each YubiKey needs to be added under both SSH and Signing keys;"
+	echo "      same pubkey content, two list entries.)"
 	echo
 	echo "  2. Wire git for SSH commit signing (writes ~/.config/git/allowed_signers):"
 	echo "       chezmoi apply       # picks up the new key in ~/.ssh/config + git config"

--- a/home/dot_config/shell/functions/yk-git-sign-setup.sh
+++ b/home/dot_config/shell/functions/yk-git-sign-setup.sh
@@ -182,8 +182,10 @@ EOF
 	echo "Required next step: upload each pubkey to GitHub as both an"
 	echo "  authentication AND signing key (signing isn't useful otherwise):"
 	for key in "${keys[@]}"; do
-		echo "    gh ssh-key add $key --type signing --title \"<descriptive title>\""
+		echo "    gh ssh-key add $key --type authentication --title \"<descriptive title>\""
+		echo "    gh ssh-key add $key --type signing       --title \"<descriptive title>\""
 	done
+	echo "  Or via the GitHub UI:  https://github.com/settings/keys"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/home/dot_config/shell/functions/yk-ssh-new.sh
+++ b/home/dot_config/shell/functions/yk-ssh-new.sh
@@ -189,6 +189,7 @@ EOF
 	echo
 	echo "Next steps:"
 	echo "  1. Add to GitHub:    gh ssh-key add ${output}.pub --title \"<descriptive title>\""
+	echo "     Or via the GitHub UI:  https://github.com/settings/keys"
 	echo "  2. Test it:          ssh -T git@github.com  # AddKeysToAgent in ~/.ssh/config handles ssh-add automatically"
 	if [[ "$resident" == true ]]; then
 		echo "  3. On new machines:  ssh-add -K   # reload from YubiKey"

--- a/home/dot_config/shell/functions/yk-status.sh
+++ b/home/dot_config/shell/functions/yk-status.sh
@@ -130,21 +130,22 @@ yk-status() {
 			printf '{"serial":"%s","device_type":"%s","firmware":"%s","form_factor":"%s","fips":%s,"pin_set":"%s","ssh_key":"%s"}' \
 				"$serial" "${device_type:-unknown}" "${fw:-unknown}" "${form_factor:-unknown}" "$fips" "$pin_set" "$ssh_key"
 		else
-			# Heading line: device type is the most recognisable thing.
-			local heading="${device_type:-YubiKey}"
-			heading="$heading  ·  serial $serial  ·  fw ${fw:-?}"
-			[[ "$fips" == "true" ]] && heading="$heading  ·  FIPS"
-			echo "$heading"
+			# Heading: device type only (most recognisable). Detail lines
+			# are vertical so a glance at the column gives every fact.
+			echo "${device_type:-YubiKey}"
+			echo "  Serial:        $serial"
+			echo "  Firmware:      ${fw:-unknown}"
+			echo "  FIPS:          $([[ $fips == true ]] && echo yes || echo no)"
 			echo "  Form factor:   ${form_factor:-unknown}"
 			case "$pin_set" in
 			true) echo "  FIDO2 PIN:     [OK] set" ;;
-			false) echo "  FIDO2 PIN:     [WARN] not set    (run \`yk-enroll\`)" ;;
+			false) echo "  FIDO2 PIN:     [WARN] not set    (run yk-enroll)" ;;
 			*) echo "  FIDO2 PIN:     [?]  could not query (ykman fido info failed)" ;;
 			esac
 			if [[ -n "$ssh_key" ]]; then
 				echo "  SSH key:       [OK] $ssh_pub"
 			else
-				echo "  SSH key:       [WARN] not enrolled  (run \`yk-enroll\`)"
+				echo "  SSH key:       [WARN] not enrolled  (run yk-enroll)"
 			fi
 			if [[ -n "$fw" ]]; then
 				major="${fw%%.*}"

--- a/tests/bash/pubkey.bats
+++ b/tests/bash/pubkey.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+# Tests for the `pubkey` shell function (defined in dot_config/shell/aliases.sh)
+
+setup() {
+	# pubkey is defined in aliases.sh as a function; source it.
+	# shellcheck disable=SC1091
+	. "${BATS_TEST_DIRNAME}/../../home/dot_config/shell/aliases.sh"
+	TEST_HOME="$(mktemp -d)"
+	export TEST_HOME
+	export ORIGINAL_HOME="$HOME"
+	export HOME="$TEST_HOME"
+	mkdir -p "$HOME/.ssh"
+}
+
+teardown() {
+	[ -n "$ORIGINAL_HOME" ] && export HOME="$ORIGINAL_HOME"
+	[ -n "$TEST_HOME" ] && [ -d "$TEST_HOME" ] && rm -rf "$TEST_HOME"
+}
+
+@test "pubkey: errors when no key present" {
+	run pubkey
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "No SSH public key found" ]]
+}
+
+@test "pubkey: picks per-serial id_ed25519_sk_<serial>.pub" {
+	# Regression: yk-enroll writes id_ed25519_sk_<serial>.pub. The legacy
+	# discovery only knew about id_ed25519_sk.pub (no suffix), so users
+	# with a freshly-enrolled YubiKey saw "No SSH public key found".
+	echo "ssh-ed25519-sk AAAAtest user@host" >"$HOME/.ssh/id_ed25519_sk_12345.pub"
+	run pubkey
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "ssh-ed25519-sk AAAAtest" ]]
+}
+
+@test "pubkey: picks legacy un-suffixed id_ed25519_sk.pub when no per-serial files" {
+	echo "ssh-ed25519-sk AAAAlegacy user@host" >"$HOME/.ssh/id_ed25519_sk.pub"
+	run pubkey
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "AAAAlegacy" ]]
+}
+
+@test "pubkey: prefers FIDO2 ed25519-sk over non-FIDO2 ed25519" {
+	echo "ssh-ed25519-sk AAAAfido user@host" >"$HOME/.ssh/id_ed25519_sk_12345.pub"
+	echo "ssh-ed25519 AAAAplain user@host" >"$HOME/.ssh/id_ed25519.pub"
+	run pubkey
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "AAAAfido" ]]
+	[[ ! "$output" =~ "AAAAplain" ]]
+}
+
+@test "pubkey: works under zsh (no NOMATCH error on unmatched globs)" {
+	# Regression: zsh's NOMATCH option made `for x in ~/.ssh/id_ecdsa_sk_*.pub`
+	# abort the whole function with "no matches found" the moment one
+	# pattern didn't match. find-based discovery avoids this.
+	if ! command -v zsh >/dev/null 2>&1; then
+		skip "zsh not installed"
+	fi
+	echo "ssh-ed25519-sk AAAAtest user@host" >"$HOME/.ssh/id_ed25519_sk_12345.pub"
+	run zsh -c "
+		HOME='$TEST_HOME'
+		. '${BATS_TEST_DIRNAME}/../../home/dot_config/shell/aliases.sh'
+		pubkey
+	"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "AAAAtest" ]]
+	[[ ! "$output" =~ "no matches found" ]]
+}

--- a/tests/bash/work-checklist.bats
+++ b/tests/bash/work-checklist.bats
@@ -29,6 +29,7 @@ setup() {
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "--type authentication" ]]
 	[[ "$output" =~ "--type signing" ]]
+	[[ "$output" =~ "https://github.com/settings/keys" ]]
 }
 
 @test "work-checklist: includes git signing wiring step" {

--- a/tests/bash/yk-enroll.bats
+++ b/tests/bash/yk-enroll.bats
@@ -147,6 +147,8 @@ Firmware version: 5.7.4"
 	# uploading a *signing* key isn't optional, that's the whole point.
 	[[ "$output" =~ "--type authentication" ]]
 	[[ "$output" =~ "--type signing" ]]
+	# GitHub UI fallback link should also be shown.
+	[[ "$output" =~ "https://github.com/settings/keys" ]]
 	# The wizard nudges users through the git-signing wiring.
 	[[ "$output" =~ "yk-git-sign-setup" ]]
 	[[ "$output" =~ "chezmoi apply" ]]

--- a/tests/bash/yk-status.bats
+++ b/tests/bash/yk-status.bats
@@ -60,7 +60,7 @@ EOF
 	[[ "$output" =~ "No YubiKey detected" ]]
 }
 
-@test "yk-status: heading uses device type, serial, fw, FIPS marker" {
+@test "yk-status: heading uses device type, vertical Serial/Firmware/FIPS lines" {
 	mock_ykman
 	export YKMAN_SERIALS="12345"
 	export YKMAN_INFO_12345="Device type: YubiKey 5C NFC FIPS
@@ -70,13 +70,18 @@ Form factor: Keychain (USB-C), NFC"
 	export YKMAN_FIDO_12345="PIN:                          8 attempt(s) remaining"
 	run yk-status
 	[ "$status" -eq 0 ]
+	# Heading is just the device type.
 	[[ "$output" =~ "YubiKey 5C NFC FIPS" ]]
-	[[ "$output" =~ "serial 12345" ]]
-	[[ "$output" =~ "fw 5.7.4" ]]
-	[[ "$output" =~ "·  FIPS" ]]
+	# Detail rows are vertical, one fact per line.
+	[[ "$output" =~ "Serial:        12345" ]]
+	[[ "$output" =~ "Firmware:      5.7.4" ]]
+	[[ "$output" =~ "FIPS:          yes" ]]
 	[[ "$output" =~ "Form factor:" ]]
-	# No more legacy "YubiKey #<serial>" header.
+	# No more legacy horizontal heading or "#serial".
 	[[ ! "$output" =~ "YubiKey #" ]]
+	[[ ! "$output" =~ "·  serial" ]]
+	[[ ! "$output" =~ "·  fw" ]]
+	[[ ! "$output" =~ "·  FIPS" ]]
 }
 
 @test "yk-status: PIN check shows [OK] when PIN is set (modern ykman)" {
@@ -137,8 +142,9 @@ Form factor: Keychain (USB-C)"
 	run yk-status
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "firmware <5.7" ]]
-	# Non-FIPS heading must NOT have the FIPS marker.
-	[[ ! "$output" =~ "·  FIPS" ]]
+	# Non-FIPS heading: FIPS row says no.
+	[[ "$output" =~ "FIPS:          no" ]]
+	[[ ! "$output" =~ "FIPS:          yes" ]]
 }
 
 @test "yk-status: handles multiple keys" {
@@ -153,8 +159,8 @@ Firmware version: 5.4.3"
 	export YKMAN_FIDO_22="PIN:                          Not set"
 	run yk-status
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "serial 11" ]]
-	[[ "$output" =~ "serial 22" ]]
+	[[ "$output" =~ "Serial:        11" ]]
+	[[ "$output" =~ "Serial:        22" ]]
 }
 
 @test "yk-status: --json includes device_type, pin_set, ssh_key" {
@@ -185,8 +191,8 @@ Firmware version: 5.7.4"
 	export YKMAN_FIDO_22="PIN:                          8 attempt(s) remaining"
 	run yk-status --serial 22
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "serial 22" ]]
-	[[ ! "$output" =~ "serial 11" ]]
+	[[ "$output" =~ "Serial:        22" ]]
+	[[ ! "$output" =~ "Serial:        11" ]]
 }
 
 @test "yk-status: zsh does not leak local declarations across iterations" {
@@ -221,7 +227,7 @@ Firmware version: 5.2.4"
 	[[ ! "$output" =~ fw=5\.7\.4$ ]]
 	[[ ! "$output" =~ ^major=5$ ]]
 	[[ ! "$output" =~ ^minor=[0-9]+$ ]]
-	[[ "$output" =~ "serial 11" ]]
-	[[ "$output" =~ "serial 22" ]]
-	[[ "$output" =~ "serial 33" ]]
+	[[ "$output" =~ "Serial:        11" ]]
+	[[ "$output" =~ "Serial:        22" ]]
+	[[ "$output" =~ "Serial:        33" ]]
 }


### PR DESCRIPTION
Four user-reported papercuts.

## 1. `yk-status`: vertical layout

The horizontal heading was hard to scan, especially with three keys plugged in. New layout:

```
YubiKey 5C NFC FIPS
  Serial:        35984479
  Firmware:      5.7.4
  FIPS:          yes
  Form factor:   Keychain (USB-C), NFC
  FIDO2 PIN:     [OK] set
  SSH key:       [OK] /Users/.../.ssh/id_ed25519_sk_35984479.pub

YubiKey 5C
  Serial:        10572542
  Firmware:      5.2.4
  FIPS:          no
  ...
```

Heading is just the device type. Detail rows are vertical, one fact per line. Also dropped the literal backticks in the warning messages (`yk-enroll` → `` `yk-enroll` `` showed as `\`yk-enroll\`` in fish).

## 2. `pubkey`: fix zsh NOMATCH error

```
$ pubkey
pubkey:4: no matches found: /Users/.../.ssh/id_ecdsa_sk_*.pub
```

zsh's `NOMATCH` option made `for x in ~/.ssh/id_ecdsa_sk_*.pub` abort the whole function the moment one pattern didn't match. Use `find(1)` for glob expansion so unmatched patterns just return empty.

## 3. GitHub Settings URL printed alongside every `gh ssh-key add`

Not everyone has `gh` installed/configured. Every nudge in `yk-enroll`, `yk-ssh-new`, `yk-git-sign-setup` and `work-checklist` now also points at <https://github.com/settings/keys> for the GUI flow. `yk-git-sign-setup` also picked up a missing `--type authentication` line in its mandatory upload prompt.

## 4. `.chezmoiremove` for `yk-ssh-load`

When PR #303 deleted the `yk-ssh-load` source files, chezmoi did **not** remove the destination copies on apply (chezmoi only manages files in source state; deletions don't cascade). New `home/.chezmoiremove.tmpl` lists both `yk-ssh-load.sh` and `yk_ssh_load.fish` so a plain `chezmoi apply` cleans them up.

## Verify

```bash
./tests/bash/run-tests.sh --test yk-status.bats --test pubkey.bats --test yk-enroll.bats --test work-checklist.bats --test yk-git-sign-setup.bats
```

51 cases green. New tests:
- `yk-status.bats` — assertions rewritten for the vertical layout, asserts no horizontal `·  serial / fw / FIPS` markers leak.
- `pubkey.bats` (new) — 5 cases including a `pubkey: works under zsh (no NOMATCH error on unmatched globs)` regression.
- `yk-enroll.bats` + `work-checklist.bats` — now also assert `https://github.com/settings/keys` appears.

## Files

- `home/dot_config/{shell,fish}/functions/yk_status.{sh,fish}` — vertical layout
- `home/dot_config/shell/aliases.sh` (`pubkey`) — `find`-based discovery, no shell-glob NOMATCH
- `home/dot_config/{shell,fish}/functions/yk-enroll.*` — GitHub URL
- `home/dot_config/{shell,fish}/functions/yk-ssh-new.*` — GitHub URL
- `home/dot_config/{shell,fish}/functions/yk-git-sign-setup.*` — GitHub URL + missing `--type authentication`
- `home/dot_config/{shell,fish}/functions/work-checklist.*` — GitHub URL
- `home/.chezmoiremove.tmpl` (new) — drops stale `yk-ssh-load` files on next apply
- `tests/bash/yk-status.bats` — vertical assertions
- `tests/bash/pubkey.bats` (new)
- `tests/bash/yk-enroll.bats` + `work-checklist.bats` — URL assertions
- `docs/yubikey.md` — Quick start gained the GitHub UI link