### PR TITLE
feat(yubikey): add yk-ssh-copy-id helper

### DIFF
--- a/home/dot_config/fish/functions/yk_ssh_copy_id.fish
+++ b/home/dot_config/fish/functions/yk_ssh_copy_id.fish
@@ -1,0 +1,125 @@
+function yk_ssh_copy_id --description "Push YubiKey SSH pubkey(s) into a remote authorized_keys (idempotent)"
+    argparse --name=yk_ssh_copy_id h/help 'i/identity=' 'p/port=' check dry-run -- $argv
+    or return 1
+
+    if set -q _flag_help
+        echo "Usage: yk_ssh_copy_id [OPTIONS] [user@]host"
+        echo "Push YubiKey SSH pubkey(s) into a remote authorized_keys (idempotent)."
+        echo ""
+        echo "Options:"
+        echo "  -i, --identity PATH    Push only this specific .pub file (default: all"
+        echo "                         id_*_sk*.pub files in ~/.ssh)"
+        echo "  -p, --port N           SSH port (default: 22)"
+        echo "  --check                Connect and report which keys are already authorized"
+        echo "  --dry-run              Print the keys that would be pushed; don't connect"
+        return 0
+    end
+
+    set -l port 22
+    set -q _flag_port; and set port $_flag_port
+    set -l check false
+    set -q _flag_check; and set check true
+    set -l dry_run false
+    set -q _flag_dry_run; and set dry_run true
+
+    if test (count $argv) -gt 1
+        echo "Error: only one [user@]host argument allowed (got: $argv)" >&2
+        return 1
+    end
+    set -l target ""
+    test (count $argv) -eq 1; and set target $argv[1]
+
+    if test -z "$target"; and test "$dry_run" != true
+        echo "Error: missing [user@]host argument. See --help." >&2
+        return 1
+    end
+
+    # Collect the set of pubkeys to push.
+    set -l keys
+    if set -q _flag_identity
+        if not test -f "$_flag_identity"
+            echo "Error: --identity file not found: $_flag_identity" >&2
+            return 1
+        end
+        set keys $_flag_identity
+    else
+        for pat in 'id_ed25519_sk_*' 'id_ed25519_sk' 'id_ecdsa_sk_*' 'id_ecdsa_sk'
+            for candidate in (find "$HOME/.ssh" -maxdepth 1 -name "$pat.pub" -type f 2>/dev/null | sort)
+                if test -n "$candidate"; and test -f "$candidate"
+                    set keys $keys $candidate
+                end
+            end
+        end
+    end
+
+    if test (count $keys) -eq 0
+        echo "Error: no YubiKey pubkey found in ~/.ssh. Run \`yk_enroll\` first." >&2
+        return 1
+    end
+
+    # Build the payload (blank lines stripped).
+    set -l payload ""
+    for k in $keys
+        set payload "$payload"(grep -vE '^[[:space:]]*$' $k)\n
+    end
+
+    if test "$dry_run" = true
+        echo "Would push "(count $keys)" pubkey(s)"(test -n "$target"; and echo " to $target")":"
+        for k in $keys
+            echo "  - $k"
+        end
+        echo ""
+        echo "Payload:"
+        printf '%s' $payload
+        return 0
+    end
+
+    if not command -q ssh
+        echo "Error: ssh not found." >&2
+        return 1
+    end
+
+    set -l remote_install '
+set -e
+umask 077
+mkdir -p ~/.ssh
+touch ~/.ssh/authorized_keys
+chmod 700 ~/.ssh
+chmod 600 ~/.ssh/authorized_keys
+existing="$(cat ~/.ssh/authorized_keys 2>/dev/null || true)"
+new=0
+present=0
+while IFS= read -r line; do
+\t[ -z "$line" ] && continue
+\tif printf "%s\\n" "$existing" | grep -qFx -- "$line"; then
+\t\tpresent=$((present + 1))
+\telse
+\t\tprintf "%s\\n" "$line" >>~/.ssh/authorized_keys
+\t\tnew=$((new + 1))
+\tfi
+done
+echo "yk-ssh-copy-id: $new added, $present already present" >&2
+'
+    set -l remote_check '
+set -e
+existing=""
+[ -f ~/.ssh/authorized_keys ] && existing="$(cat ~/.ssh/authorized_keys)"
+new=0
+present=0
+while IFS= read -r line; do
+\t[ -z "$line" ] && continue
+\tif printf "%s\\n" "$existing" | grep -qFx -- "$line"; then
+\t\techo "[OK]   $line"
+\t\tpresent=$((present + 1))
+\telse
+\t\techo "[MISS] $line"
+\t\tnew=$((new + 1))
+\tfi
+done
+echo "yk-ssh-copy-id: $present already present, $new missing" >&2
+'
+    set -l script "$remote_install"
+    test "$check" = true; and set script "$remote_check"
+
+    printf '%s' $payload | ssh -T -p $port $target "/bin/sh -c '$script'"
+end

