### PR TITLE
style(shell): normalize indentation to spaces (partial)

### DIFF
--- a/.devcontainer/postStart.sh
+++ b/.devcontainer/postStart.sh
@@ -23,26 +23,26 @@ workspace_home="${1:-/workspaces/dotfiles/home}"
 export PATH="${HOME}/.local/share/mise/shims:${HOME}/.local/bin:${PATH}"
 
 if ! command -v chezmoi >/dev/null 2>&1; then
-	echo "[postStart] chezmoi not on PATH; skipping source re-point" >&2
-	exit 0
+    echo "[postStart] chezmoi not on PATH; skipping source re-point" >&2
+    exit 0
 fi
 
-if [ ! -d "$workspace_home" ]; then
-	echo "[postStart] '$workspace_home' not found; skipping source re-point" >&2
-	exit 0
+if [ ! -d "${workspace_home}" ]; then
+    echo "[postStart] '${workspace_home}' not found; skipping source re-point" >&2
+    exit 0
 fi
 
 current_source="$(chezmoi source-path 2>/dev/null || true)"
-if [ "$current_source" = "$workspace_home" ]; then
-	echo "[postStart] chezmoi source already points at $workspace_home"
-	exit 0
+if [ "${current_source}" = "${workspace_home}" ]; then
+    echo "[postStart] chezmoi source already points at ${workspace_home}"
+    exit 0
 fi
 
-echo "[postStart] Re-pointing chezmoi source: ${current_source:-<unset>} -> $workspace_home"
+echo "[postStart] Re-pointing chezmoi source: ${current_source:-<unset>} -> ${workspace_home}"
 # init (without --apply) only regenerates the config from .chezmoi.yaml.tmpl,
 # which persists `sourceDir: {{ .chezmoi.sourceDir }}`. Data is read from the
 # existing chezmoi state DB, so this is non-interactive and side-effect free.
-chezmoi init --no-tty --source="$workspace_home"
+chezmoi init --no-tty --source="${workspace_home}"
 
 echo "[postStart] Done. chezmoi now sources from the workspace."
 echo "[postStart] Use 'chezmoi diff' to preview and 'chezmoi apply' to sync."

--- a/home/.chezmoiscripts/linux/run_once_setup-gh-telemetry.sh
+++ b/home/.chezmoiscripts/linux/run_once_setup-gh-telemetry.sh
@@ -16,8 +16,8 @@
 LOG_TAG="gh-telemetry"
 
 if ! command -v gh >/dev/null 2>&1; then
-	log_info "gh CLI not found, nothing to do"
-	exit 0
+    log_info "gh CLI not found, nothing to do"
+    exit 0
 fi
 
 log_info "gh has no configurable telemetry; export DO_NOT_TRACK=1 to opt out broadly"

--- a/home/dot_config/shell/completions.d/docker.bash
+++ b/home/dot_config/shell/completions.d/docker.bash
@@ -3,7 +3,7 @@
 # Generate completion dynamically if docker is available
 
 if command -v docker >/dev/null 2>&1; then
-	# Safely evaluate docker completion, suppressing any error messages
-	# This prevents issues when Docker Desktop WSL integration is not properly configured
-	eval "$(docker completion bash 2>/dev/null)" 2>/dev/null || true
+  # Safely evaluate docker completion, suppressing any error messages
+  # This prevents issues when Docker Desktop WSL integration is not properly configured
+  eval "$(docker completion bash 2>/dev/null)" 2>/dev/null || true
 fi

--- a/home/dot_config/shell/completions.d/log.bash
+++ b/home/dot_config/shell/completions.d/log.bash
@@ -3,20 +3,20 @@
 # Completes the first argument with severities and kinds.
 
 _log_completion() {
-	local cur
-	cur="${COMP_WORDS[COMP_CWORD]}"
+  local cur
+  cur="${COMP_WORDS[COMP_CWORD]}"
 
-	if [[ ${COMP_CWORD} -eq 1 ]]; then
-		local levels="trace debug info notice warn error fatal state result hint step banner"
-		# shellcheck disable=SC2207
-		COMPREPLY=($(compgen -W "${levels}" -- "${cur}"))
-		return 0
-	fi
+  if [[ ${COMP_CWORD} -eq 1 ]]; then
+    local levels="trace debug info notice warn error fatal state result hint step banner"
+    # shellcheck disable=SC2207
+    COMPREPLY=($(compgen -W "${levels}" -- "${cur}"))
+    return 0
+  fi
 
-	# After the level/kind, fall back to filename completion so paths used in
-	# messages (e.g. log info "/var/log/foo") still complete naturally.
-	# shellcheck disable=SC2207
-	COMPREPLY=($(compgen -f -- "${cur}"))
+  # After the level/kind, fall back to filename completion so paths used in
+  # messages (e.g. log info "/var/log/foo") still complete naturally.
+  # shellcheck disable=SC2207
+  COMPREPLY=($(compgen -f -- "${cur}"))
 }
 
 complete -F _log_completion log

--- a/home/dot_config/shell/config.bash
+++ b/home/dot_config/shell/config.bash
@@ -7,70 +7,70 @@
 # Source - https://stackoverflow.com/a/2264537
 # Posted by alphaniner, modified by community. See post 'Timeline' for change history
 # Retrieved 2026-01-22, License - CC BY-SA 4.0
-if [[ "$TERM_PROGRAM" != "vscode" ]]; then
-	current_path="$(pwd)"
-	projects_path="$HOME/projects"
+if [[ "${TERM_PROGRAM}" != "vscode" ]]; then
+  current_path="$(pwd)"
+  projects_path="${HOME}/projects"
 
-	# Check if current path contains 'projects' (case-insensitive)
-	# Using bash parameter expansion to convert to lowercase for comparison
-	if [[ ! "${current_path,,}" =~ "projects" ]]; then
-		# Not in projects directory, change to it if it exists
-		if [[ -d "$projects_path" ]]; then
-			cd "$projects_path" || true
-		fi
-	fi
+  # Check if current path contains 'projects' (case-insensitive)
+  # Using bash parameter expansion to convert to lowercase for comparison
+  if [[ ! "${current_path,,}" =~ "projects" ]]; then
+    # Not in projects directory, change to it if it exists
+    if [[ -d "${projects_path}" ]]; then
+      cd "${projects_path}" || true
+    fi
+  fi
 fi
 
 # Add custom paths
-export PATH="$HOME/.local/bin:$HOME/bin:$PATH"
+export PATH="${HOME}/.local/bin:${HOME}/bin:${PATH}"
 
 # Environment variables
 # Use VS Code if available, otherwise vim
 if command -v code &>/dev/null; then
-	export EDITOR="code --wait"
-	export VISUAL="code --wait"
+  export EDITOR="code --wait"
+  export VISUAL="code --wait"
 else
-	export EDITOR=vim
-	export VISUAL=vim
+  export EDITOR=vim
+  export VISUAL=vim
 fi
 
 # Load chezmoi configuration variables
-if [ -f "$HOME/.config/shell/chezmoi.sh" ]; then
-	# shellcheck source=/dev/null
-	source "$HOME/.config/shell/chezmoi.sh"
+if [ -f "${HOME}/.config/shell/chezmoi.sh" ]; then
+  # shellcheck source=/dev/null
+  source "${HOME}/.config/shell/chezmoi.sh"
 fi
 
 # Load common aliases
