### PR TITLE
feat(pwsh): testable Nerd Font install + Windows Terminal font + Copilot CLI MCP config

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -322,6 +322,22 @@ over raw `echo` / `printf`. Full reference: [`docs/logging.md`](../docs/logging.
    `tests/bash/log-*.bats` (one file per concern: format / kinds / banner /
    injection / structured / shells).
 
+### 8. Never sign PowerShell scripts manually
+
+**Do not add, update, or worry about Authenticode signatures on `.ps1` files.**
+Signing is fully automated by the
+[`sign-powershell.yml`](../.github/workflows/sign-powershell.yml) workflow,
+which runs on every push to `main`, re-signs all `.ps1` files (excluding
+`*.ps1.tmpl`), and opens a follow-up PR with the signed files.
+
+- Add new `.ps1` files (including `DotfilesHelpers` module `Public/*.ps1`)
+  **unsigned** — the workflow signs them after merge.
+- Editing an already-signed `.ps1` invalidates its existing signature block;
+  that is expected and fine. Leave the old block in place (the workflow
+  replaces it) — do **not** hand-edit or strip signature blocks.
+- `*.ps1.tmpl` files are intentionally never signed (they change after chezmoi
+  renders them), so no action is needed there either.
+
 ## Common Issues & Solutions
 
 ### Issue: Validation scripts fail with "command not found"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+    "mcpServers": {
+        "github": {
+            "type": "http",
+            "url": "https://api.githubcopilot.com/mcp/"
+        },
+        "microsoft-learn": {
+            "type": "http",
+            "url": "https://learn.microsoft.com/api/mcp"
+        }
+    }
+}

--- a/home/.chezmoiscripts/windows/run_once_install-modules.ps1.tmpl
+++ b/home/.chezmoiscripts/windows/run_once_install-modules.ps1.tmpl
@@ -14,11 +14,12 @@ Set-PSResourceRepository -Name "PSGallery" -Priority 25 -Trusted #-PassThru
 
 Write-Host "`nInstalling PowerShell Fonts..." -ForegroundColor Cyan
 
-# chezmoi uses Windows PowerShell which throws 'CouldNotAutoloadMatchingModule'
-# TODO: Make nice function for calling pwsh non-interactive. Also reuse in Install-PowerShellModule file.
+# Install-DotfilesNerdFont (from the DotfilesHelpers module imported above) is
+# idempotent, delegates the actual install to pwsh (the NerdFonts module is
+# PowerShell 7 only), and verifies the font registered instead of swallowing
+# failures. See Public/FontManagement.ps1.
 # TODO: Move font install after installing packages since package install will install pwsh
-# TODO: Make nice font install function that checks if font was installed successfully
-pwsh -ExecutionPolicy Bypass -NoProfile -NonInteractive -Command "Install-PSResource -Name NerdFonts -Scope CurrentUser && Install-NerdFont -Name FiraCode -Scope CurrentUser" 2>&1
+Install-DotfilesNerdFont -Name FiraCode -Scope CurrentUser | Out-Null
 
 Write-Host "`nInstalling PowerShell Modules..." -ForegroundColor Cyan
 