--- a/home/dot_config/shell/functions/yk-ssh-copy-id.sh
+++ b/home/dot_config/shell/functions/yk-ssh-copy-id.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# yk-ssh-copy-id - Push YubiKey SSH pubkey(s) into a remote authorized_keys.
+#
+# Like ssh-copy-id, but tailored for FIDO2 (`*-sk`) keys with per-serial
+# filenames written by `yk-enroll` (id_*_sk_<serial>.pub). Pushes every
+# YubiKey-backed pubkey it finds in ~/.ssh in one SSH call (one touch +
+# one PIN, not N touches), and is idempotent: keys already present in the
+# remote authorized_keys are skipped.
+#
+# Usage:
+#   yk-ssh-copy-id [user@]host                # push every YubiKey pubkey
+#   yk-ssh-copy-id -i ~/.ssh/id_yk.pub host   # push one specific pubkey
+#   yk-ssh-copy-id -p 2222 user@host          # custom SSH port
+#   yk-ssh-copy-id --check user@host          # report which keys are already there
+#   yk-ssh-copy-id --dry-run user@host        # print payload locally; don't connect
+#
+# Notes:
+#   - Requires existing SSH access (password, gh-cli'd key, etc.) to bootstrap.
+#   - Discovers per-serial files first (id_*_sk_<serial>.pub), then legacy
+#     un-suffixed names. Same priority as `pubkey`.
+#   - Remote authorized_keys gets `chmod 600`, ~/.ssh `chmod 700`, umask 077.
+
+yk-ssh-copy-id() {
+	local port=22
+	local identity=""
+	local check=false
+	local dry_run=false
+	local target=""
+
+	while [[ $# -gt 0 ]]; do
+		case $1 in
+		-i | --identity)
+			identity="$2"
+			shift 2
+			;;
+		-p | --port)
+			port="$2"
+			shift 2
+			;;
+		--check)
+			check=true
+			shift
+			;;
+		--dry-run)
+			dry_run=true
+			shift
+			;;
+		-h | --help)
+			cat <<EOF
+Usage: yk-ssh-copy-id [OPTIONS] [user@]host
+Push YubiKey SSH pubkey(s) into a remote authorized_keys (idempotent).
+
+Options:
+  -i, --identity PATH    Push only this specific .pub file (default: all
+                         id_*_sk*.pub files in ~/.ssh)
+  -p, --port N           SSH port (default: 22)
+  --check                Connect and report which keys are already authorized;
+                         don't write
+  --dry-run              Print the keys that would be pushed locally; don't
+                         connect to the remote
+EOF
+			return 0
+			;;
+		-*)
+			echo "Error: unknown option: $1" >&2
+			return 1
+			;;
+		*)
+			if [[ -n "$target" ]]; then
+				echo "Error: only one [user@]host argument allowed (got '$target' and '$1')" >&2
+				return 1
+			fi
+			target="$1"
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$target" && "$dry_run" != true ]]; then
+		echo "Error: missing [user@]host argument. See --help." >&2
+		return 1
+	fi
+
+	# Collect the set of pubkeys to push.
+	local -a keys=()
+	if [[ -n "$identity" ]]; then
+		if [[ ! -f "$identity" ]]; then
+			echo "Error: --identity file not found: $identity" >&2
+			return 1
+		fi
+		keys=("$identity")
+	else
+		# Per-serial first, then legacy. Use find for zsh NOMATCH-safety.
+		local pat candidate
+		for pat in 'id_ed25519_sk_*' 'id_ed25519_sk' 'id_ecdsa_sk_*' 'id_ecdsa_sk'; do
+			while IFS= read -r candidate; do
+				[[ -n "$candidate" && -f "$candidate" ]] && keys+=("$candidate")
+			done < <(find "$HOME/.ssh" -maxdepth 1 -name "${pat}.pub" -type f 2>/dev/null | sort)
+		done
+	fi
+
+	if [[ ${#keys[@]} -eq 0 ]]; then
+		echo "Error: no YubiKey pubkey found in ~/.ssh. Run \`yk-enroll\` first." >&2
+		return 1
+	fi
+
+	# Build the payload (one pubkey line per file, blank lines stripped).
+	local payload=""
+	local k
+	for k in "${keys[@]}"; do
+		payload+="$(grep -vE '^[[:space:]]*$' "$k")"$'\n'
+	done
+
+	if [[ "$dry_run" == true ]]; then
+		echo "Would push ${#keys[@]} pubkey(s)${target:+ to ${target}}:"
+		for k in "${keys[@]}"; do
+			echo "  - $k"
+		done
+		echo
+		echo "Payload:"
+		printf '%s' "$payload"
+		return 0
+	fi
+
+	if ! command -v ssh >/dev/null 2>&1; then
+		echo "Error: ssh not found." >&2
+		return 1
+	fi
+
+	# Single SSH call: dedupe against the remote's existing authorized_keys
+	# and append only the missing entries. One FIDO2 touch + PIN, not N.
+	local remote_install
+	# shellcheck disable=SC2016 # $variables are intentionally literal here — they're evaluated by the remote shell.
+	remote_install='set -e
+umask 077
+mkdir -p ~/.ssh
+touch ~/.ssh/authorized_keys
+chmod 700 ~/.ssh
+chmod 600 ~/.ssh/authorized_keys
+existing="$(cat ~/.ssh/authorized_keys 2>/dev/null || true)"
+new=0
+present=0
+while IFS= read -r line; do
+	[ -z "$line" ] && continue
+	if printf "%s\n" "$existing" | grep -qFx -- "$line"; then
+		present=$((present + 1))
+	else
+		printf "%s\n" "$line" >>~/.ssh/authorized_keys
+		new=$((new + 1))
+	fi
+done
+echo "yk-ssh-copy-id: $new added, $present already present" >&2'
+
+	local remote_check
+	# shellcheck disable=SC2016 # $variables are intentionally literal here — they're evaluated by the remote shell.
+	remote_check='set -e
+existing=""
+[ -f ~/.ssh/authorized_keys ] && existing="$(cat ~/.ssh/authorized_keys)"
+new=0
+present=0
+while IFS= read -r line; do
+	[ -z "$line" ] && continue
+	if printf "%s\n" "$existing" | grep -qFx -- "$line"; then
+		echo "[OK]   $line"
+		present=$((present + 1))
+	else
+		echo "[MISS] $line"
+		new=$((new + 1))
+	fi
+done
+echo "yk-ssh-copy-id: $present already present, $new missing" >&2'
+
+	local script
+	if [[ "$check" == true ]]; then
+		script="$remote_check"
+	else
+		script="$remote_install"
+	fi
+
+	# Pipe the payload to the remote bash. Use -T to skip the pty, -o
+	# BatchMode=no so password/PIN prompts still work, and explicit /bin/sh
+	# on the far side to avoid login-shell surprises.
+	printf '%s' "$payload" | ssh -T -p "$port" "$target" "/bin/sh -c '$script'"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	yk-ssh-copy-id "$@"
+fi

--- a/tests/bash/yk-ssh-copy-id.bats
+++ b/tests/bash/yk-ssh-copy-id.bats
@@ -1,0 +1,142 @@
+#!/usr/bin/env bats
+# Tests for yk-ssh-copy-id
+
+setup() {
+	load "${BATS_TEST_DIRNAME}/../../home/dot_config/shell/functions/yk-ssh-copy-id.sh"
+	TEST_HOME="$(mktemp -d)"
+	TEST_BIN_DIR="$(mktemp -d)"
+	export TEST_HOME TEST_BIN_DIR
+	export ORIGINAL_HOME="$HOME"
+	export ORIGINAL_PATH="$PATH"
+	export HOME="$TEST_HOME"
+	export PATH="$TEST_BIN_DIR:$ORIGINAL_PATH"
+	mkdir -p "$HOME/.ssh"
+
+	# Mock ssh: record argv to .args, write stdin to .stdin, exit 0.
+	# This lets tests inspect the remote command and the keys payload
+	# without ever touching a real network.
+	cat >"$TEST_BIN_DIR/ssh" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$@" >"${TEST_BIN_DIR:?}/ssh.args"
+cat >"${TEST_BIN_DIR:?}/ssh.stdin"
+# Echo a fake "yk-ssh-copy-id: ..." line so tests can see we ran.
+echo "yk-ssh-copy-id: 1 added, 0 already present" >&2
+exit 0
+EOF
+	chmod +x "$TEST_BIN_DIR/ssh"
+}
+
+teardown() {
+	[ -n "$ORIGINAL_HOME" ] && export HOME="$ORIGINAL_HOME"
+	[ -n "$ORIGINAL_PATH" ] && export PATH="$ORIGINAL_PATH"
+	[ -n "$TEST_HOME" ] && [ -d "$TEST_HOME" ] && rm -rf "$TEST_HOME"
+	[ -n "$TEST_BIN_DIR" ] && [ -d "$TEST_BIN_DIR" ] && rm -rf "$TEST_BIN_DIR"
+}
+
+@test "yk-ssh-copy-id: --help works" {
+	run yk-ssh-copy-id --help
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "Push YubiKey SSH pubkey" ]]
+	[[ "$output" =~ "--check" ]]
+	[[ "$output" =~ "--dry-run" ]]
+}
+
+@test "yk-ssh-copy-id: errors when no host given" {
+	echo "ssh-ed25519-sk AAAAtest user@host" >"$HOME/.ssh/id_ed25519_sk_12345.pub"
+	run yk-ssh-copy-id
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "missing [user@]host" ]]
+}
+
+@test "yk-ssh-copy-id: errors when no YubiKey pubkey present" {
+	run yk-ssh-copy-id user@host
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "no YubiKey pubkey found" ]]
+	[[ "$output" =~ "yk-enroll" ]]
+}
+
+@test "yk-ssh-copy-id: --identity rejects missing file" {
+	run yk-ssh-copy-id --identity "$HOME/.ssh/nonexistent.pub" user@host
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "--identity file not found" ]]
+}
+
+@test "yk-ssh-copy-id: rejects multiple host arguments" {
+	echo "ssh-ed25519-sk AAAAtest user@host" >"$HOME/.ssh/id_ed25519_sk_12345.pub"
+	run yk-ssh-copy-id one@host two@host
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "only one [user@]host argument allowed" ]]
+}
+
+@test "yk-ssh-copy-id: --dry-run lists keys without invoking ssh" {
+	echo "ssh-ed25519-sk AAAAfirst user@host" >"$HOME/.ssh/id_ed25519_sk_11.pub"
+	echo "ssh-ed25519-sk AAAAsecond user@host" >"$HOME/.ssh/id_ed25519_sk_22.pub"
+	run yk-ssh-copy-id --dry-run user@host
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "Would push 2 pubkey(s)" ]]
+	[[ "$output" =~ "id_ed25519_sk_11.pub" ]]
+	[[ "$output" =~ "id_ed25519_sk_22.pub" ]]
+	[[ "$output" =~ "AAAAfirst" ]]
+	[[ "$output" =~ "AAAAsecond" ]]
+	# ssh must NOT have been invoked.
+	[ ! -f "$TEST_BIN_DIR/ssh.args" ]
+}
+
+@test "yk-ssh-copy-id: discovers per-serial keys (yk-enroll output)" {
+	# Regression: must find id_ed25519_sk_<serial>.pub, not just legacy.
+	echo "ssh-ed25519-sk AAAAfirst user@host" >"$HOME/.ssh/id_ed25519_sk_11.pub"
+	echo "ssh-ed25519-sk AAAAsecond user@host" >"$HOME/.ssh/id_ed25519_sk_22.pub"
+	run yk-ssh-copy-id user@host
+	[ "$status" -eq 0 ]
+	# Both keys appear in the payload sent to ssh.
+	grep -q "AAAAfirst" "$TEST_BIN_DIR/ssh.stdin"
+	grep -q "AAAAsecond" "$TEST_BIN_DIR/ssh.stdin"
+}
+
+@test "yk-ssh-copy-id: legacy un-suffixed file works when no per-serial" {
+	echo "ssh-ed25519-sk AAAAlegacy user@host" >"$HOME/.ssh/id_ed25519_sk.pub"
+	run yk-ssh-copy-id user@host
+	[ "$status" -eq 0 ]
+	grep -q "AAAAlegacy" "$TEST_BIN_DIR/ssh.stdin"
+}
+
+@test "yk-ssh-copy-id: passes -p port to ssh" {
+	echo "ssh-ed25519-sk AAAAtest user@host" >"$HOME/.ssh/id_ed25519_sk_11.pub"
+	run yk-ssh-copy-id -p 2222 user@host
+	[ "$status" -eq 0 ]
+	grep -qE '^2222$' "$TEST_BIN_DIR/ssh.args"
+}
+
+@test "yk-ssh-copy-id: --identity pushes only the specified key" {
+	echo "ssh-ed25519-sk AAAAfirst user@host" >"$HOME/.ssh/id_ed25519_sk_11.pub"
+	echo "ssh-ed25519-sk AAAAsecond user@host" >"$HOME/.ssh/other.pub"
+	run yk-ssh-copy-id --identity "$HOME/.ssh/other.pub" user@host
+	[ "$status" -eq 0 ]
+	grep -q "AAAAsecond" "$TEST_BIN_DIR/ssh.stdin"
+	! grep -q "AAAAfirst" "$TEST_BIN_DIR/ssh.stdin"
+}
+
+@test "yk-ssh-copy-id: --check sends the check script (no install)" {
+	echo "ssh-ed25519-sk AAAAtest user@host" >"$HOME/.ssh/id_ed25519_sk_11.pub"
+	run yk-ssh-copy-id --check user@host
+	[ "$status" -eq 0 ]
+	# Remote command (last positional arg sent to ssh) must include the
+	# check-mode marker (echo "[OK]"/"[MISS]"). The install script does
+	# not echo those.
+	grep -q '\[OK\]' "$TEST_BIN_DIR/ssh.args"
+	grep -q '\[MISS\]' "$TEST_BIN_DIR/ssh.args"
+	# And install-only markers must NOT be there.
+	! grep -q 'umask 077' "$TEST_BIN_DIR/ssh.args"
+}
+
+@test "yk-ssh-copy-id: install script enforces ~/.ssh permissions and dedupes" {
+	# Regression-guard: the remote install script must chmod 700 ~/.ssh,
+	# chmod 600 ~/.ssh/authorized_keys, and skip lines already present.
+	echo "ssh-ed25519-sk AAAAtest user@host" >"$HOME/.ssh/id_ed25519_sk_11.pub"
+	run yk-ssh-copy-id user@host
+	[ "$status" -eq 0 ]
+	grep -qF 'chmod 700 ~/.ssh' "$TEST_BIN_DIR/ssh.args"
+	grep -qF 'chmod 600 ~/.ssh/authorized_keys' "$TEST_BIN_DIR/ssh.args"
+	grep -qF 'grep -qFx --' "$TEST_BIN_DIR/ssh.args"
+	grep -qF 'umask 077' "$TEST_BIN_DIR/ssh.args"
+}