-if [ -f "$HOME/.config/shell/aliases.sh" ]; then
-	# shellcheck source=/dev/null
-	source "$HOME/.config/shell/aliases.sh"
+if [ -f "${HOME}/.config/shell/aliases.sh" ]; then
+  # shellcheck source=/dev/null
+  source "${HOME}/.config/shell/aliases.sh"
 fi
 
 # Load TrueNAS apps aliases if available
 if [ -f "/mnt/vm-pool/apps/scripts/aliases.sh" ]; then
-	# shellcheck source=/dev/null
-	source "/mnt/vm-pool/apps/scripts/aliases.sh"
+  # shellcheck source=/dev/null
+  source "/mnt/vm-pool/apps/scripts/aliases.sh"
 elif [ -f "/opt/apps/scripts/aliases.sh" ]; then
-	# shellcheck source=/dev/null
-	source "/opt/apps/scripts/aliases.sh"
+  # shellcheck source=/dev/null
+  source "/opt/apps/scripts/aliases.sh"
 fi
 
 # Load all completions and evals from completions.d/
-if [ -d "$HOME/.config/shell/completions.d" ]; then
-	for comp_file in "$HOME/.config/shell/completions.d"/*.bash; do
-		if [ -r "$comp_file" ] && [ -f "$comp_file" ]; then
-			# shellcheck source=/dev/null
-			source "$comp_file"
-		fi
-	done
+if [ -d "${HOME}/.config/shell/completions.d" ]; then
+  for comp_file in "${HOME}/.config/shell/completions.d"/*.bash; do
+    if [ -r "${comp_file}" ] && [ -f "${comp_file}" ]; then
+      # shellcheck source=/dev/null
+      source "${comp_file}"
+    fi
+  done
 fi
 
 # Load all functions from shell/functions directory
-if [ -d "$HOME/.config/shell/functions" ]; then
-	for func_file in "$HOME/.config/shell/functions"/*; do
-		if [ -r "$func_file" ] && [ -f "$func_file" ]; then
-			# shellcheck source=/dev/null
-			source "$func_file"
-		fi
-	done
+if [ -d "${HOME}/.config/shell/functions" ]; then
+  for func_file in "${HOME}/.config/shell/functions"/*; do
+    if [ -r "${func_file}" ] && [ -f "${func_file}" ]; then
+      # shellcheck source=/dev/null
+      source "${func_file}"
+    fi
+  done
 fi

--- a/home/dot_config/shell/functions/calculate-points-value.sh
+++ b/home/dot_config/shell/functions/calculate-points-value.sh
@@ -14,57 +14,57 @@
 # It's 110% better value than Option 2
 
 calculate-points-value() {
-	if [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
-		echo "Usage: calculate-points-value [name1] <points1> <euros1> [name2] <points2> <euros2>"
-		echo "Example with names: calculate-points-value 'Regency Bali' 8000 180 'Regency Seattle' 25000 268"
-		echo "Example without names: calculate-points-value 8000 180 25000 268"
-		echo "Will compare two redemption options and show which gives better value per point/mile"
-		return 0
-	fi
+    if [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
+        echo "Usage: calculate-points-value [name1] <points1> <euros1> [name2] <points2> <euros2>"
+        echo "Example with names: calculate-points-value 'Regency Bali' 8000 180 'Regency Seattle' 25000 268"
+        echo "Example without names: calculate-points-value 8000 180 25000 268"
+        echo "Will compare two redemption options and show which gives better value per point/mile"
+        return 0
+    fi
 
-	# Check if we have names provided (6 arguments) or just numbers (4 arguments)
-	if [[ $# -eq 6 ]]; then
-		name1="$1"
-		points1="$2"
-		euros1="$3"
-		name2="$4"
-		points2="$5"
-		euros2="$6"
-	elif [[ $# -eq 4 ]]; then
-		name1="Option 1"
-		points1="$1"
-		euros1="$2"
-		name2="Option 2"
-		points2="$3"
-		euros2="$4"
-	else
-		echo "Error: Invalid number of arguments."
-		echo "Use -h or --help flag for usage information."
-		return 1
-	fi
+    # Check if we have names provided (6 arguments) or just numbers (4 arguments)
+    if [[ $# -eq 6 ]]; then
+        name1="$1"
+        points1="$2"
+        euros1="$3"
+        name2="$4"
+        points2="$5"
+        euros2="$6"
+    elif [[ $# -eq 4 ]]; then
+        name1="Option 1"
+        points1="$1"
+        euros1="$2"
+        name2="Option 2"
+        points2="$3"
+        euros2="$4"
+    else
+        echo "Error: Invalid number of arguments."
+        echo "Use -h or --help flag for usage information."
+        return 1
+    fi
 
-	# Calculate values per point (multiply by 10000 to handle 4 decimal places in pure bash)
-	value1=$(((euros1 * 10000) / points1))
-	value2=$(((euros2 * 10000) / points2))
+    # Calculate values per point (multiply by 10000 to handle 4 decimal places in pure bash)
+    value1=$(((euros1 * 10000) / points1))
+    value2=$(((euros2 * 10000) / points2))
 
-	echo "Points/miles value analysis:"
-	echo "-------------------------"
-	echo "$name1: €0.$(printf "%04d" $value1) per point ($points1 points for €$euros1)"
-	echo "$name2: €0.$(printf "%04d" $value2) per point ($points2 points for €$euros2)"
+    echo "Points/miles value analysis:"
+    echo "-------------------------"
+    echo "${name1}: €0.$(printf "%04d" "${value1}") per point (${points1} points for €${euros1})"
+    echo "${name2}: €0.$(printf "%04d" "${value2}") per point (${points2} points for €${euros2})"
 
-	echo -e "\nComparison between options:"
-	if ((value1 > value2)); then
-		percent_better=$((((value1 * 100) / value2) - 100))
-		echo "$name1 offers better value"
-		echo "It's ${percent_better}% better value than $name2"
-	else
-		percent_better=$((((value2 * 100) / value1) - 100))
-		echo "$name2 offers better value"
-		echo "It's ${percent_better}% better value than $name1"
-	fi
+    echo -e "\nComparison between options:"
+    if ((value1 > value2)); then
+        percent_better=$((((value1 * 100) / value2) - 100))
+        echo "${name1} offers better value"
+        echo "It's ${percent_better}% better value than ${name2}"
+    else
+        percent_better=$((((value2 * 100) / value1) - 100))
+        echo "${name2} offers better value"
+        echo "It's ${percent_better}% better value than ${name1}"
+    fi
 }
 
 # Auto-execute if script is run directly (not sourced)
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	calculate-points-value "$@"
+    calculate-points-value "$@"
 fi

--- a/home/dot_config/shell/functions/get-external-ip.sh
+++ b/home/dot_config/shell/functions/get-external-ip.sh
@@ -18,70 +18,70 @@
 #   - Uses the ipify.org API service
 
 get-external-ip() {
-	# Initialize variables
-	local verbose=false
+    # Initialize variables
+    local verbose=false
 
-	# Parse arguments
-	while [[ $# -gt 0 ]]; do
-		case $1 in
-		--verbose | -v)
-			verbose=true
-			shift
-			;;
-		-h | --help)
-			echo "Usage: get-external-ip [OPTIONS]"
-			echo "Get your public/external IP address"
-			echo ""
-			echo "Options:"
-			echo "  --verbose, -v    Enable verbose output"
-			echo "  -h, --help       Show this help message"
-			echo ""
-			echo "Examples:"
-			echo "  get-external-ip              # Display external IP"
-			echo "  get-external-ip --verbose    # Display with verbose output"
-			return 0
-			;;
-		-*)
-			echo "❌ Unknown option: $1"
-			echo "Use --help for usage information"
-			return 1
-			;;
-		*)
-			echo "❌ Too many arguments. This command takes no arguments."
-			echo "Use --help for usage information"
-			return 1
-			;;
-		esac
-	done
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+        --verbose | -v)
+            verbose=true
+            shift
+            ;;
+        -h | --help)
+            echo "Usage: get-external-ip [OPTIONS]"
+            echo "Get your public/external IP address"
+            echo ""
+            echo "Options:"
+            echo "  --verbose, -v    Enable verbose output"
+            echo "  -h, --help       Show this help message"
+            echo ""
+            echo "Examples:"
+            echo "  get-external-ip              # Display external IP"
+            echo "  get-external-ip --verbose    # Display with verbose output"
+            return 0
+            ;;
+        -*)
+            echo "❌ Unknown option: $1"
+            echo "Use --help for usage information"
+            return 1
+            ;;
+        *)
+            echo "❌ Too many arguments. This command takes no arguments."
+            echo "Use --help for usage information"
+            return 1
+            ;;
+        esac
+    done
 
-	# Check for required commands
-	if ! command -v curl >/dev/null 2>&1; then
-		echo "❌ Required command 'curl' is not installed or not in PATH"
-		return 1
-	fi
+    # Check for required commands
+    if ! command -v curl >/dev/null 2>&1; then
+        echo "❌ Required command 'curl' is not installed or not in PATH"
+        return 1
+    fi
 
-	# Verbose output
-	if [ "$verbose" = true ]; then
-		echo "🔍 Fetching external IP address from ipify.org..."
-	fi
+    # Verbose output
+    if [ "${verbose}" = true ]; then
+        echo "🔍 Fetching external IP address from ipify.org..."
+    fi
 
-	# Get external IP
-	local external_ip
-	if external_ip=$(curl -s https://api.ipify.org) && [ -n "$external_ip" ]; then
-		if [ "$verbose" = true ]; then
-			echo "✅ Successfully retrieved external IP address"
-			echo "📋 External IP: $external_ip"
-		else
-			echo "$external_ip"
-		fi
-		return 0
-	else
-		echo "❌ Failed to retrieve external IP address"
-		return 1
-	fi
+    # Get external IP
+    local external_ip
+    if external_ip=$(curl -s https://api.ipify.org) && [ -n "${external_ip}" ]; then
+        if [ "${verbose}" = true ]; then
+            echo "✅ Successfully retrieved external IP address"
+            echo "📋 External IP: ${external_ip}"
+        else
+            echo "${external_ip}"
+        fi
+        return 0
+    else
+        echo "❌ Failed to retrieve external IP address"
+        return 1
+    fi
 }
 
 # Auto-execute if script is run directly (not sourced)
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	get-external-ip "$@"
+    get-external-ip "$@"
 fi

--- a/home/dot_config/shell/functions/git-undo.sh
+++ b/home/dot_config/shell/functions/git-undo.sh
@@ -21,70 +21,70 @@
 #   - To undo and discard changes, use: git reset --hard HEAD^
 
 git-undo() {
-	# Initialize variables
-	local verbose=false
+    # Initialize variables
+    local verbose=false
 
-	# Parse arguments
-	while [[ $# -gt 0 ]]; do
-		case $1 in
-		--verbose | -v)
-			verbose=true
-			shift
-			;;
-		-h | --help)
-			echo "Usage: git-undo [OPTIONS]"
-			echo "Undo the last Git commit while keeping changes staged"
-			echo ""
-			echo "Options:"
-			echo "  --verbose, -v    Enable verbose output"
-			echo "  -h, --help       Show this help message"
-			echo ""
-			echo "Examples:"
-			echo "  git-undo                # Undo last commit, keep changes staged"
-			echo "  git-undo --verbose      # Undo with verbose output"
-			return 0
-			;;
-		*)
-			echo "Unknown option: $1"
-			echo "Use 'git-undo --help' for usage information"
-			return 1
-			;;
-		esac
-	done
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+        --verbose | -v)
+            verbose=true
+            shift
+            ;;
+        -h | --help)
+            echo "Usage: git-undo [OPTIONS]"
+            echo "Undo the last Git commit while keeping changes staged"
+            echo ""
+            echo "Options:"
+            echo "  --verbose, -v    Enable verbose output"
+            echo "  -h, --help       Show this help message"
+            echo ""
+            echo "Examples:"
+            echo "  git-undo                # Undo last commit, keep changes staged"
+            echo "  git-undo --verbose      # Undo with verbose output"
+            return 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use 'git-undo --help' for usage information"
+            return 1
+            ;;
+        esac
+    done
 
-	# Check if we're in a Git repository
-	if ! git rev-parse --git-dir >/dev/null 2>&1; then
-		echo "Error: Not in a Git repository"
-		return 1
-	fi
+    # Check if we're in a Git repository
+    if ! git rev-parse --git-dir >/dev/null 2>&1; then
+        echo "Error: Not in a Git repository"
+        return 1
+    fi
 
-	# Check if there are any commits to undo
-	if ! git rev-parse --verify HEAD >/dev/null 2>&1; then
-		echo "Error: No commits to undo"
-		return 1
-	fi
+    # Check if there are any commits to undo
+    if ! git rev-parse --verify HEAD >/dev/null 2>&1; then
+        echo "Error: No commits to undo"
+        return 1
+    fi
 
-	# Undo last commit
-	if [[ "$verbose" == true ]]; then
-		echo "Undoing last commit (keeping changes staged)..."
-	fi
+    # Undo last commit
+    if [[ "${verbose}" == true ]]; then
+        echo "Undoing last commit (keeping changes staged)..."
+    fi
 
-	if git reset --soft HEAD^; then
-		if [[ "$verbose" == true ]]; then
-			echo "✓ Last commit undone successfully"
-			echo ""
-			git status --short
-		else
-			echo "Last commit undone (changes still staged)"
-		fi
-		return 0
-	else
-		echo "Error: Failed to undo last commit"
-		return 1
-	fi
+    if git reset --soft HEAD^; then
+        if [[ "${verbose}" == true ]]; then
+            echo "✓ Last commit undone successfully"
+            echo ""
+            git status --short
+        else
+            echo "Last commit undone (changes still staged)"
+        fi
+        return 0
+    else
+        echo "Error: Failed to undo last commit"
+        return 1
+    fi
 }
 
 # Auto-execute if script is run directly (not sourced)
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	git-undo "$@"
+    git-undo "$@"
 fi

--- a/home/dot_config/shell/functions/git-update-forked-repo.sh
+++ b/home/dot_config/shell/functions/git-update-forked-repo.sh
@@ -18,78 +18,78 @@
 #   - Use 'git remote add <name> <url>' to add an upstream remote first
 
 git-update-forked-repo() {
-	# Parse help flag
-	if [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
-		echo "Usage: git-update-forked-repo <upstream_remote_name>"
-		echo "Sync a forked repository with its upstream remote"
-		echo ""
-		echo "Arguments:"
-		echo "  upstream_remote_name  Name of the upstream remote (e.g., 'upstream')"
-		echo ""
-		echo "Options:"
-		echo "  -h, --help       Show this help message"
-		echo ""
-		echo "Examples:"
-		echo "  git-update-forked-repo upstream        # Sync with 'upstream' remote"
-		echo "  git-update-forked-repo original-repo   # Sync with custom remote name"
-		return 0
-	fi
+    # Parse help flag
+    if [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
+        echo "Usage: git-update-forked-repo <upstream_remote_name>"
+        echo "Sync a forked repository with its upstream remote"
+        echo ""
+        echo "Arguments:"
+        echo "  upstream_remote_name  Name of the upstream remote (e.g., 'upstream')"
+        echo ""
+        echo "Options:"
+        echo "  -h, --help       Show this help message"
+        echo ""
+        echo "Examples:"
+        echo "  git-update-forked-repo upstream        # Sync with 'upstream' remote"
+        echo "  git-update-forked-repo original-repo   # Sync with custom remote name"
+        return 0
+    fi
 
-	if [ "$#" -ne 1 ]; then
-		echo "❌ Error: Expected exactly one argument"
-		echo "Usage: git-update-forked-repo <upstream_remote_name>"
-		echo "Use --help for more information"
-		return 1
-	fi
+    if [ "$#" -ne 1 ]; then
+        echo "❌ Error: Expected exactly one argument"
+        echo "Usage: git-update-forked-repo <upstream_remote_name>"
+        echo "Use --help for more information"
+        return 1
+    fi
 
-	local inside_git_repo
-	inside_git_repo="$(git rev-parse --is-inside-work-tree 2>/dev/null)"
+    local inside_git_repo
+    inside_git_repo="$(git rev-parse --is-inside-work-tree 2>/dev/null)"
 
-	if [ ! "$inside_git_repo" ]; then
-		echo "❌ Error: Not in a Git repository"
-		return 1
-	fi
+    if [ ! -n "${inside_git_repo}" ]; then
+        echo "❌ Error: Not in a Git repository"
+        return 1
+    fi
 
-	local upstream_remote_name="$1"
-	local current_branch
-	current_branch=$(git symbolic-ref --short HEAD)
+    local upstream_remote_name="$1"
+    local current_branch
+    current_branch=$(git symbolic-ref --short HEAD)
 
-	# Check if the upstream remote exists
-	if ! git remote get-url "$upstream_remote_name" >/dev/null 2>&1; then
-		echo "❌ Error: Upstream remote '${upstream_remote_name}' not found."
-		echo "Please add the upstream remote using 'git remote add <upstream_remote_name> <upstream_url>'."
-		return 1
-	fi
+    # Check if the upstream remote exists
+    if ! git remote get-url "${upstream_remote_name}" >/dev/null 2>&1; then
+        echo "❌ Error: Upstream remote '${upstream_remote_name}' not found."
+        echo "Please add the upstream remote using 'git remote add <upstream_remote_name> <upstream_url>'."
+        return 1
+    fi
 
-	# Fetch the latest changes from the upstream remote for the current branch only
-	git fetch "$upstream_remote_name" "${current_branch}"
+    # Fetch the latest changes from the upstream remote for the current branch only
+    git fetch "${upstream_remote_name}" "${current_branch}"
 
-	# Show information and prompt for confirmation
-	echo "Current branch: ${current_branch}"
-	echo "Upstream remote: ${upstream_remote_name}"
-	echo "Merge branch: ${upstream_remote_name}/${current_branch}"
-	echo "Are you sure you want to merge? [y/N]"
-	read -r confirm
-	if [[ ! "${confirm}" =~ ^[Yy] ]]; then
-		echo "Merge cancelled."
-		return 1
-	fi
+    # Show information and prompt for confirmation
+    echo "Current branch: ${current_branch}"
+    echo "Upstream remote: ${upstream_remote_name}"
+    echo "Merge branch: ${upstream_remote_name}/${current_branch}"
+    echo "Are you sure you want to merge? [y/N]"
+    read -r confirm
+    if [[ ! "${confirm}" =~ ^[Yy] ]]; then
+        echo "Merge cancelled."
+        return 1
+    fi
 
-	# Merge the current branch on top of the upstream remote branch
-	git merge "${upstream_remote_name}/${current_branch}"
+    # Merge the current branch on top of the upstream remote branch
+    git merge "${upstream_remote_name}/${current_branch}"
 
-	echo "Confirm merge was successful. Push to ${current_branch}? [y/N]"
-	read -r confirm
-	if [[ ! "${confirm}" =~ ^[Yy] ]]; then
-		echo "Push cancelled."
-		return 1
-	fi
+    echo "Confirm merge was successful. Push to ${current_branch}? [y/N]"
+    read -r confirm
+    if [[ ! "${confirm}" =~ ^[Yy] ]]; then
+        echo "Push cancelled."
+        return 1
+    fi
 
-	# Force push branch
-	git push origin "${current_branch}"
+    # Force push branch
+    git push origin "${current_branch}"
 }
 
 # Auto-execute if script is run directly (not sourced)
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	git-update-forked-repo "$@"
+    git-update-forked-repo "$@"
 fi

--- a/home/dot_config/shell/functions/mcd.sh
+++ b/home/dot_config/shell/functions/mcd.sh
@@ -2,15 +2,15 @@
 # mcd - Create a directory and cd into it
 
 mcd() {
-	if [ $# -ne 1 ]; then
-		echo "Usage: mcd <directory>" >&2
-		return 1
-	fi
+    if [ $# -ne 1 ]; then
+        echo "Usage: mcd <directory>" >&2
+        return 1
+    fi
 
-	mkdir -p "$1" && cd "$1" || return 1
+    mkdir -p "$1" && cd "$1" || return 1
 }
 
 # If script is executed directly (not sourced), run the function
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	mcd "$@"
+    mcd "$@"
 fi

--- a/home/dot_config/shell/functions/refreshenv.sh
+++ b/home/dot_config/shell/functions/refreshenv.sh
@@ -2,16 +2,16 @@
 # refreshenv - Reload the current shell to refresh environment variables
 
 refreshenv() {
-	local shell
-	shell=$(ps -p $$ -ocomm=) || return 1
-	if [ -z "$shell" ]; then
-		echo "refreshenv: could not determine current shell" >&2
-		return 1
-	fi
-	exec "${shell}"
+    local shell
+    shell=$(ps -p $$ -ocomm=) || return 1
+    if [ -z "${shell}" ]; then
+        echo "refreshenv: could not determine current shell" >&2
+        return 1
+    fi
+    exec "${shell}"
 }
 
 # If script is executed directly (not sourced), run the function
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	refreshenv "$@"
+    refreshenv "$@"
 fi

--- a/home/dot_config/shell/functions/silent-background.sh
+++ b/home/dot_config/shell/functions/silent-background.sh
@@ -17,38 +17,38 @@
 #   - Based on https://superuser.com/a/1334617
 
 silent-background() {
-	if [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
-		echo "Usage: silent-background COMMAND [ARGS...]"
-		echo "Run a command silently in the background"
-		echo ""
-		echo "Options:"
-		echo "  -h, --help       Show this help message"
-		echo ""
-		echo "Examples:"
-		echo "  silent-background sleep 10       # Run sleep in the background"
-		echo "  silent-background ./my-script    # Run a script silently"
-		return 0
-	fi
+    if [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
+        echo "Usage: silent-background COMMAND [ARGS...]"
+        echo "Run a command silently in the background"
+        echo ""
+        echo "Options:"
+        echo "  -h, --help       Show this help message"
+        echo ""
+        echo "Examples:"
+        echo "  silent-background sleep 10       # Run sleep in the background"
+        echo "  silent-background ./my-script    # Run a script silently"
+        return 0
+    fi
 
-	if [[ $# -eq 0 ]]; then
-		echo "❌ Error: No command specified"
-		echo "Use --help for usage information"
-		return 1
-	fi
+    if [[ $# -eq 0 ]]; then
+        echo "❌ Error: No command specified"
+        echo "Use --help for usage information"
+        return 1
+    fi
 
-	if [[ -n $ZSH_VERSION ]]; then # zsh:  https://superuser.com/a/1285272/365890
-		setopt NO_NOTIFY NO_MONITOR
-		# We'd use &| to background and disown, but incompatible with bash, so:
-		"$@" &
-	elif [[ -n $BASH_VERSION ]]; then # bash: https://stackoverflow.com/a/27340076/5353461
-		{ 2>&3 "$@" & } 3>&2 2>/dev/null
-	else # Unknownness - just background it
-		"$@" &
-	fi
-	disown &>/dev/null # Close STD{OUT,ERR} to prevent whine if job has already completed
+    if [[ -n ${ZSH_VERSION} ]]; then # zsh:  https://superuser.com/a/1285272/365890
+        setopt NO_NOTIFY NO_MONITOR
+        # We'd use &| to background and disown, but incompatible with bash, so:
+        "$@" &
+    elif [[ -n ${BASH_VERSION} ]]; then # bash: https://stackoverflow.com/a/27340076/5353461
+        { 2>&3 "$@" & } 3>&2 2>/dev/null
+    else # Unknownness - just background it
+        "$@" &
+    fi
+    disown &>/dev/null # Close STD{OUT,ERR} to prevent whine if job has already completed
 }
 
 # Auto-execute if script is run directly (not sourced)
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	silent-background "$@"
+    silent-background "$@"
 fi

--- a/home/dot_config/shell/functions/work-checklist.sh
+++ b/home/dot_config/shell/functions/work-checklist.sh
@@ -15,7 +15,7 @@
 # Usage: work-checklist
 
 work-checklist() {
-	cat <<'EOF'
+    cat <<'EOF'
 Work machine — manual post-install checklist
 
 These steps can't be automated by chezmoi (network-gated, browser flows,
@@ -50,5 +50,5 @@ EOF
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	work-checklist "$@"
+    work-checklist "$@"
 fi

--- a/home/dot_config/shell/functions/yk-git-sign-setup.sh
+++ b/home/dot_config/shell/functions/yk-git-sign-setup.sh
@@ -18,30 +18,30 @@
 #     [gpg] format = ssh and friends.
 
 yk-git-sign-setup() {
-	local key="" add_key="" principal="" mode="setup"
-	local allowed_signers="${ALLOWED_SIGNERS_FILE:-$HOME/.config/git/allowed_signers}"
+    local key="" add_key="" principal="" mode="setup"
+    local allowed_signers="${ALLOWED_SIGNERS_FILE:-${HOME}/.config/git/allowed_signers}"
 
-	while [[ $# -gt 0 ]]; do
-		case $1 in
-		--key)
-			key="$2"
-			shift 2
-			;;
-		--add)
-			add_key="$2"
-			mode="add"
-			shift 2
-			;;
-		--principal)
-			principal="$2"
-			shift 2
-			;;
-		--check)
-			mode="check"
-			shift
-			;;
-		-h | --help)
-			cat <<EOF
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+        --key)
+            key="$2"
+            shift 2
+            ;;
+        --add)
+            add_key="$2"
+            mode="add"
+            shift 2
+            ;;
+        --principal)
+            principal="$2"
+            shift 2
+            ;;
+        --check)
+            mode="check"
+            shift
+            ;;
+        -h | --help)
+            cat <<EOF
 Usage: yk-git-sign-setup [OPTIONS]
 Configure git to sign commits with your YubiKey SSH key.
 
@@ -53,147 +53,147 @@ Options:
   --principal STR             Principal (email) to associate with --add
   --check                     Exit 0 if signing is configured, 1 otherwise
 EOF
-			return 0
-			;;
-		*)
-			echo "Unknown option: $1" >&2
-			return 1
-			;;
-		esac
-	done
+            return 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            return 1
+            ;;
+        esac
+    done
 
-	if ! command -v git >/dev/null 2>&1; then
-		echo "Error: git not found." >&2
-		return 1
-	fi
+    if ! command -v git >/dev/null 2>&1; then
+        echo "Error: git not found." >&2
+        return 1
+    fi
 
-	if [[ "$mode" == "check" ]]; then
-		local fmt sign signer
-		fmt="$(git config --get gpg.format 2>/dev/null || true)"
-		sign="$(git config --get commit.gpgsign 2>/dev/null || true)"
-		signer="$(git config --get user.signingkey 2>/dev/null || true)"
-		if [[ "$fmt" == "ssh" && "$sign" == "true" && -n "$signer" ]]; then
-			echo "ssh signing: ON  signingkey=$signer"
-			return 0
-		fi
-		echo "ssh signing: OFF (gpg.format='$fmt' commit.gpgsign='$sign' signingkey='$signer')" >&2
-		return 1
-	fi
+    if [[ "${mode}" == "check" ]]; then
+        local fmt sign signer
+        fmt="$(git config --get gpg.format 2>/dev/null || true)"
+        sign="$(git config --get commit.gpgsign 2>/dev/null || true)"
+        signer="$(git config --get user.signingkey 2>/dev/null || true)"
+        if [[ "${fmt}" == "ssh" && "${sign}" == "true" && -n "${signer}" ]]; then
+            echo "ssh signing: ON  signingkey=${signer}"
+            return 0
+        fi
+        echo "ssh signing: OFF (gpg.format='${fmt}' commit.gpgsign='${sign}' signingkey='${signer}')" >&2
+        return 1
+    fi
 
-	# Ensure allowed_signers exists
-	mkdir -p "$(dirname "$allowed_signers")"
-	[[ -f "$allowed_signers" ]] || {
-		printf '# Managed by yk-git-sign-setup\n' >"$allowed_signers"
-	}
+    # Ensure allowed_signers exists
+    mkdir -p "$(dirname "${allowed_signers}")"
+    [[ -f "${allowed_signers}" ]] || {
+        printf '# Managed by yk-git-sign-setup\n' >"${allowed_signers}"
+    }
 
-	if [[ "$mode" == "add" ]]; then
-		if [[ -z "$add_key" || ! -f "$add_key" ]]; then
-			echo "Error: --add file not found: $add_key" >&2
-			return 1
-		fi
-		if [[ -z "$principal" ]]; then
-			echo "Error: --principal <email> is required with --add" >&2
-			return 1
-		fi
-		local pubkey
-		pubkey="$(cat "$add_key")"
-		if grep -Fq -- "$pubkey" "$allowed_signers" 2>/dev/null; then
-			echo "Already present: $principal"
-			return 0
-		fi
-		printf '%s %s\n' "$principal" "$pubkey" >>"$allowed_signers"
-		echo "Added principal $principal -> $allowed_signers"
-		return 0
-	fi
+    if [[ "${mode}" == "add" ]]; then
+        if [[ -z "${add_key}" || ! -f "${add_key}" ]]; then
+            echo "Error: --add file not found: ${add_key}" >&2
+            return 1
+        fi
+        if [[ -z "${principal}" ]]; then
+            echo "Error: --principal <email> is required with --add" >&2
+            return 1
+        fi
+        local pubkey
+        pubkey="$(cat "${add_key}")"
+        if grep -Fq -- "${pubkey}" "${allowed_signers}" 2>/dev/null; then
+            echo "Already present: ${principal}"
+            return 0
+        fi
+        printf '%s %s\n' "${principal}" "${pubkey}" >>"${allowed_signers}"
+        echo "Added principal ${principal} -> ${allowed_signers}"
+        return 0
+    fi
 
-	# Setup mode: pick public key(s), ensure each is in allowed_signers, and
-	# verify git config. We don't *write* git config here — that's owned by
-	# git/config.tmpl + the chezmoi `useYubiKey` var. Instead we explain how
-	# to enable it if it isn't on yet.
-	if [[ -z "$(git config --get user.email 2>/dev/null || true)" ]]; then
-		echo "Error: git config user.email is not set." >&2
-		return 1
-	fi
+    # Setup mode: pick public key(s), ensure each is in allowed_signers, and
+    # verify git config. We don't *write* git config here — that's owned by
+    # git/config.tmpl + the chezmoi `useYubiKey` var. Instead we explain how
+    # to enable it if it isn't on yet.
+    if [[ -z "$(git config --get user.email 2>/dev/null || true)" ]]; then
+        echo "Error: git config user.email is not set." >&2
+        return 1
+    fi
 
-	# Collect the set of pubkeys to register.
-	local -a keys=()
-	if [[ -n "$key" ]]; then
-		if [[ ! -f "$key" ]]; then
-			echo "Error: --key file not found: $key" >&2
-			return 1
-		fi
-		keys=("$key")
-	else
-		# Per-serial files first (yk-enroll), then legacy un-suffixed, then
-		# non-FIDO2.
-		local pat
-		for pat in \
-			"$HOME/.ssh/id_ed25519_sk_"*.pub \
-			"$HOME/.ssh/id_ecdsa_sk_"*.pub \
-			"$HOME/.ssh/id_ed25519_sk.pub" \
-			"$HOME/.ssh/id_ecdsa_sk.pub" \
-			"$HOME/.ssh/id_ed25519.pub"; do
-			for candidate in $pat; do
-				[[ -f "$candidate" ]] && keys+=("$candidate")
-			done
-		done
-	fi
-	if [[ ${#keys[@]} -eq 0 ]]; then
-		echo "Error: no public key found. Run \`yk-enroll\` first." >&2
-		return 1
-	fi
+    # Collect the set of pubkeys to register.
+    local -a keys=()
+    if [[ -n "${key}" ]]; then
+        if [[ ! -f "${key}" ]]; then
+            echo "Error: --key file not found: ${key}" >&2
+            return 1
+        fi
+        keys=("${key}")
+    else
+        # Per-serial files first (yk-enroll), then legacy un-suffixed, then
+        # non-FIDO2.
+        local pat
+        for pat in \
+            "${HOME}/.ssh/id_ed25519_sk_"*.pub \
+            "${HOME}/.ssh/id_ecdsa_sk_"*.pub \
+            "${HOME}/.ssh/id_ed25519_sk.pub" \
+            "${HOME}/.ssh/id_ecdsa_sk.pub" \
+            "${HOME}/.ssh/id_ed25519.pub"; do
+            for candidate in ${pat}; do
+                [[ -f "${candidate}" ]] && keys+=("${candidate}")
+            done
+        done
+    fi
+    if [[ ${#keys[@]} -eq 0 ]]; then
+        echo "Error: no public key found. Run \`yk-enroll\` first." >&2
+        return 1
+    fi
 
-	# allowed_signers for self keys is owned by chezmoi (see
-	# home/dot_config/git/allowed_signers.tmpl). We only verify presence
-	# here; writing them ourselves would cause `chezmoi apply` to flag the
-	# file as drifted on every subsequent run.
-	local pubkey missing=0
-	for key in "${keys[@]}"; do
-		pubkey="$(cat "$key")"
-		if grep -Fq -- "$pubkey" "$allowed_signers" 2>/dev/null; then
-			echo "Already registered: $key"
-		else
-			echo "Missing from allowed_signers: $key"
-			missing=$((missing + 1))
-		fi
-	done
-	if [[ $missing -gt 0 ]]; then
-		echo
-		echo "Hint: $missing key(s) not yet in $allowed_signers."
-		echo "      Set chezmoi data 'useYubiKey: true' and run \`chezmoi apply\`"
-		echo "      to populate allowed_signers from your enrolled YubiKey pubkeys."
-	fi
+    # allowed_signers for self keys is owned by chezmoi (see
+    # home/dot_config/git/allowed_signers.tmpl). We only verify presence
+    # here; writing them ourselves would cause `chezmoi apply` to flag the
+    # file as drifted on every subsequent run.
+    local pubkey missing=0
+    for key in "${keys[@]}"; do
+        pubkey="$(cat "${key}")"
+        if grep -Fq -- "${pubkey}" "${allowed_signers}" 2>/dev/null; then
+            echo "Already registered: ${key}"
+        else
+            echo "Missing from allowed_signers: ${key}"
+            missing=$((missing + 1))
+        fi
+    done
+    if [[ ${missing} -gt 0 ]]; then
+        echo
+        echo "Hint: ${missing} key(s) not yet in ${allowed_signers}."
+        echo "      Set chezmoi data 'useYubiKey: true' and run \`chezmoi apply\`"
+        echo "      to populate allowed_signers from your enrolled YubiKey pubkeys."
+    fi
 
-	# Verify config
-	local fmt sign signer
-	fmt="$(git config --get gpg.format 2>/dev/null || true)"
-	sign="$(git config --get commit.gpgsign 2>/dev/null || true)"
-	signer="$(git config --get user.signingkey 2>/dev/null || true)"
-	echo
-	echo "Current git signing config:"
-	echo "  gpg.format        = ${fmt:-(unset)}"
-	echo "  commit.gpgsign    = ${sign:-(unset)}"
-	echo "  user.signingkey   = ${signer:-(unset)}"
-	if [[ "$fmt" != "ssh" || "$sign" != "true" || -z "$signer" ]]; then
-		echo
-		echo "Hint: set chezmoi data 'useYubiKey: true' and run \`chezmoi apply\`"
-		echo "      to wire ~/.config/git/config for SSH signing."
-		return 1
-	fi
+    # Verify config
+    local fmt sign signer
+    fmt="$(git config --get gpg.format 2>/dev/null || true)"
+    sign="$(git config --get commit.gpgsign 2>/dev/null || true)"
+    signer="$(git config --get user.signingkey 2>/dev/null || true)"
+    echo
+    echo "Current git signing config:"
+    echo "  gpg.format        = ${fmt:-(unset)}"
+    echo "  commit.gpgsign    = ${sign:-(unset)}"
+    echo "  user.signingkey   = ${signer:-(unset)}"
+    if [[ "${fmt}" != "ssh" || "${sign}" != "true" || -z "${signer}" ]]; then
+        echo
+        echo "Hint: set chezmoi data 'useYubiKey: true' and run \`chezmoi apply\`"
+        echo "      to wire ~/.config/git/config for SSH signing."
+        return 1
+    fi
 
-	# Final, mandatory step: upload the pubkey(s) to GitHub as *signing* keys
-	# so commits get the green Verified badge. Without this, signing locally
-	# does very little.
-	echo
-	echo "Required next step: upload each pubkey to GitHub as both an"
-	echo "  authentication AND signing key (signing isn't useful otherwise):"
-	for key in "${keys[@]}"; do
-		echo "    gh ssh-key add $key --type authentication --title \"<descriptive title>\""
-		echo "    gh ssh-key add $key --type signing       --title \"<descriptive title>\""
-	done
-	echo "  Or via the GitHub UI:  https://github.com/settings/keys"
+    # Final, mandatory step: upload the pubkey(s) to GitHub as *signing* keys
+    # so commits get the green Verified badge. Without this, signing locally
+    # does very little.
+    echo
+    echo "Required next step: upload each pubkey to GitHub as both an"
+    echo "  authentication AND signing key (signing isn't useful otherwise):"
+    for key in "${keys[@]}"; do
+        echo "    gh ssh-key add ${key} --type authentication --title \"<descriptive title>\""
+        echo "    gh ssh-key add ${key} --type signing       --title \"<descriptive title>\""
+    done
+    echo "  Or via the GitHub UI:  https://github.com/settings/keys"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	yk-git-sign-setup "$@"
+    yk-git-sign-setup "$@"
 fi

--- a/home/dot_config/shell/functions/yk-pick.sh
+++ b/home/dot_config/shell/functions/yk-pick.sh
@@ -10,55 +10,55 @@
 #   --first   Skip the picker and just print the first serial
 
 yk-pick() {
-	local first_only=false
-	while [[ $# -gt 0 ]]; do
-		case $1 in
-		--first)
-			first_only=true
-			shift
-			;;
-		-h | --help)
-			echo "Usage: yk-pick [--first]"
-			return 0
-			;;
-		*)
-			echo "Unknown option: $1" >&2
-			return 1
-			;;
-		esac
-	done
+    local first_only=false
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+        --first)
+            first_only=true
+            shift
+            ;;
+        -h | --help)
+            echo "Usage: yk-pick [--first]"
+            return 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            return 1
+            ;;
+        esac
+    done
 
-	if ! command -v ykman >/dev/null 2>&1; then
-		echo "Error: 'ykman' not found." >&2
-		return 1
-	fi
+    if ! command -v ykman >/dev/null 2>&1; then
+        echo "Error: 'ykman' not found." >&2
+        return 1
+    fi
 
-	local serials
-	serials="$(ykman list --serials 2>/dev/null)" || serials=""
-	if [[ -z "$serials" ]]; then
-		echo "Error: no YubiKey detected." >&2
-		return 1
-	fi
+    local serials
+    serials="$(ykman list --serials 2>/dev/null)" || serials=""
+    if [[ -z "${serials}" ]]; then
+        echo "Error: no YubiKey detected." >&2
+        return 1
+    fi
 
-	local count
-	count="$(echo "$serials" | grep -c .)"
-	if [[ "$count" -eq 1 ]] || [[ "$first_only" == true ]]; then
-		echo "$serials" | head -n1
-		return 0
-	fi
+    local count
+    count="$(echo "${serials}" | grep -c .)"
+    if [[ "${count}" -eq 1 ]] || [[ "${first_only}" == true ]]; then
+        echo "${serials}" | head -n1
+        return 0
+    fi
 
-	if command -v fzf >/dev/null 2>&1 && [[ -t 0 ]]; then
-		local pick
-		pick="$(echo "$serials" | fzf --prompt='YubiKey> ' --height=10 --no-multi)" || return 1
-		echo "$pick"
-		return 0
-	fi
+    if command -v fzf >/dev/null 2>&1 && [[ -t 0 ]]; then
+        local pick
+        pick="$(echo "${serials}" | fzf --prompt='YubiKey> ' --height=10 --no-multi)" || return 1
+        echo "${pick}"
+        return 0
+    fi
 
-	echo "Error: multiple YubiKeys connected; pass --serial or install fzf:" >&2
-	echo "$serials" >&2
-	return 1
+    echo "Error: multiple YubiKeys connected; pass --serial or install fzf:" >&2
+    echo "${serials}" >&2
+    return 1
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	yk-pick "$@"
+    yk-pick "$@"
 fi

--- a/script/build-log-sh-release.sh
+++ b/script/build-log-sh-release.sh
@@ -31,20 +31,20 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-cd "$REPO_ROOT"
+cd "${REPO_ROOT}"
 
 version="${1:-}"
 outdir="${2:-${REPO_ROOT}/dist}"
 
-if [ -z "$version" ]; then
-	if version="$(git describe --tags --abbrev=0 2>/dev/null)"; then
-		:
-	else
-		version="v0.0.0-dev"
-	fi
+if [ -z "${version}" ]; then
+    if version="$(git describe --tags --abbrev=0 2>/dev/null)"; then
+        :
+    else
+        version="v0.0.0-dev"
+    fi
 fi
 
-case "$version" in
+case "${version}" in
 v*) ;;
 *) version="v${version}" ;;
 esac
@@ -56,25 +56,25 @@ src_fish="${REPO_ROOT}/home/dot_config/fish/completions/log.fish"
 src_bash="${REPO_ROOT}/home/dot_config/shell/completions.d/log.bash"
 src_zsh="${REPO_ROOT}/home/dot_config/shell/completions.d/log.zsh"
 
-for f in "$src_log" "$src_installer" "$src_license" "$src_fish" "$src_bash" "$src_zsh"; do
-	if [ ! -f "$f" ]; then
-		printf 'error: required source file missing: %s\n' "$f" >&2
-		exit 1
-	fi
+for f in "${src_log}" "${src_installer}" "${src_license}" "${src_fish}" "${src_bash}" "${src_zsh}"; do
+    if [ ! -f "${f}" ]; then
+        printf 'error: required source file missing: %s\n' "${f}" >&2
+        exit 1
+    fi
 done
 
-mkdir -p "$outdir"
+mkdir -p "${outdir}"
 rm -f \
-	"${outdir}/log.sh" \
-	"${outdir}/log.sh.sha256" \
-	"${outdir}/install-log-sh.sh" \
-	"${outdir}/install-log-sh.sh.sha256" \
-	"${outdir}/log-sh-${version}.tar.gz" \
-	"${outdir}/log-sh-${version}.tar.gz.sha256"
+    "${outdir}/log.sh" \
+    "${outdir}/log.sh.sha256" \
+    "${outdir}/install-log-sh.sh" \
+    "${outdir}/install-log-sh.sh.sha256" \
+    "${outdir}/log-sh-${version}.tar.gz" \
+    "${outdir}/log-sh-${version}.tar.gz.sha256"
 
 # Raw single-file asset (for direct `curl ... -o scripts/lib/log.sh`).
-cp "$src_log" "${outdir}/log.sh"
-cp "$src_installer" "${outdir}/install-log-sh.sh"
+cp "${src_log}" "${outdir}/log.sh"
+cp "${src_installer}" "${outdir}/install-log-sh.sh"
 chmod 0644 "${outdir}/log.sh"
 chmod 0755 "${outdir}/install-log-sh.sh"
 
@@ -84,12 +84,12 @@ trap 'rm -rf "$stage"' EXIT
 pkgdir="${stage}/log-sh-${version}"
 mkdir -p "${pkgdir}/completions"
 
-cp "$src_log" "${pkgdir}/log.sh"
-cp "$src_installer" "${pkgdir}/install-log-sh.sh"
-cp "$src_license" "${pkgdir}/LICENSE"
-cp "$src_fish" "${pkgdir}/completions/log.fish"
-cp "$src_bash" "${pkgdir}/completions/log.bash"
-cp "$src_zsh" "${pkgdir}/completions/log.zsh"
+cp "${src_log}" "${pkgdir}/log.sh"
+cp "${src_installer}" "${pkgdir}/install-log-sh.sh"
+cp "${src_license}" "${pkgdir}/LICENSE"
+cp "${src_fish}" "${pkgdir}/completions/log.fish"
+cp "${src_bash}" "${pkgdir}/completions/log.bash"
+cp "${src_zsh}" "${pkgdir}/completions/log.zsh"
 
 cat >"${pkgdir}/README.md" <<EOF
 # log-sh ${version}
@@ -145,28 +145,28 @@ See the full reference in
 EOF
 
 # Reproducible-ish tarball: pin owner/mtime to the source file's mtime.
-mtime="$(date -u -r "$src_log" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null ||
-	date -u '+%Y-%m-%dT%H:%M:%SZ')"
+mtime="$(date -u -r "${src_log}" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null ||
+    date -u '+%Y-%m-%dT%H:%M:%SZ')"
 
 tar \
-	--owner=0 --group=0 --numeric-owner \
-	--mtime="$mtime" \
-	--sort=name \
-	-C "$stage" \
-	-czf "${outdir}/log-sh-${version}.tar.gz" \
-	"log-sh-${version}"
+    --owner=0 --group=0 --numeric-owner \
+    --mtime="${mtime}" \
+    --sort=name \
+    -C "${stage}" \
+    -czf "${outdir}/log-sh-${version}.tar.gz" \
+    "log-sh-${version}"
 
 # sha256 sidecars.
-(cd "$outdir" && sha256sum "log.sh" >"log.sh.sha256")
-(cd "$outdir" && sha256sum "install-log-sh.sh" >"install-log-sh.sh.sha256")
-(cd "$outdir" && sha256sum "log-sh-${version}.tar.gz" \
-	>"log-sh-${version}.tar.gz.sha256")
+(cd "${outdir}" && sha256sum "log.sh" >"log.sh.sha256")
+(cd "${outdir}" && sha256sum "install-log-sh.sh" >"install-log-sh.sh.sha256")
+(cd "${outdir}" && sha256sum "log-sh-${version}.tar.gz" \
+    >"log-sh-${version}.tar.gz.sha256")
 
-printf 'Built release artifacts for %s in %s:\n' "$version" "$outdir"
+printf 'Built release artifacts for %s in %s:\n' "${version}" "${outdir}"
 ls -1 \
-	"${outdir}/log.sh" \
-	"${outdir}/log.sh.sha256" \
-	"${outdir}/install-log-sh.sh" \
-	"${outdir}/install-log-sh.sh.sha256" \
-	"${outdir}/log-sh-${version}.tar.gz" \
-	"${outdir}/log-sh-${version}.tar.gz.sha256"
+    "${outdir}/log.sh" \
+    "${outdir}/log.sh.sha256" \
+    "${outdir}/install-log-sh.sh" \
+    "${outdir}/install-log-sh.sh.sha256" \
+    "${outdir}/log-sh-${version}.tar.gz" \
+    "${outdir}/log-sh-${version}.tar.gz.sha256"

--- a/tests/bash/helpers/common.bash
+++ b/tests/bash/helpers/common.bash
@@ -20,7 +20,7 @@ TESTS_BASH_DIR="${REPO_ROOT}/tests/bash"
 
 # Auto-install BATS helper libraries if missing
 if [ ! -f "${TESTS_BASH_DIR}/libs/bats-support/load.bash" ]; then
-	bash "${TESTS_BASH_DIR}/setup_libs.sh"
+  bash "${TESTS_BASH_DIR}/setup_libs.sh"
 fi
 
 # shellcheck disable=SC1091
@@ -31,15 +31,15 @@ load "${TESTS_BASH_DIR}/libs/bats-assert/load"
 load "${TESTS_BASH_DIR}/libs/bats-file/load"
 
 common_setup() {
-	# Make REPO_ROOT visible to tests
-	export REPO_ROOT
+  # Make REPO_ROOT visible to tests
+  export REPO_ROOT
 
-	# Ensure ~/.local/bin is on PATH so chezmoi (and friends) are findable
-	export PATH="${HOME}/.local/bin:${PATH}"
+  # Ensure ~/.local/bin is on PATH so chezmoi (and friends) are findable
+  export PATH="${HOME}/.local/bin:${PATH}"
 }
 
 common_teardown() {
-	# Placeholder for future per-test cleanup; currently a no-op so test
-	# files can call it unconditionally.
-	:
+  # Placeholder for future per-test cleanup; currently a no-op so test
+  # files can call it unconditionally.
+  :
 }

--- a/tests/bash/setup_libs.sh
+++ b/tests/bash/setup_libs.sh
@@ -19,21 +19,21 @@ BATS_ASSERT_VERSION="v2.1.0"
 BATS_FILE_VERSION="v0.4.0"
 
 download_lib() {
-	local name="$1" version="$2" dest="${LIBS_DIR}/${1}"
+    local name="$1" version="$2" dest="${LIBS_DIR}/${1}"
 
-	if [ -f "${dest}/load.bash" ]; then
-		return 0
-	fi
+    if [ -f "${dest}/load.bash" ]; then
+        return 0
+    fi
 
-	echo "Downloading ${name} ${version}..."
-	local url="https://github.com/bats-core/${name}/archive/refs/tags/${version}.tar.gz"
-	local tmpdir
-	tmpdir=$(mktemp -d)
+    echo "Downloading ${name} ${version}..."
+    local url="https://github.com/bats-core/${name}/archive/refs/tags/${version}.tar.gz"
+    local tmpdir
+    tmpdir=$(mktemp -d)
 
-	curl -fsSL "${url}" | tar -xz -C "${tmpdir}"
-	rm -rf "${dest}"
-	mv "${tmpdir}/${name}-${version#v}" "${dest}"
-	rm -rf "${tmpdir}"
+    curl -fsSL "${url}" | tar -xz -C "${tmpdir}"
+    rm -rf "${dest}"
+    mv "${tmpdir}/${name}-${version#v}" "${dest}"
+    rm -rf "${tmpdir}"
 }
 
 mkdir -p "${LIBS_DIR}"


### PR DESCRIPTION
## Description

Normalize shell-script indentation from tabs to **4-space** (matching `.editorconfig`, and my default across repos), plus shellcheck's safe autofixes. Independent of the Copilot work — based on `main`.

## Changes

- Reformatted **18** shell scripts to 4-space indent via `shfmt` (reads `.editorconfig`).
- Applied shellcheck's mechanical autofixes on those files: `SC2250` (variable braces) and `SC2248` (quoting).
- **No behavior change** — only whitespace and `${brace}` wrapping.

## Scope note (why partial)

CI lints **changed files**, so every reformatted file must also pass the repo's enabled shellcheck rules. **37 of 58** shell files additionally carry `SC2312` (`check-extra-masked-returns`) — a behavior-sensitive check that isn't safely auto-fixable. Reformatting those now would make CI red on pre-existing findings, so they are **intentionally deferred** to a dedicated follow-up. This PR contains only files that end up fully lint-clean.

- `.shellcheckrc` is **unchanged** (all rules kept).
- Follow-up will tackle the `SC2312` files (and `SC2310`/`SC2311`/`SC2249` residuals) with care.

## Validation

- `shfmt -d` clean on all changed files
- `shellcheck -x` clean on all changed files (pinned versions via mise: shellcheck 0.11.0, shfmt v3.13.1)
- `bash -n` syntax OK on all changed files
- lefthook pre-commit + commit-msg passed

## Checklist

- [x] Linting passes locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] Documentation updated (n/a — formatting only)