### PR TITLE
ci(mise): pin mise binary version across all CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Single source of truth for the mise binary version across every job
+  # (including the bats.yml caller input below). Renovate keeps it patched.
+  # renovate: datasource=github-releases depName=jdx/mise
+  MISE_VERSION: "2026.5.15"
+
 jobs:
   validate:
     name: Validate Dotfiles
@@ -28,6 +34,8 @@ jobs:
 
       - name: Install mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: ${{ env.MISE_VERSION }}
 
       - name: Install shells required by validation tests
         # Fish and Zsh are required so the validation BATS tests do not
@@ -149,6 +157,8 @@ jobs:
 
       - name: Install mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: ${{ env.MISE_VERSION }}
 
       - name: Run install script
         run: ./home/install.sh
@@ -206,6 +216,8 @@ jobs:
 
       - name: Install mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: ${{ env.MISE_VERSION }}
 
       - name: Run root install script (Coder support)
         run: ./install.sh
@@ -254,6 +266,8 @@ jobs:
 
       - name: Install mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: ${{ env.MISE_VERSION }}
 
       - name: Test light server installation
         run: ./.github/scripts/test-light-server.sh
@@ -275,6 +289,8 @@ jobs:
 
       - name: Install mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: ${{ env.MISE_VERSION }}
 
       - name: Test dev server installation
         run: ./.github/scripts/test-dev-server.sh
@@ -466,6 +482,8 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/bats.yml
     with:
+      # Keep in sync with MISE_VERSION above. The env context is not available
+      # in a reusable-workflow `with:` input, so this pin is tracked separately.
       # renovate: datasource=github-releases depName=jdx/mise
       mise-version: "2026.5.15"
       test-dirs: "tests/bash/"


### PR DESCRIPTION
## What

Pin the mise binary version consistently across every job in `ci.yaml`.

## Why

The five inline `Install mise` steps had **no `version:` input**, so they installed whatever mise was latest at run time, and Renovate had nothing to track. This let the `validate` job drift to a newer mise than the `bats` job, and a breaking mise release could land with no Renovate PR.

## How

- Added a workflow-level `env.MISE_VERSION` (Renovate-tracked via `# renovate: datasource=github-releases depName=jdx/mise`) as the single source of truth.
- Pointed all five inline `Install mise` steps at it via `with.version: ${{ env.MISE_VERSION }}.
- The `bats.yml` reusable-workflow caller keeps its own literal pin (with Renovate comment) because the `env` context is **not** available in a reusable-workflow `with:` input ([docs context-availability table](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts)). A `keep in sync` comment notes this.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>