### PR TITLE
feat(vscode): auto-manage remote.SSH.path on macOS + friendly no-destination usage

### DIFF
--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -103,14 +103,20 @@ centrally-managed pieces close that gap with **no per-repo changes**:
    by chezmoi) is a drop-in `ssh` for VS Code: for hosts matching
    `COPILOT_SSH_HOST_PATTERN` (default `svl`) it reads the tokens from your
    1Password Environment and adds `-o SendEnv=…`; every other host gets a plain
-   `ssh`. Point VS Code at it (one-time, per machine):
+   `ssh`. VS Code is pointed at it via the `remote.SSH.path` setting:
 
-   ```jsonc
-   // VS Code user settings.json
-   // macOS:   ~/Library/Application Support/Code/User/settings.json
-   // Linux:   ~/.config/Code/User/settings.json
-   "remote.SSH.path": "/Users/<you>/.local/bin/copilot-ssh-proxy.sh"
-   ```
+   - **macOS:** managed automatically — a chezmoi `modify_` script sets
+     `remote.SSH.path` in `~/Library/Application Support/Code/User/settings.json`
+     on `chezmoi apply`. It only ever sets that one key and never rewrites a
+     `settings.json` that contains comments/trailing commas (JSONC); in that case
+     it prints a hint to add the line manually.
+   - **Other OSes / manual:** add it to your VS Code user `settings.json`:
+
+     ```jsonc
+     // Linux:   ~/.config/Code/User/settings.json
+     // Windows: %APPDATA%\Code\User\settings.json
+     "remote.SSH.path": "/home/<you>/.local/bin/copilot-ssh-proxy.sh"
+     ```
 
    With this, the VS Code Server on the dev host inherits the tokens, so the
    **integrated terminal** has `copilot` and `gh` authenticated (scenario #1).

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -14,6 +14,7 @@ renovate.json
 
 {{ if ne .chezmoi.os "darwin" }}
 .chezmoiscripts/darwin/**
+Library/Application Support/Code/User/settings.json
 {{ end }}
 
 {{ if eq .chezmoi.os "windows" }}

--- a/home/Library/Application Support/Code/User/modify_settings.json.tmpl
+++ b/home/Library/Application Support/Code/User/modify_settings.json.tmpl
@@ -1,0 +1,40 @@
+#!/bin/bash
+# chezmoi modify_ script: idempotently set VS Code's "remote.SSH.path" to the
+# copilot-ssh-proxy helper so VS Code Remote-SSH forwards the GitHub Copilot CLI
+# / gh tokens (see docs/copilot-cli.md). chezmoi passes the current settings.json
+# on stdin and replaces it with our stdout.
+#
+# Safety-first, because settings.json is user-edited and VS Code writes it too:
+#   - Never clobbers: if the file is not strict JSON (VS Code allows // comments
+#     and trailing commas, which jq cannot parse) it is emitted byte-for-byte
+#     unchanged and a hint is printed to stderr.
+#   - Low churn: if the key already has the desired value the input is emitted
+#     unchanged, preserving the user's formatting/comments.
+#   - Only ever sets a single key; all other settings are preserved.
+set -euo pipefail
+
+proxy="{{ .chezmoi.homeDir }}/.local/bin/copilot-ssh-proxy.sh"
+# Capture stdin preserving trailing newlines ($(cat) would strip them), so the
+# "unchanged" paths below are truly byte-for-byte no-ops.
+input="$(cat; printf x)"
+input="${input%x}"
+
+# Empty (file absent / whitespace only) -> start from an empty object.
+if [ -z "$(printf '%s' "$input" | tr -d '[:space:]')" ]; then
+	input='{}'
+fi
+
+# If the key already matches, emit unchanged (no churn, keeps comments intact).
+current="$(printf '%s' "$input" | jq -r '."remote.SSH.path" // empty' 2>/dev/null || true)"
+if [ "$current" = "$proxy" ]; then
+	printf '%s' "$input"
+	exit 0
+fi
+
+# Only edit when the file parses as strict JSON; never rewrite JSONC.
+if printf '%s' "$input" | jq empty >/dev/null 2>&1; then
+	printf '%s' "$input" | jq --indent 4 --arg p "$proxy" '.["remote.SSH.path"] = $p'
+else
+	printf '%s' "$input"
+	echo "modify_settings.json: VS Code settings.json is not plain JSON (has comments or trailing commas); leaving it unchanged. Add \"remote.SSH.path\": \"$proxy\" manually. See docs/copilot-cli.md." >&2
+fi

--- a/home/dot_config/fish/functions/copilot_ssh.fish
+++ b/home/dot_config/fish/functions/copilot_ssh.fish
@@ -25,6 +25,12 @@ function copilot_ssh --description "SSH with COPILOT_GITHUB_TOKEN and GH_TOKEN f
         return 0
     end
 
+    if test (count $argv) -eq 0
+        echo "copilot_ssh: no destination given." >&2
+        echo "Usage: copilot_ssh [ssh options...] <host>   (e.g. copilot_ssh svldev)" >&2
+        return 1
+    end
+
     if not command -q op
         echo "copilot_ssh: 'op' (1Password CLI) not found; using plain ssh (no token forwarded)." >&2
         command ssh $argv

--- a/home/dot_config/shell/functions/copilot-ssh.sh
+++ b/home/dot_config/shell/functions/copilot-ssh.sh
@@ -32,6 +32,12 @@ copilot-ssh() {
         return 0
     fi
 
+    if [ "$#" -eq 0 ]; then
+        echo "copilot-ssh: no destination given." >&2
+        echo "Usage: copilot-ssh [ssh options...] <host>   (e.g. copilot-ssh svldev)" >&2
+        return 1
+    fi
+
     if ! command -v op >/dev/null 2>&1; then
         echo "copilot-ssh: 'op' (1Password CLI) not found; using plain ssh (no token forwarded)." >&2
         command ssh "$@"

--- a/tests/bash/copilot-ssh.bats
+++ b/tests/bash/copilot-ssh.bats
@@ -62,6 +62,13 @@ EOF
 	[[ "$output" =~ "Usage: copilot-ssh" ]]
 }
 
+@test "copilot-ssh: shows usage and errors when no destination is given" {
+	run copilot-ssh
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "no destination given" ]]
+	[[ "$output" =~ "Usage: copilot-ssh" ]]
+}
+
 @test "copilot-ssh: falls back to plain ssh when op is not installed" {
 	_stub_ssh
 	# PATH without op (stub dir has only ssh); real op excluded.

--- a/tests/bash/modify-vscode-settings.bats
+++ b/tests/bash/modify-vscode-settings.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+# Tests for the VS Code settings.json chezmoi modify_ script
+# (home/Library/Application Support/Code/User/modify_settings.json.tmpl).
+#
+# The source is a chezmoi template; we render it with chezmoi so
+# {{ .chezmoi.homeDir }} is resolved, then exercise the rendered script by
+# piping candidate settings.json contents on stdin (as chezmoi does).
+
+setup() {
+	REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+	SRC="${REPO_ROOT}/home/Library/Application Support/Code/User/modify_settings.json.tmpl"
+	export REPO_ROOT SRC
+
+	TEST_DIR="$(mktemp -d)"
+	export TEST_DIR
+
+	if ! command -v chezmoi >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+		skip "chezmoi and jq are required"
+	fi
+
+	# Render the template to a runnable script.
+	SCRIPT="$TEST_DIR/modify_settings.sh"
+	chezmoi execute-template <"$SRC" >"$SCRIPT"
+	chmod +x "$SCRIPT"
+	export SCRIPT
+
+	# The proxy path the script should write (matches the template expression).
+	PROXY="$HOME/.local/bin/copilot-ssh-proxy.sh"
+	export PROXY
+}
+
+teardown() {
+	if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+		rm -rf "$TEST_DIR"
+	fi
+}
+
+@test "modify-vscode-settings: creates the key when the file is absent (empty stdin)" {
+	run bash -c "printf '' | '$SCRIPT'"
+	[ "$status" -eq 0 ]
+	# Output must be valid JSON containing the key set to the proxy path.
+	echo "$output" | jq -e --arg p "$PROXY" '.["remote.SSH.path"] == $p'
+}
+
+@test "modify-vscode-settings: adds the key while preserving existing settings" {
+	run bash -c "printf '%s' '{\"editor.fontSize\": 13}' | '$SCRIPT'"
+	[ "$status" -eq 0 ]
+	echo "$output" | jq -e '.["editor.fontSize"] == 13'
+	echo "$output" | jq -e --arg p "$PROXY" '.["remote.SSH.path"] == $p'
+}
+
+@test "modify-vscode-settings: leaves input unchanged when the value already matches" {
+	local in
+	in="$(jq -n --arg p "$PROXY" '{"remote.SSH.path": $p, "a": 1}')"
+	run bash -c "printf '%s' '$in' | '$SCRIPT'"
+	[ "$status" -eq 0 ]
+	[ "$output" = "$in" ]
+}
+
+@test "modify-vscode-settings: never clobbers JSONC (comments), leaves it unchanged" {
+	local in_file="$TEST_DIR/jsonc-settings.json"
+	cat >"$in_file" <<'JSONC'
+{
+  // a comment VS Code allows
+  "editor.fontSize": 13,
+}
+JSONC
+	run bash -c "'$SCRIPT' < '$in_file'"
+	[ "$status" -eq 0 ]
+	# Output must be byte-for-byte identical to the input (never clobbered)...
+	[ "$output" = "$(cat "$in_file")" ]
+	# ...and must NOT have had the key injected.
+	[[ ! "$output" =~ "remote.SSH.path" ]]
+	[[ "$output" =~ "// a comment VS Code allows" ]]
+}
+
+@test "modify-vscode-settings: updates an existing but different value" {
+	run bash -c "printf '%s' '{\"remote.SSH.path\": \"/old\", \"x\": 2}' | '$SCRIPT'"
+	[ "$status" -eq 0 ]
+	echo "$output" | jq -e '.["x"] == 2'
+	echo "$output" | jq -e --arg p "$PROXY" '.["remote.SSH.path"] == $p'
+}


### PR DESCRIPTION
## Description

Two follow-ups on top of #546 (VS Code token forwarding). **Stacked on `feat/copilot-cli-vscode`** — review/merge #546 first (base will collapse to `main` once #546 merges).

1. **Removes the manual VS Code step on macOS** — a chezmoi `modify_` script sets `remote.SSH.path` in `~/Library/Application Support/Code/User/settings.json` automatically on `chezmoi apply`.
2. **Friendlier `copilot-ssh` / `copilot_ssh`** — a clear usage message when called with no destination, instead of ssh's raw usage dump.

## Changes

- **`home/Library/Application Support/Code/User/modify_settings.json.tmpl`** — chezmoi `modify_` script (macOS-scoped via `.chezmoiignore`). Safety-first:
  - sets **only** `remote.SSH.path`; all other settings preserved;
  - **byte-for-byte no-op** (incl. trailing newline) when the value already matches — zero churn;
  - **never rewrites JSONC** (comments / trailing commas that `jq` can't parse) — leaves the file untouched and prints a manual hint.
- **`copilot-ssh.sh` / `copilot_ssh.fish`** — friendly "no destination given" usage message + non-zero exit.
- **`docs/copilot-cli.md`** — document the auto-managed macOS setting and the manual path for other OSes.
- **tests** — `modify-vscode-settings.bats` (create / add-preserving / no-churn / JSONC-safe / update) and a no-destination case in `copilot-ssh.bats`.

## Notes

- Scoped to **macOS** (the only desktop OS in use); other OSes keep the documented manual `remote.SSH.path` step.
- Raw `echo`/`printf` are intentional here (the `modify_` script's stdout **is** the settings file; consistent with the merged helpers) rather than `log.sh`.

## Checklist

- [x] Linting passes locally (`shellcheck`/`shfmt` on changed files; `fish -n`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] Documentation updated (docs/copilot-cli.md)

> Not urgent — for review alongside #546 once you're happy with `copilot_ssh` stability.