### PR TITLE
fix(yubikey): yk-git-sign-setup must not write self-keys to allowed_signers (chezmoi drift)

### DIFF
--- a/home/dot_config/shell/functions/yk-git-sign-setup.sh
+++ b/home/dot_config/shell/functions/yk-git-sign-setup.sh
@@ -110,9 +110,7 @@ EOF
 	# verify git config. We don't *write* git config here — that's owned by
 	# git/config.tmpl + the chezmoi `useYubiKey` var. Instead we explain how
 	# to enable it if it isn't on yet.
-	local email
-	email="$(git config --get user.email 2>/dev/null || true)"
-	if [[ -z "$email" ]]; then
+	if [[ -z "$(git config --get user.email 2>/dev/null || true)" ]]; then
 		echo "Error: git config user.email is not set." >&2
 		return 1
 	fi
@@ -145,18 +143,26 @@ EOF
 		return 1
 	fi
 
-	local pubkey registered=0 already=0
+	# allowed_signers for self keys is owned by chezmoi (see
+	# home/dot_config/git/allowed_signers.tmpl). We only verify presence
+	# here; writing them ourselves would cause `chezmoi apply` to flag the
+	# file as drifted on every subsequent run.
+	local pubkey missing=0
 	for key in "${keys[@]}"; do
 		pubkey="$(cat "$key")"
 		if grep -Fq -- "$pubkey" "$allowed_signers" 2>/dev/null; then
 			echo "Already registered: $key"
-			already=$((already + 1))
 		else
-			printf '%s %s\n' "$email" "$pubkey" >>"$allowed_signers"
-			echo "Registered $key for $email"
-			registered=$((registered + 1))
+			echo "Missing from allowed_signers: $key"
+			missing=$((missing + 1))
 		fi
 	done
+	if [[ $missing -gt 0 ]]; then
+		echo
+		echo "Hint: $missing key(s) not yet in $allowed_signers."
+		echo "      Set chezmoi data 'useYubiKey: true' and run \`chezmoi apply\`"
+		echo "      to populate allowed_signers from your enrolled YubiKey pubkeys."
+	fi
 
 	# Verify config
 	local fmt sign signer

--- a/tests/bash/yk-git-sign-setup.bats
+++ b/tests/bash/yk-git-sign-setup.bats
@@ -75,50 +75,63 @@ set_git_cfg() {
 	[[ "$output" =~ "user.email is not set" ]]
 }
 
