### PR TITLE
feat(vscode): forward Copilot/gh tokens to Remote-SSH and dev containers

### DIFF
--- a/.devcontainer/devcontainer-prebuild.json
+++ b/.devcontainer/devcontainer-prebuild.json
@@ -23,5 +23,16 @@
             "version": "latest"
         }
     },
+    // Baked into the image's devcontainer.metadata label so EVERY repo using
+    // this image inherits it with no per-repo devcontainer.json change. Forwards
+    // the GitHub Copilot CLI / gh tokens from the host running the Dev Containers
+    // backend (for Remote-SSH that is the VS Code Server on the dev server, which
+    // gets them from the copilot-ssh-proxy remote.SSH.path helper) into the
+    // container. Resolves to empty (harmless, treated as unset) where the tokens
+    // aren't present, e.g. local/Codespaces. See dotfiles docs/copilot-cli.md.
+    "remoteEnv": {
+        "COPILOT_GITHUB_TOKEN": "${localEnv:COPILOT_GITHUB_TOKEN}",
+        "GH_TOKEN": "${localEnv:GH_TOKEN}"
+    },
     "remoteUser": "vscode"
 }

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -92,6 +92,51 @@ they pick up the forwarded tokens. Any extra `ssh` arguments are passed through
 If `op` or `OP_COPILOT_ENVIRONMENT_ID` is unavailable, the helper falls back to
 a plain `ssh` (you connect, but the tools won't receive a token).
 
+## VS Code Remote-SSH and Dev Containers
+
+VS Code Remote-SSH connects with its **own** `ssh` invocation, so it does not go
+through the `copilot-ssh` / `copilot_ssh` helper — the tokens won't reach the
+VS Code Server (or its integrated terminals / dev containers) by default. Two
+centrally-managed pieces close that gap with **no per-repo changes**:
+
+1. **`remote.SSH.path` wrapper** — `~/.local/bin/copilot-ssh-proxy.sh` (installed
+   by chezmoi) is a drop-in `ssh` for VS Code: for hosts matching
+   `COPILOT_SSH_HOST_PATTERN` (default `svl`) it reads the tokens from your
+   1Password Environment and adds `-o SendEnv=…`; every other host gets a plain
+   `ssh`. Point VS Code at it (one-time, per machine):
+
+   ```jsonc
+   // VS Code user settings.json
+   // macOS:   ~/Library/Application Support/Code/User/settings.json
+   // Linux:   ~/.config/Code/User/settings.json
+   "remote.SSH.path": "/Users/<you>/.local/bin/copilot-ssh-proxy.sh"
+   ```
+
+   With this, the VS Code Server on the dev host inherits the tokens, so the
+   **integrated terminal** has `copilot` and `gh` authenticated (scenario #1).
+   1Password will prompt to unlock when VS Code connects.
+
+2. **`remoteEnv` baked into the base dev container image** — the
+   `dotfiles-devcontainer` image embeds (via `devcontainer-prebuild.json`):
+
+   ```jsonc
+   "remoteEnv": {
+     "COPILOT_GITHUB_TOKEN": "${localEnv:COPILOT_GITHUB_TOKEN}",
+     "GH_TOKEN": "${localEnv:GH_TOKEN}"
+   }
+   ```
+
+   Dev Container image metadata is merged into every repo that uses the image,
+   so this propagates the tokens from the VS Code Server host (which has them
+   from piece 1) **into the container** — covering scenario #2 with no
+   per-repo `devcontainer.json` edits. Repos pick it up when Renovate bumps the
+   pinned image digest. Where the tokens aren't present (local dev, Codespaces)
+   the values resolve to empty, which the tools treat as unset (harmless).
+
+> The VS Code **Copilot chat / completions extension** is unrelated to this — it
+> authenticates via VS Code's own GitHub sign-in and already works over
+> Remote-SSH / Dev Containers.
+
 ## Security notes
 
 - The tokens live only in 1Password (at rest), transiently in the helper's

--- a/home/dot_local/bin/executable_copilot-ssh-proxy.sh
+++ b/home/dot_local/bin/executable_copilot-ssh-proxy.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# copilot-ssh-proxy - an `ssh` drop-in for VS Code Remote-SSH.
+#
+# VS Code Remote-SSH connects with its own `ssh` invocation, so it never goes
+# through the interactive `copilot-ssh` / `copilot_ssh` helper. Point VS Code at
+# this script via the "remote.SSH.path" setting and it will forward the GitHub
+# Copilot CLI / gh tokens (from a 1Password Environment) into the connection for
+# matching dev hosts, so the VS Code Server - and every integrated terminal and
+# dev container it spawns - is authenticated. All other hosts get a plain ssh.
+#
+# It is deliberately scoped to hosts matching COPILOT_SSH_HOST_PATTERN (default
+# "svl") so unrelated SSH connections don't trigger a 1Password unlock.
+#
+# Requirements (same as copilot-ssh):
+#   - 1Password CLI (`op`) >= 2.33.0-beta.02 with the desktop-app integration on.
+#   - OP_COPILOT_ENVIRONMENT_ID set (from the chezmoi opCopilotEnvironmentId var),
+#     with a COPILOT_GITHUB_TOKEN variable (and optional GH_TOKEN) in the
+#     Environment.
+#
+# VS Code setting (macOS example):
+#   "remote.SSH.path": "/Users/<you>/.local/bin/copilot-ssh-proxy.sh"
+#
+# See docs/copilot-cli.md.
+
+host_pattern="${COPILOT_SSH_HOST_PATTERN:-svl}"
+
+# Does any non-option argument (i.e. the destination) match the dev-host pattern?
+_matches_dev_host=0
+for _arg in "$@"; do
+    case "${_arg}" in
+    -*) ;; # option flag - ignore
+    *"${host_pattern}"*) _matches_dev_host=1 ;;
+    *) ;; # non-matching destination or value
+    esac
+done
+
+# Only inject tokens for matching hosts when 1Password is available; otherwise
+# behave exactly like plain ssh.
+if [ "${_matches_dev_host}" -eq 1 ] &&
+    [ -n "${OP_COPILOT_ENVIRONMENT_ID:-}" ] &&
+    command -v op >/dev/null 2>&1; then
+    # Single `op run` (one unlock); --no-masking because Environment values are
+    # hidden by default. Tab-separated: GitHub tokens never contain a tab.
+    # shellcheck disable=SC2016
+    if creds="$(op run --environment "${OP_COPILOT_ENVIRONMENT_ID}" --no-masking -- \
+        sh -c 'printf "%s\t%s" "${COPILOT_GITHUB_TOKEN:-}" "${GH_TOKEN:-}"' 2>/dev/null)"; then
+        copilot_token="${creds%%$'\t'*}"
+        gh_token="${creds#*$'\t'}"
+        if [ -n "${copilot_token}" ]; then
+            export COPILOT_GITHUB_TOKEN="${copilot_token}"
+            ssh_env_opts=(-o SendEnv=COPILOT_GITHUB_TOKEN)
+            if [ -n "${gh_token}" ]; then
+                export GH_TOKEN="${gh_token}"
+                ssh_env_opts+=(-o SendEnv=GH_TOKEN)
+            fi
+            exec ssh "${ssh_env_opts[@]}" "$@"
+        fi
+    fi
+fi
+
+exec ssh "$@"