--- a/home/.chezmoiscripts/windows/run_once_setup-windows-terminal.ps1
+++ b/home/.chezmoiscripts/windows/run_once_setup-windows-terminal.ps1
@@ -53,7 +53,7 @@ if (-not (Test-Path $settingsFile)) {
             {
                 "face": "FiraCode Nerd Font"
             }
-        }
+        },
         "list":
         [
             {

--- a/home/.chezmoiscripts/windows/run_onchange_set-windows-terminal-font.ps1.tmpl
+++ b/home/.chezmoiscripts/windows/run_onchange_set-windows-terminal-font.ps1.tmpl
@@ -1,0 +1,31 @@
+# {{ if eq .chezmoi.os "windows" }}
+# Set the Windows Terminal default font face WITHOUT managing the whole config.
+# Windows Terminal owns settings.json (it rewrites it at runtime), so we only
+# patch profiles.defaults.font.face. This keeps the font in sync via git without
+# the conflicts that come from chezmoi managing the entire settings.json.
+#
+# This complements run_once_setup-windows-terminal.ps1 (which creates the file
+# only if it is missing): the run_once handles brand-new machines, while this
+# run_onchange fixes the font on machines that already had Windows Terminal
+# settings. The font face is embedded literally below so chezmoi's run-onchange
+# content hash changes (and this re-runs) whenever the desired font changes.
+#
+# Windows Terminal font face: FiraCode Nerd Font
+$ErrorActionPreference = "Stop"
+
+$modulePath = "{{ .chezmoi.sourceDir }}\dot_config\powershell\modules\DotfilesHelpers"
+if (Test-Path $modulePath) {
+    Import-Module $modulePath -Force -DisableNameChecking
+}
+else {
+    Write-Error "DotfilesHelpers module not found at: $modulePath"
+    exit 1
+}
+
+Write-Host "Setting Windows Terminal default font..." -ForegroundColor Cyan
+$results = Set-WindowsTerminalFont -FontFace "FiraCode Nerd Font"
+
+if (-not $results) {
+    Write-Host "[SKIP] No Windows Terminal settings found to update" -ForegroundColor Yellow
+}
+# {{ end }}

--- a/home/dot_config/powershell/modules/DotfilesHelpers/DotfilesHelpers.psd1
+++ b/home/dot_config/powershell/modules/DotfilesHelpers/DotfilesHelpers.psd1
@@ -39,6 +39,11 @@
         'Install-GitPowerShellModule'
         'Add-ToPSModulePath'
 
+        # Font management
+        'Test-NerdFontInstalled'
+        'Install-DotfilesNerdFont'
+        'Set-WindowsTerminalFont'
+
         # Office 365 mail aliases
         'New-MailAlias'
         'Select-MailAlias'

--- a/home/dot_config/powershell/modules/DotfilesHelpers/Public/FontManagement.ps1
+++ b/home/dot_config/powershell/modules/DotfilesHelpers/Public/FontManagement.ps1
@@ -1,0 +1,302 @@
+# Font management utilities
+#
+# Functions for installing Nerd Fonts and for pointing Windows Terminal at an
+# installed font without managing (and fighting git-sync on) the whole
+# settings.json file.
+
+function Remove-JsonComment {
+    <#
+    .SYNOPSIS
+    Strips // and /* */ comments from a JSONC string in a string-aware way.
+
+    .DESCRIPTION
+    Windows PowerShell 5.1's ConvertFrom-Json cannot parse JSONC (comments /
+    trailing commas), which Windows Terminal allows. This helper removes
+    comments while preserving content inside string literals (so URLs such as
+    "https://example.com" are not mangled) and drops trailing commas before
+    closing braces/brackets.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$Text
+    )
+
+    $sb = [System.Text.StringBuilder]::new()
+    $inString = $false
+    $escaped = $false
+    $i = 0
+    $len = $Text.Length
+
+    while ($i -lt $len) {
+        $c = $Text[$i]
+        $next = if ($i + 1 -lt $len) { $Text[$i + 1] } else { [char]0 }
+
+        if ($inString) {
+            [void]$sb.Append($c)
+            if ($escaped) { $escaped = $false }
+            elseif ($c -eq '\') { $escaped = $true }
+            elseif ($c -eq '"') { $inString = $false }
+            $i++
+            continue
+        }
+
+        if ($c -eq '"') {
+            $inString = $true
+            [void]$sb.Append($c)
+            $i++
+            continue
+        }
+
+        if ($c -eq '/' -and $next -eq '/') {
+            while ($i -lt $len -and $Text[$i] -ne "`n") { $i++ }
+            continue
+        }
+
+        if ($c -eq '/' -and $next -eq '*') {
+            $i += 2
+            while ($i + 1 -lt $len -and -not ($Text[$i] -eq '*' -and $Text[$i + 1] -eq '/')) { $i++ }
+            $i += 2
+            continue
+        }
+
+        [void]$sb.Append($c)
+        $i++
+    }
+
+    # Remove trailing commas (",}" / ",]") that JSONC allows but JSON rejects.
+    return [regex]::Replace($sb.ToString(), ',(\s*[}\]])', '$1')
+}
+
+function Test-NerdFontInstalled {
+    <#
+    .SYNOPSIS
+    Returns $true if a Nerd Font matching the given name is registered.
+
+    .PARAMETER Name
+    The Nerd Font family name (as passed to Install-NerdFont), e.g. 'FiraCode'.
+    Matching ignores spaces, so 'FiraCode' matches the registered
+    'FiraCodeNerdFont-Regular (TrueType)' value.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter()]
+        [ValidatePattern('^[A-Za-z0-9._ -]+$')]
+        [string]$Name = 'FiraCode'
+    )
+
+    $needle = ($Name -replace '\s', '')
+    $keys = @(
+        'HKCU:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts',
+        'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts'
+    )
+
+    foreach ($key in $keys) {
+        if (-not (Test-Path -Path $key)) { continue }
+        $props = (Get-ItemProperty -Path $key).PSObject.Properties
+        foreach ($prop in $props) {
+            if ($prop.Name -like 'PS*') { continue }
+            $normalized = ($prop.Name -replace '\s', '')
+            if ($normalized -like "*${needle}NerdFont*") { return $true }
+        }
+    }
+
+    return $false
+}
+
+function Invoke-NerdFontInstaller {
+    <#
+    .SYNOPSIS
+    Performs the actual Nerd Font install via the (PowerShell 7) NerdFonts module.
+
+    .DESCRIPTION
+    chezmoi runs scripts under Windows PowerShell 5.1, but the NerdFonts module
+    is PowerShell 7 only, so the install is delegated to pwsh. Kept private so
+    Install-DotfilesNerdFont can be unit-tested by mocking this function.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidatePattern('^[A-Za-z0-9._-]+$')]
+        [string]$Name,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('CurrentUser', 'AllUsers')]
+        [string]$Scope
+    )
+
+    $pwshCmd = Get-Command pwsh -ErrorAction SilentlyContinue
+    if (-not $pwshCmd) {
+        Write-Warning "pwsh (PowerShell 7) not found; cannot install Nerd Font '$Name'. Install PowerShell 7 first."
+        return $false
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($Name, 'Install Nerd Font')) { return $false }
+
+    # $Name and $Scope are constrained by ValidatePattern/ValidateSet above, so
+    # interpolating them into the command string is safe from injection.
+    $inner = "Install-PSResource -Name NerdFonts -Scope CurrentUser -TrustRepository -Quiet -ErrorAction Stop; " +
+    "Install-NerdFont -Name $Name -Scope $Scope -Confirm:`$false -ErrorAction Stop"
+
+    & $pwshCmd.Source -ExecutionPolicy Bypass -NoProfile -NonInteractive -Command $inner 2>&1 |
+        ForEach-Object { Write-Verbose ([string]$_) }
+
+    return ($LASTEXITCODE -eq 0)
+}
+
+function Install-DotfilesNerdFont {
+    <#
+    .SYNOPSIS
+    Idempotently installs a Nerd Font and verifies it registered.
+
+    .PARAMETER Name
+    Nerd Font family name (default 'FiraCode').
+
+    .PARAMETER Scope
+    Install scope: CurrentUser (default) or AllUsers.
+
+    .PARAMETER Force
+    Reinstall even if the font already appears to be installed.
+
+    .EXAMPLE
+    Install-DotfilesNerdFont -Name FiraCode -Scope CurrentUser
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter()]
+        [ValidatePattern('^[A-Za-z0-9._-]+$')]
+        [string]$Name = 'FiraCode',
+
+        [Parameter()]
+        [ValidateSet('CurrentUser', 'AllUsers')]
+        [string]$Scope = 'CurrentUser',
+
+        [switch]$Force
+    )
+
+    if ((Test-NerdFontInstalled -Name $Name) -and -not $Force) {
+        Write-Host "[OK] $Name Nerd Font already installed" -ForegroundColor Green
+        return [pscustomobject]@{ Name = $Name; Installed = $true; Action = 'AlreadyInstalled' }
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($Name, 'Install Nerd Font')) {
+        return [pscustomobject]@{ Name = $Name; Installed = (Test-NerdFontInstalled -Name $Name); Action = 'Skipped' }
+    }
+
+    Write-Host "Installing $Name Nerd Font..." -ForegroundColor Cyan
+    $ok = Invoke-NerdFontInstaller -Name $Name -Scope $Scope
+    $installed = Test-NerdFontInstalled -Name $Name
+
+    if ($ok -and $installed) {
+        Write-Host "[OK] $Name Nerd Font installed" -ForegroundColor Green
+        return [pscustomobject]@{ Name = $Name; Installed = $true; Action = 'Installed' }
+    }
+
+    Write-Warning "Failed to install $Name Nerd Font. Install manually with: pwsh -Command 'Install-NerdFont -Name $Name -Scope $Scope'"
+    return [pscustomobject]@{ Name = $Name; Installed = $false; Action = 'Failed' }
+}
+
+function Set-WindowsTerminalFont {
+    <#
+    .SYNOPSIS
+    Sets the Windows Terminal default font face by surgically patching settings.json.
+
+    .DESCRIPTION
+    Updates only profiles.defaults.font.face in each existing Windows Terminal
+    settings.json, leaving everything else untouched. Windows Terminal keeps
+    owning the file, so this avoids the conflicts that come from managing the
+    whole config in git. Files that do not exist are skipped (initial creation
+    is handled by run_once_setup-windows-terminal.ps1).
+
+    .PARAMETER FontFace
+    The font face name to set, e.g. 'FiraCode Nerd Font'.
+
+    .PARAMETER SettingsPath
+    One or more settings.json paths. Defaults to the known Windows Terminal
+    locations (Store, Preview, and unpackaged).
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$FontFace,
+
+        [Parameter()]
+        [string[]]$SettingsPath
+    )
+
+    if (-not $SettingsPath) {
+        $SettingsPath = @(
+            (Join-Path $env:LOCALAPPDATA 'Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState\settings.json'),
+            (Join-Path $env:LOCALAPPDATA 'Packages\Microsoft.WindowsTerminalPreview_8wekyb3d8bbwe\LocalState\settings.json'),
+            (Join-Path $env:LOCALAPPDATA 'Microsoft\Windows Terminal\settings.json')
+        )
+    }
+
+    $results = @()
+
+    foreach ($path in $SettingsPath) {
+        if (-not (Test-Path -LiteralPath $path)) {
+            Write-Verbose "Windows Terminal settings not found at: $path (skipping)"
+            continue
+        }
+
+        try {
+            $raw = Get-Content -LiteralPath $path -Raw -ErrorAction Stop
+
+            $json = $null
+            try {
+                $json = $raw | ConvertFrom-Json -ErrorAction Stop
+            }
+            catch {
+                # Retry assuming JSONC (comments / trailing commas).
+                $json = (Remove-JsonComment -Text $raw) | ConvertFrom-Json -ErrorAction Stop
+            }
+
+            if ($null -eq $json.profiles) {
+                $json | Add-Member -NotePropertyName profiles -NotePropertyValue ([pscustomobject]@{}) -Force
+            }
+            if ($null -eq $json.profiles.defaults) {
+                $json.profiles | Add-Member -NotePropertyName defaults -NotePropertyValue ([pscustomobject]@{}) -Force
+            }
+            if ($null -eq $json.profiles.defaults.font) {
+                $json.profiles.defaults | Add-Member -NotePropertyName font -NotePropertyValue ([pscustomobject]@{}) -Force
+            }
+
+            if ($json.profiles.defaults.font.face -eq $FontFace) {
+                Write-Verbose "Font already set to '$FontFace' at: $path"
+                $results += [pscustomobject]@{ Path = $path; Changed = $false; Status = 'AlreadySet' }
+                continue
+            }
+
+            if ($null -eq $json.profiles.defaults.font.PSObject.Properties['face']) {
+                $json.profiles.defaults.font | Add-Member -NotePropertyName face -NotePropertyValue $FontFace -Force
+            }
+            else {
+                $json.profiles.defaults.font.face = $FontFace
+            }
+
+            if ($PSCmdlet.ShouldProcess($path, "Set default font face to '$FontFace'")) {
+                $out = $json | ConvertTo-Json -Depth 32
+                [System.IO.File]::WriteAllText($path, $out, (New-Object System.Text.UTF8Encoding($false)))
+                Write-Host "[OK] Set Windows Terminal font to '$FontFace' at: $path" -ForegroundColor Green
+                $results += [pscustomobject]@{ Path = $path; Changed = $true; Status = 'Updated' }
+            }
+            else {
+                $results += [pscustomobject]@{ Path = $path; Changed = $false; Status = 'WhatIf' }
+            }
+        }
+        catch {
+            Write-Warning "Could not update Windows Terminal settings at '$path': $_"
+            $results += [pscustomobject]@{ Path = $path; Changed = $false; Status = 'Error' }
+        }
+    }
+
+    return $results
+}