-@test "yk-git-sign-setup: registers all per-serial pubkeys (yk-enroll output)" {
+@test "yk-git-sign-setup: verifies all per-serial pubkeys (yk-enroll output)" {
 	# Regression: yk-enroll writes id_ed25519_sk_<serial>.pub. The setup
-	# helper must register every per-serial file, not just the legacy
-	# un-suffixed one.
+	# helper must check every per-serial file, not just the legacy
+	# un-suffixed one. Self-key writes are owned by chezmoi (see
+	# allowed_signers.tmpl) — this helper only verifies presence.
 	set_git_cfg user.email "me@example.com"
 	set_git_cfg gpg.format ssh
 	set_git_cfg commit.gpgsign true
 	set_git_cfg user.signingkey "$TEST_HOME/.ssh/id_ed25519_sk_11.pub"
-	mkdir -p "$TEST_HOME/.ssh"
+	mkdir -p "$TEST_HOME/.ssh" "$TEST_HOME/.config/git"
 	echo "ssh-ed25519-sk AAAAfirst user@host" >"$TEST_HOME/.ssh/id_ed25519_sk_11.pub"
 	echo "ssh-ed25519-sk AAAAsecond user@host" >"$TEST_HOME/.ssh/id_ed25519_sk_22.pub"
+	# Pre-populate as chezmoi would have.
+	printf 'me@example.com ssh-ed25519-sk AAAAfirst user@host\nme@example.com ssh-ed25519-sk AAAAsecond user@host\n' >"$ALLOWED_SIGNERS_FILE"
 	run yk-git-sign-setup
 	[ "$status" -eq 0 ]
-	grep -q "me@example.com ssh-ed25519-sk AAAAfirst" "$ALLOWED_SIGNERS_FILE"
-	grep -q "me@example.com ssh-ed25519-sk AAAAsecond" "$ALLOWED_SIGNERS_FILE"
+	[[ "$output" =~ "Already registered" ]]
 	# Required-next-step nudge mentions BOTH gh ssh-key add commands.
 	[[ "$output" =~ "--type signing" ]]
 }
 
-@test "yk-git-sign-setup: registers legacy un-suffixed key when no per-serial files exist" {
+@test "yk-git-sign-setup: warns when self-key missing from allowed_signers" {
+	# Self keys are managed by chezmoi. If they're missing, yk-git-sign-setup
+	# should NOT write them itself (that would cause chezmoi drift). It
+	# should print a hint pointing at chezmoi apply.
 	set_git_cfg user.email "me@example.com"
 	set_git_cfg gpg.format ssh
 	set_git_cfg commit.gpgsign true
 	set_git_cfg user.signingkey "$TEST_HOME/.ssh/id_ed25519_sk.pub"
-	mkdir -p "$TEST_HOME/.ssh"
+	mkdir -p "$TEST_HOME/.ssh" "$TEST_HOME/.config/git"
 	echo "ssh-ed25519-sk AAAAtest user@host" >"$TEST_HOME/.ssh/id_ed25519_sk.pub"
+	: >"$ALLOWED_SIGNERS_FILE"
 	run yk-git-sign-setup
-	[ "$status" -eq 0 ]
-	[[ "$output" =~ "Registered" ]]
-	grep -q "me@example.com ssh-ed25519-sk AAAAtest" "$ALLOWED_SIGNERS_FILE"
+	[[ "$output" =~ "Missing from allowed_signers" ]]
+	[[ "$output" =~ "chezmoi apply" ]]
+	# Should NOT have written the key itself.
+	run grep -q "AAAAtest" "$ALLOWED_SIGNERS_FILE"
+	[ "$status" -ne 0 ]
 }
 
-@test "yk-git-sign-setup: idempotent re-registration of per-serial keys" {
+@test "yk-git-sign-setup: idempotent — never writes self-keys to allowed_signers" {
+	# Even called many times, yk-git-sign-setup must not append self keys
+	# to allowed_signers (that file is owned by chezmoi).
 	set_git_cfg user.email "me@example.com"
 	set_git_cfg gpg.format ssh
 	set_git_cfg commit.gpgsign true
 	set_git_cfg user.signingkey "$TEST_HOME/.ssh/id_ed25519_sk_11.pub"
-	mkdir -p "$TEST_HOME/.ssh"
+	mkdir -p "$TEST_HOME/.ssh" "$TEST_HOME/.config/git"
 	echo "ssh-ed25519-sk AAAAtest user@host" >"$TEST_HOME/.ssh/id_ed25519_sk_11.pub"
+	# Pre-populate as chezmoi would have.
+	echo "me@example.com ssh-ed25519-sk AAAAtest user@host" >"$ALLOWED_SIGNERS_FILE"
+	yk-git-sign-setup >/dev/null
 	yk-git-sign-setup >/dev/null
 	run yk-git-sign-setup
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "Already registered" ]]
-	# Single entry only (no duplicates).
+	# Single entry only (no duplicates appended by helper).
 	[ "$(grep -c "ssh-ed25519-sk AAAAtest" "$ALLOWED_SIGNERS_FILE")" -eq 1 ]
 }
 
@@ -128,8 +141,9 @@ set_git_cfg() {
 	# the failure so callers know signing isn't actually working yet.
 	set_git_cfg user.email "me@example.com"
 	# Note: gpg.format/commit.gpgsign/user.signingkey deliberately NOT set.
-	mkdir -p "$TEST_HOME/.ssh"
+	mkdir -p "$TEST_HOME/.ssh" "$TEST_HOME/.config/git"
 	echo "ssh-ed25519-sk AAAAtest user@host" >"$TEST_HOME/.ssh/id_ed25519_sk_11.pub"
+	echo "me@example.com ssh-ed25519-sk AAAAtest user@host" >"$ALLOWED_SIGNERS_FILE"
 	run yk-git-sign-setup
 	[ "$status" -eq 1 ]
 	[[ "$output" =~ "Hint:" ]]


### PR DESCRIPTION
## Bug

On the Mac mini:

```
jean-paulvanravensberg@Jean-Pauls-Mini> chezmoi apply
.config/git/allowed_signers has changed since chezmoi last wrote it?
diff --git a/.config/git/allowed_signers b/.config/git/allowed_signers
-14926452+DevSecNinja@users.noreply.github.com sk-ssh-ed25519@... YubiKey 5C NFC FIPS (·5443)
-14926452+DevSecNinja@users.noreply.github.com sk-ssh-ed25519@... YubiKey 5C NFC FIPS (·4479)
```

`chezmoi apply` complained on every run because two writers fought over the same file.

## Root cause

| Writer | Source | Behaviour |
| ------ | ------ | --------- |
| chezmoi | `home/dot_config/git/allowed_signers.tmpl` | renders all per-serial YubiKey pubkeys when `useYubiKey: true` |
| `yk-git-sign-setup` | runtime helper | also appended the same per-serial keys |

→ chezmoi sees the live file diverging from the template it last wrote.

## Fix

`yk-git-sign-setup` no longer writes self (per-serial) keys. It only **validates** that every per-serial pubkey is already present in the chezmoi-rendered `allowed_signers`. If any are missing, it prints:

```
Hint: enable chezmoi data 'useYubiKey: true' and run `chezmoi apply`
      to populate ~/.config/git/allowed_signers.
```

`--add <pubkey> --principal <email>` for **coworker** keys still appends (the template never owns those entries — they're additive).

## Tests

`tests/bash/yk-git-sign-setup.bats` updated:

- New: idempotency test asserting the helper **never writes** self-keys to `allowed_signers`.
- New: warning test for the missing-self-key hint.
- Existing `--add` coworker-key tests unchanged (still pass).
- All 11/11 green.