--- a/tests/bash/copilot-ssh-proxy.bats
+++ b/tests/bash/copilot-ssh-proxy.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+# Tests for copilot-ssh-proxy.sh (VS Code remote.SSH.path ssh drop-in)
+
+setup() {
+	PROXY="${BATS_TEST_DIRNAME}/../../home/dot_local/bin/executable_copilot-ssh-proxy.sh"
+	export PROXY
+
+	TEST_DIR="$(mktemp -d)"
+	export TEST_DIR
+	ORIGINAL_PATH="$PATH"
+	export ORIGINAL_PATH
+
+	# Stub `ssh`: report args + the tokens present in its environment.
+	cat >"$TEST_DIR/ssh" <<'EOF'
+#!/bin/bash
+echo "SSH_ARGS: $*"
+echo "FWD_COPILOT=${COPILOT_GITHUB_TOKEN:-<unset>}"
+echo "FWD_GH=${GH_TOKEN:-<unset>}"
+EOF
+	chmod +x "$TEST_DIR/ssh"
+
+	export OP_COPILOT_ENVIRONMENT_ID="ENV-TEST"
+}
+
+teardown() {
+	PATH="$ORIGINAL_PATH"
+	unset OP_COPILOT_ENVIRONMENT_ID COPILOT_SSH_HOST_PATTERN
+	if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+		rm -rf "$TEST_DIR"
+	fi
+}
+
+# Stub `op` that records invocation and emulates `op run ... -- <cmd>`.
+# $1 = COPILOT_GITHUB_TOKEN value, $2 = GH_TOKEN value.
+_stub_op() {
+	cat >"$TEST_DIR/op" <<EOF
+#!/bin/bash
+touch "$TEST_DIR/op_was_called"
+export COPILOT_GITHUB_TOKEN='$1'
+export GH_TOKEN='$2'
+while [ "\$1" != "--" ] && [ \$# -gt 0 ]; do shift; done
+shift
+exec "\$@"
+EOF
+	chmod +x "$TEST_DIR/op"
+}
+
+@test "copilot-ssh-proxy: forwards both tokens for a matching host" {
+	_stub_op "ctok" "gtok"
+	PATH="$TEST_DIR:$ORIGINAL_PATH"
+	run bash "$PROXY" -T svldev bash
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "SSH_ARGS: -o SendEnv=COPILOT_GITHUB_TOKEN -o SendEnv=GH_TOKEN -T svldev bash" ]]
+	[[ "$output" =~ "FWD_COPILOT=ctok" ]]
+	[[ "$output" =~ "FWD_GH=gtok" ]]
+}
+
+@test "copilot-ssh-proxy: forwards only COPILOT_GITHUB_TOKEN when GH_TOKEN is empty" {
+	_stub_op "ctok" ""
+	PATH="$TEST_DIR:$ORIGINAL_PATH"
+	run bash "$PROXY" svldev
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "-o SendEnv=COPILOT_GITHUB_TOKEN svldev" ]]
+	[[ ! "$output" =~ "SendEnv=GH_TOKEN" ]]
+}
+
+@test "copilot-ssh-proxy: non-matching host uses plain ssh and does not call op" {
+	_stub_op "ctok" "gtok"
+	PATH="$TEST_DIR:$ORIGINAL_PATH"
+	run bash "$PROXY" -T example.com bash
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "SSH_ARGS: -T example.com bash" ]]
+	[[ ! "$output" =~ "SendEnv" ]]
+	[ ! -f "$TEST_DIR/op_was_called" ]
+}
+
+@test "copilot-ssh-proxy: ssh -V (no destination) does not call op" {
+	_stub_op "ctok" "gtok"
+	PATH="$TEST_DIR:$ORIGINAL_PATH"
+	run bash "$PROXY" -V
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "SSH_ARGS: -V" ]]
+	[ ! -f "$TEST_DIR/op_was_called" ]
+}
+
+@test "copilot-ssh-proxy: falls back to plain ssh when op is not installed" {
+	# Only the ssh stub is on PATH; no op.
+	PATH="$TEST_DIR:/usr/bin:/bin"
+	run bash "$PROXY" svldev
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "SSH_ARGS: svldev" ]]
+	[[ ! "$output" =~ "SendEnv" ]]
+}
+
+@test "copilot-ssh-proxy: honours a custom COPILOT_SSH_HOST_PATTERN" {
+	_stub_op "ctok" "gtok"
+	PATH="$TEST_DIR:$ORIGINAL_PATH"
+	export COPILOT_SSH_HOST_PATTERN="myhost"
+	run bash "$PROXY" myhost.internal
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "-o SendEnv=COPILOT_GITHUB_TOKEN" ]]
+	[[ "$output" =~ "FWD_COPILOT=ctok" ]]
+}