--- a/tests/powershell/FontManagement.Tests.ps1
+++ b/tests/powershell/FontManagement.Tests.ps1
@@ -1,0 +1,224 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Pester tests for font management utilities (Test-NerdFontInstalled,
+    Install-DotfilesNerdFont, Set-WindowsTerminalFont) in the DotfilesHelpers
+    module.
+
+.DESCRIPTION
+    Validates function metadata, the idempotency / failure control flow of the
+    Nerd Font installer (with the real install mocked), and the surgical
+    Windows Terminal settings.json font patching against real temporary files.
+#>
+
+BeforeAll {
+    $script:RepoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+    Push-Location $script:RepoRoot
+
+    $modulePath = Join-Path $script:RepoRoot "home/dot_config/powershell/modules/DotfilesHelpers"
+    if (Test-Path $modulePath) {
+        Get-Module DotfilesHelpers -All | Remove-Module -Force -ErrorAction SilentlyContinue
+        Import-Module $modulePath -Force -DisableNameChecking
+    }
+    else {
+        throw "DotfilesHelpers module not found at: $modulePath"
+    }
+
+    $tmpRoot = if ($env:TEMP) { $env:TEMP } else { '/tmp' }
+    $script:TestDir = New-Item -ItemType Directory -Path (Join-Path $tmpRoot "font-mgmt-tests-$(Get-Random)") -Force
+}
+
+AfterAll {
+    Pop-Location
+    if (Test-Path $script:TestDir) {
+        Remove-Item -Recurse -Force $script:TestDir.FullName -ErrorAction SilentlyContinue
+    }
+}
+
+Describe "Test-NerdFontInstalled Function" -Tag "Unit" {
+    It "Should be available as a function" {
+        Get-Command Test-NerdFontInstalled -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+    }
+
+    It "Should default the Name parameter to 'FiraCode'" {
+        (Get-Command Test-NerdFontInstalled).Parameters["Name"].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ValidatePatternAttribute] } |
+            Should -Not -BeNullOrEmpty
+    }
+
+    It "Should return a boolean" {
+        $result = Test-NerdFontInstalled -Name 'FiraCode'
+        $result | Should -BeOfType [bool]
+    }
+}
+
+Describe "Install-DotfilesNerdFont Function" -Tag "Unit" {
+    It "Should be available as a function" {
+        Get-Command Install-DotfilesNerdFont -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+    }
+
+    It "Should support ShouldProcess (WhatIf)" {
+        (Get-Command Install-DotfilesNerdFont).Parameters.ContainsKey("WhatIf") | Should -Be $true
+    }
+
+    It "Should validate Scope against an allow-list" {
+        { Install-DotfilesNerdFont -Scope "Nonsense" -WhatIf } | Should -Throw
+    }
+
+    Context "Idempotency and control flow (install mocked)" {
+        It "Should skip installation when the font is already present" {
+            Mock -ModuleName DotfilesHelpers Test-NerdFontInstalled { $true }
+            Mock -ModuleName DotfilesHelpers Invoke-NerdFontInstaller { $true }
+
+            $result = Install-DotfilesNerdFont -Name FiraCode
+
+            $result.Action | Should -Be 'AlreadyInstalled'
+            $result.Installed | Should -Be $true
+            Should -Invoke -ModuleName DotfilesHelpers Invoke-NerdFontInstaller -Times 0 -Exactly
+        }
+
+        It "Should install when forced even if already present" {
+            Mock -ModuleName DotfilesHelpers Test-NerdFontInstalled { $true }
+            Mock -ModuleName DotfilesHelpers Invoke-NerdFontInstaller { $true }
+
+            $result = Install-DotfilesNerdFont -Name FiraCode -Force
+
+            $result.Action | Should -Be 'Installed'
+            $result.Installed | Should -Be $true
+            Should -Invoke -ModuleName DotfilesHelpers Invoke-NerdFontInstaller -Times 1 -Exactly
+        }
+
+        It "Should report failure when the font does not register after install" {
+            Mock -ModuleName DotfilesHelpers Test-NerdFontInstalled { $false }
+            Mock -ModuleName DotfilesHelpers Invoke-NerdFontInstaller { $true }
+
+            $result = Install-DotfilesNerdFont -Name FiraCode
+
+            $result.Action | Should -Be 'Failed'
+            $result.Installed | Should -Be $false
+        }
+
+        It "Should not install under -WhatIf" {
+            Mock -ModuleName DotfilesHelpers Test-NerdFontInstalled { $false }
+            Mock -ModuleName DotfilesHelpers Invoke-NerdFontInstaller { $true }
+
+            Install-DotfilesNerdFont -Name FiraCode -WhatIf | Out-Null
+
+            Should -Invoke -ModuleName DotfilesHelpers Invoke-NerdFontInstaller -Times 0 -Exactly
+        }
+    }
+}
+
+Describe "Set-WindowsTerminalFont Function" -Tag "Unit" {
+    BeforeEach {
+        $script:settingsPath = Join-Path $script:TestDir.FullName "settings-$(Get-Random).json"
+    }
+
+    AfterEach {
+        Remove-Item -LiteralPath $script:settingsPath -ErrorAction SilentlyContinue
+    }
+
+    It "Should be available as a function with a mandatory FontFace parameter" {
+        $cmd = Get-Command Set-WindowsTerminalFont
+        $cmd | Should -Not -BeNullOrEmpty
+        $cmd.Parameters["FontFace"].Attributes |
+            Where-Object { $_ -is [Parameter] } |
+            Select-Object -ExpandProperty Mandatory |
+            Should -Contain $true
+    }
+
+    It "Should set the font when no profiles section exists" {
+        '{ "theme": "dark" }' | Set-Content -LiteralPath $script:settingsPath -Encoding utf8
+
+        $result = Set-WindowsTerminalFont -FontFace "FiraCode Nerd Font" -SettingsPath $script:settingsPath
+
+        $result.Status | Should -Be 'Updated'
+        $json = Get-Content -LiteralPath $script:settingsPath -Raw | ConvertFrom-Json
+        $json.profiles.defaults.font.face | Should -Be "FiraCode Nerd Font"
+        $json.theme | Should -Be "dark"
+    }
+
+    It "Should update an existing different font face" {
+        '{ "profiles": { "defaults": { "font": { "face": "Consolas" } } } }' |
+            Set-Content -LiteralPath $script:settingsPath -Encoding utf8
+
+        $result = Set-WindowsTerminalFont -FontFace "FiraCode Nerd Font" -SettingsPath $script:settingsPath
+
+        $result.Status | Should -Be 'Updated'
+        $json = Get-Content -LiteralPath $script:settingsPath -Raw | ConvertFrom-Json
+        $json.profiles.defaults.font.face | Should -Be "FiraCode Nerd Font"
+    }
+
+    It "Should be idempotent when the font is already correct" {
+        '{ "profiles": { "defaults": { "font": { "face": "FiraCode Nerd Font" } } } }' |
+            Set-Content -LiteralPath $script:settingsPath -Encoding utf8
+
+        $result = Set-WindowsTerminalFont -FontFace "FiraCode Nerd Font" -SettingsPath $script:settingsPath
+
+        $result.Status | Should -Be 'AlreadySet'
+        $result.Changed | Should -Be $false
+    }
+
+    It "Should preserve other settings including the profiles.list array" {
+        $original = @'
+{
+    "theme": "dark",
+    "profiles": {
+        "defaults": { "font": { "face": "Consolas" } },
+        "list": [
+            { "name": "PowerShell", "guid": "{abc}" },
+            { "name": "cmd", "guid": "{def}" }
+        ]
+    }
+}
+'@
+        $original | Set-Content -LiteralPath $script:settingsPath -Encoding utf8
+
+        Set-WindowsTerminalFont -FontFace "FiraCode Nerd Font" -SettingsPath $script:settingsPath | Out-Null
+
+        $json = Get-Content -LiteralPath $script:settingsPath -Raw | ConvertFrom-Json
+        $json.profiles.defaults.font.face | Should -Be "FiraCode Nerd Font"
+        $json.theme | Should -Be "dark"
+        $json.profiles.list.Count | Should -Be 2
+        $json.profiles.list[0].name | Should -Be "PowerShell"
+    }
+
+    It "Should parse JSONC (comments and trailing commas) without mangling URLs" {
+        $jsonc = @'
+{
+    // user comment
+    "schema": "https://aka.ms/terminal-profiles-schema",
+    "profiles": {
+        "defaults": { "font": { "face": "Consolas" } },
+    }
+}
+'@
+        $jsonc | Set-Content -LiteralPath $script:settingsPath -Encoding utf8
+
+        $result = Set-WindowsTerminalFont -FontFace "FiraCode Nerd Font" -SettingsPath $script:settingsPath
+
+        $result.Status | Should -Be 'Updated'
+        $json = Get-Content -LiteralPath $script:settingsPath -Raw | ConvertFrom-Json
+        $json.profiles.defaults.font.face | Should -Be "FiraCode Nerd Font"
+        $json.schema | Should -Be "https://aka.ms/terminal-profiles-schema"
+    }
+
+    It "Should skip paths that do not exist" {
+        $missing = Join-Path $script:TestDir.FullName "does-not-exist-$(Get-Random).json"
+
+        $result = Set-WindowsTerminalFont -FontFace "FiraCode Nerd Font" -SettingsPath $missing
+
+        $result | Should -BeNullOrEmpty
+    }
+
+    It "Should not write under -WhatIf" {
+        '{ "profiles": { "defaults": { "font": { "face": "Consolas" } } } }' |
+            Set-Content -LiteralPath $script:settingsPath -Encoding utf8
+
+        $result = Set-WindowsTerminalFont -FontFace "FiraCode Nerd Font" -SettingsPath $script:settingsPath -WhatIf
+
+        $result.Status | Should -Be 'WhatIf'
+        $json = Get-Content -LiteralPath $script:settingsPath -Raw | ConvertFrom-Json
+        $json.profiles.defaults.font.face | Should -Be "Consolas"
+    }
+}


