### PR TITLE
feat(mise): add APM CLI to the devcontainer

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -28,6 +28,14 @@ shfmt = "latest"
 cocogitto = "latest"
 git-cliff = "latest"
 
+# Agent Package Manager (APM): installs & updates AI agent primitives (prompts,
+# instructions, skills) from APM packages such as DevSecNinja/ai-toolkit.
+# Installed via the pipx backend (PyPI package `apm-cli`); the GitHub binary
+# release is a PyInstaller bundle that mise's github/ubi backends extract
+# incompletely, so pipx is the working install path.
+# renovate: datasource=pypi depName=apm-cli
+"pipx:apm-cli" = "0.21.0"
+
 # Additional tools for development (commented out by default)
 # Uncomment based on your needs
 # node = "lts"

--- a/.mise.toml
+++ b/.mise.toml
@@ -28,6 +28,11 @@ shfmt = "latest"
 cocogitto = "latest"
 git-cliff = "latest"
 
+# uv powers the pipx backend used for apm-cli below (mise shells out to
+# `uv tool install`). Without uv declared, `mise install` fails with
+# "No version is set for shim: uv".
+uv = "latest"
+
 # Agent Package Manager (APM): installs & updates AI agent primitives (prompts,
 # instructions, skills) from APM packages such as DevSecNinja/ai-toolkit.
 # Installed via the pipx backend (PyPI package `apm-cli`); the GitHub binary

--- a/script/devcontainer-software-manifest.sh
+++ b/script/devcontainer-software-manifest.sh
@@ -56,6 +56,7 @@ write_key_tools() {
 	tool_version "npm" npm npm --version
 	tool_version "Task" task task --version
 	tool_version "ShellCheck" shellcheck shellcheck --version
+	tool_version "APM" apm apm --version
 }
 
 write_apt_packages() {


### PR DESCRIPTION
## What

Adds the **Agent Package Manager (`apm`)** to the dotfiles devcontainer so every container built from `ghcr.io/devsecninja/dotfiles-devcontainer` can `apm install` AI agent primitives (e.g. `DevSecNinja/ai-toolkit`).

## How

One line in `.mise.toml`:

```toml
# renovate: datasource=pypi depName=apm-cli
"pipx:apm-cli" = "0.21.0"
```

The Dockerfile copies `.mise.toml` and runs `mise install` during prebuild, and mise shims are on the baked `ENV PATH` — so `apm` lands in the published image and is available in every downstream devcontainer's lifecycle hooks. Version-pinned and Renovate-tracked, following the same inline `# renovate:` pattern already used for `chezmoi` in this file.

Also lists `apm --version` under the software manifest's **Key tools** (it already auto-appears in the `mise ls --current` section).

## Why pipx, not the github binary backend

I verified this empirically before choosing:

- `ubi:`/`github:` backends extract only the `apm` executable from APM's release, but it's a **PyInstaller bundle** (`apm` + `_internal/`). The bundle's `libpython3.12.so` is left behind → `apm --version` fails with `Failed to load Python shared library`. (`ubi` is also deprecated in mise.)
- The official `curl … | sh` installer works but isn't version-pinned/Renovate-friendly and adds a bespoke install path.
- **`pipx:apm-cli`** (PyPI, same project — v0.21.0 matches the GitHub release) installs cleanly and `apm --version` → `Agent Package Manager (APM) CLI version 0.21.0`. It also matches the org's existing mise `pipx:` usage (`pipx:yamllint`, `pipx:checkov` in `.github`'s `lint.yml`).

## Verification

Locally, on this branch's config:

```
$ mise exec pipx:apm-cli@0.21.0 -- apm --version
Agent Package Manager (APM) CLI version 0.21.0
```

## Note for reviewer

I couldn't trigger the actual devcontainer prebuild from here — please let the `devcontainer-prebuild` workflow build the image and confirm `apm` resolves in the resulting container. The mise/pipx install was verified in isolation; the only integration assumption is that prebuild's `mise install` picks up the new tool (same mechanism as every other tool in this file).