### PR DESCRIPTION
## Summary

Adds a `yk-ssh-copy-id` helper to push **per-serial** YubiKey SSH pubkeys (those produced by `yk-enroll`, named `id_ed25519_sk_<serial>.pub`) into a remote host's `~/.ssh/authorized_keys`.

## Files

- `home/dot_config/shell/functions/yk-ssh-copy-id.sh` (bash, 188 lines)
- `home/dot_config/fish/functions/yk_ssh_copy_id.fish` (fish wrapper, 125 lines)
- `tests/bash/yk-ssh-copy-id.bats` (12 tests, all passing)

## Behaviour

- Auto-discovers all per-serial YubiKey pubkeys in `~/.ssh/`
- Idempotent: dedupes against existing `authorized_keys`
- Enforces `~/.ssh` perms (`700`) and `authorized_keys` (`600`) on the remote
- Falls back to legacy un-suffixed `id_ed25519_sk.pub` when no per-serial files exist

## Flags

| Flag | Purpose |
| ---- | ------- |
| `--check` | Only report which keys are present remotely (no install) |
| `--dry-run` | Print what would happen, do not contact the remote |
| `--identity <file>` | Push only the specified pubkey |
| `--port <n>` | Pass through to `ssh` |
| `--help` | Usage |

## Tests

```
12 tests, 12 passed (bats)
```

## Note on history

This branch was rebased onto current `main` after a prior incident in which these three files were accidentally folded into the squash-merge of #282. That contamination has already been cleaned up on `main` in commit `de7f495`. This PR re-introduces the helper through proper review.