### PR DESCRIPTION
## Summary

Fixes broken oh-my-posh prompt glyphs (root cause: no Nerd Font was actually installed) and restores Copilot CLI MCP support, with full test coverage.

## Changes

### Nerd Font + Windows Terminal (feat)
- New `DotfilesHelpers/Public/FontManagement.ps1`:
  - `Install-DotfilesNerdFont` — idempotent, verifies registry registration, delegates the install to `pwsh` (the NerdFonts module is PowerShell 7 only).
  - `Test-NerdFontInstalled` — registry check across HKCU/HKLM.
  - `Set-WindowsTerminalFont` — surgically patches **only** `profiles.defaults.font.face` so the font stays in git sync without managing the whole `settings.json` (which Windows Terminal rewrites at runtime). JSONC-safe; never breaks `chezmoi apply`.
- `run_onchange_set-windows-terminal-font.ps1.tmpl` sets the font on existing installs; `run_once_install-modules` now calls the helper instead of an inline here-string that failed silently.
- Fixed invalid JSON (missing comma) in `run_once_setup-windows-terminal.ps1`.
- **18 Pester tests** in `tests/powershell/FontManagement.Tests.ps1`.

### Copilot CLI MCP config
- Added root `.mcp.json` (`mcpServers` key) so the Copilot CLI discovers the `github` and `microsoft-learn` servers. This complements `.vscode/mcp.json` (`servers` key) used by VS Code Copilot — different filename **and** schema key, so both files are kept in sync.

### Docs
- Added the never-sign-PowerShell-manually rule to `copilot-instructions` (scripts are signed automatically on merge to main).

## Verification
- `FontManagement.Tests.ps1`: **18/18 pass**. Full Pester suite: 390 passed (4 pre-existing environmental signing-cert failures, unrelated).
- Live: `Install-DotfilesNerdFont` → `AlreadyInstalled`; `Set-WindowsTerminalFont` → `AlreadySet` (idempotent).
- Isolated `chezmoi apply --dry-run` (chezmoi 2.70.3, throwaway state): exit 0; both font scripts present and render to valid PowerShell.
- `copilot mcp list` shows both servers from the new `.mcp.json`.

> [!NOTE]
> New `.ps1` files are intentionally left unsigned — they are signed automatically when this lands on main.