### PR DESCRIPTION
## Description

Follow-up to #540: make the 1Password → SSH token forwarding work in **VS Code** too, so `copilot` and `gh` are authenticated in the integrated terminal over Remote-SSH and inside dev containers — with **no per-repo changes**.

VS Code Remote-SSH connects with its own `ssh` invocation, so it never goes through the interactive `copilot_ssh` helper. Two centrally-managed pieces close that gap.

## Changes

- **`home/dot_local/bin/copilot-ssh-proxy.sh`** — an `ssh` drop-in for VS Code's `remote.SSH.path`. For hosts matching `COPILOT_SSH_HOST_PATTERN` (default `svl`) it reads the tokens from the 1Password Environment and adds `-o SendEnv=…`; every other host gets a plain `ssh` (no spurious 1Password unlock). This gets the tokens into the VS Code Server env → integrated terminals are authenticated.
- **`.devcontainer/devcontainer-prebuild.json`** — bake `remoteEnv` for `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` into the shared `dotfiles-devcontainer` image metadata, so every repo using the image inherits it (merged per the Dev Container spec) and the tokens reach inside containers with no per-repo `devcontainer.json` edits. Resolves to empty (harmless) where absent (local/Codespaces).
- **`docs/copilot-cli.md`** — document the VS Code setup and the extension-vs-CLI distinction.
- **`tests/bash/copilot-ssh-proxy.bats`** — matching/non-matching hosts, `op`-not-called scoping, optional `GH_TOKEN`, custom pattern, and `op`-absent fallback.

## Manual step (per workstation, not managed here)

```jsonc
// VS Code user settings.json
"remote.SSH.path": "/Users/<you>/.local/bin/copilot-ssh-proxy.sh"
```

## Checklist

- [x] Linting passes locally (`mise exec -- lefthook run pre-commit`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] Documentation updated (docs/copilot-cli.md)

> Not urgent — opening for review once you're happy with the stability of `copilot_ssh` (which you've been exercising day to day).