### PR TITLE
feat(fastfetch): add cached update, reboot and ansible-pull status modules

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -24,6 +24,9 @@ renovate.json
 
 {{ if eq .chezmoi.os "windows" }}
 .chezmoiscripts/linux/**
+# fastfetch status modules are driven by a bash script (status.sh); Windows
+# fastfetch keeps its own default config instead.
+dot_config/fastfetch/**
 {{ end }}
 
 {{ if ne .chezmoi.os "windows" }}

--- a/home/dot_config/fastfetch/config.jsonc
+++ b/home/dot_config/fastfetch/config.jsonc
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json",
+  "//": "Managed by chezmoi (dot_config/fastfetch/config.jsonc). The three trailing 'command' modules call status.sh, which prints cached lines and refreshes in the background so login stays fast. Empty output makes a line disappear, so updates/reboot/ansible only show when relevant.",
+  "modules": [
+    "title",
+    "separator",
+    "os",
+    "host",
+    "kernel",
+    "uptime",
+    "packages",
+    "shell",
+    "display",
+    "de",
+    "wm",
+    "wmtheme",
+    "theme",
+    "icons",
+    "font",
+    "cursor",
+    "terminal",
+    "terminalfont",
+    "cpu",
+    "gpu",
+    "memory",
+    "swap",
+    "disk",
+    "localip",
+    "battery",
+    "poweradapter",
+    "locale",
+    {
+      "type": "command",
+      "key": "Updates",
+      "keyColor": "yellow",
+      "text": "\"$HOME/.config/fastfetch/status.sh\" updates"
+    },
+    {
+      "type": "command",
+      "key": "Reboot",
+      "keyColor": "red",
+      "text": "\"$HOME/.config/fastfetch/status.sh\" reboot"
+    },
+    {
+      "type": "command",
+      "key": "Ansible",
+      "keyColor": "blue",
+      "text": "\"$HOME/.config/fastfetch/status.sh\" ansible"
+    },
+    "break",
+    "colors"
+  ]
+}

--- a/home/dot_config/fastfetch/executable_status.sh
+++ b/home/dot_config/fastfetch/executable_status.sh
@@ -1,0 +1,321 @@
+#!/bin/bash
+# fastfetch status.sh - Cached system status lines for fastfetch
+#
+# Emits short, self-hiding status lines that fastfetch renders as extra
+# modules: available package updates, pending reboots and (when the host is
+# managed by the DevSecNinja/docker ansible-pull project) the ansible-pull
+# run status.
+#
+# Speed is the priority: this script is invoked once per section on every
+# shell login (via fastfetch), so the section commands ONLY read a small
+# cache and never run package managers, git or systemctl inline. The
+# expensive work happens in `refresh`, which the section commands spawn in
+# the background (fully detached) using a stale-while-revalidate strategy:
+# the current (possibly slightly stale) cache is printed instantly while a
+# fresh copy is computed for the next login. fastfetch hides a `command`
+# module entirely when it prints nothing, so a section with nothing to
+# report simply disappears.
+#
+# Usage: status.sh <section|command>
+#   updates            Print cached "updates available" line (may be empty)
+#   reboot             Print cached "reboot required" line (may be empty)
+#   ansible            Print cached ansible-pull status line (may be empty)
+#   refresh            Recompute the cache (respects a single-runner lock)
+#   refresh --force    Recompute even if a refresh lock is held
+#   clear              Remove the cache
+#   -h, --help         Show this help
+#
+# Environment:
+#   FASTFETCH_STATUS_TTL       Cache lifetime in seconds (default 3600)
+#   FASTFETCH_STATUS_DISABLE   When set to 1, all sections print nothing
+#   ANSIBLE_PULL_WORKDIR       ansible-pull checkout (default /var/lib/ansible/local)
+#   XDG_CACHE_HOME             Base cache dir (default ~/.cache)
+#
+# Notes:
+#   - Never requires root and never touches the network. Update counts are
+#     read from already-downloaded package metadata; ansible/reboot status is
+#     read from local files and systemd/git state.
+#   - Update checks cover apt, dnf, pacman, zypper, apk (Linux) and brew
+#     (macOS / Linuxbrew). Reboot detection is Linux-only; it prints nothing
+#     elsewhere.
+#   - Safe to run on any host; unmanaged hosts simply omit the ansible line.
+
+set -uo pipefail
+
+CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/fastfetch-status"
+STAMP="${CACHE_DIR}/.refreshed-at"
+LOCK_DIR="${CACHE_DIR}/.refresh.lock"
+TTL="${FASTFETCH_STATUS_TTL:-3600}"
+ANSIBLE_WORKDIR="${ANSIBLE_PULL_WORKDIR:-/var/lib/ansible/local}"
+
+# --- small helpers ----------------------------------------------------------
+
+# _epoch_of FILE -> modification time in seconds since epoch (0 if missing).
+_epoch_of() {
+    stat -c %Y "${1}" 2>/dev/null || stat -f %m "${1}" 2>/dev/null || echo 0
+}
+
+# _reltime SECONDS -> compact human duration (e.g. 45s, 12m, 3h, 2d).
+_reltime() {
+    local s="${1}"
+    [ "${s}" -lt 0 ] && s=0
+    if [ "${s}" -lt 60 ]; then
+        echo "${s}s"
+    elif [ "${s}" -lt 3600 ]; then
+        echo "$((s / 60))m"
+    elif [ "${s}" -lt 86400 ]; then
+        echo "$((s / 3600))h"
+    else
+        echo "$((s / 86400))d"
+    fi
+}
+
+# _is_stale -> 0 (true) when the cache is missing or older than the TTL.
+_is_stale() {
+    [ -f "${STAMP}" ] || return 0
+    local now stamp_epoch
+    now="$(date +%s)"
+    stamp_epoch="$(_epoch_of "${STAMP}")"
+    [ "$((now - stamp_epoch))" -ge "${TTL}" ]
+}
+
+# _spawn_refresh -> kick off a background refresh, fully detached so fastfetch
+# never blocks on it. A refresh lock in the child prevents multiple section
+# calls from all launching a refresh at once.
+_spawn_refresh() {
+    if command -v setsid >/dev/null 2>&1; then
+        setsid "${0}" refresh >/dev/null 2>&1 </dev/null &
+    else
+        ("${0}" refresh >/dev/null 2>&1 </dev/null &)
+    fi
+}
+
+# _emit SECTION -> print the cached section and trigger a background refresh
+# when the cache is stale.
+_emit() {
+    [ "${FASTFETCH_STATUS_DISABLE:-0}" = "1" ] && return 0
+    if _is_stale; then
+        _spawn_refresh
+    fi
+    local file="${CACHE_DIR}/${1}"
+    [ -f "${file}" ] && cat "${file}"
+    return 0
+}
+
+# --- collectors (run only inside refresh) -----------------------------------
+
+# _collect_updates -> line describing available package updates, or nothing.
+# Reads already-synced package-manager metadata; never syncs (no root/network).
+_collect_updates() {
+    local count=0 mgr=""
+
+    if command -v apt-get >/dev/null 2>&1; then
+        mgr="apt"
+        count="$(apt-get -s -o Debug::NoLocking=true upgrade 2>/dev/null | grep -c '^Inst ' || true)"
+    elif command -v dnf >/dev/null 2>&1; then
+        mgr="dnf"
+        # -C = cache only, so no network access.
+        count="$(dnf -q -C check-update 2>/dev/null | grep -cE '^[a-zA-Z0-9]' || true)"
+    elif command -v pacman >/dev/null 2>&1; then
+        mgr="pacman"
+        count="$(pacman -Qu 2>/dev/null | grep -c . || true)"
+    elif command -v zypper >/dev/null 2>&1; then
+        mgr="zypper"
+        count="$(zypper --non-interactive -q list-updates 2>/dev/null | grep -c '^v ' || true)"
+    elif command -v apk >/dev/null 2>&1; then
+        mgr="apk"
+        count="$(apk version -l '<' 2>/dev/null | grep -c . || true)"
+    elif command -v brew >/dev/null 2>&1; then
+        # macOS (and Linuxbrew as a fallback). Reads local state only; does
+        # not run `brew update`, so no network access.
+        mgr="brew"
+        count="$(brew outdated --quiet 2>/dev/null | grep -c . || true)"
+    else
+        return 0
+    fi
+
+    count="${count//[!0-9]/}"
+    [ -z "${count}" ] && count=0
+    if [ "${count}" -gt 0 ]; then
+        printf '\360\237\223\246 %s update(s) available (%s)\n' "${count}" "${mgr}"
+    fi
+}
+
+# _collect_reboot -> line describing a pending reboot, or nothing.
+_collect_reboot() {
+    if [ -f /var/run/reboot-required ] || [ -f /run/reboot-required ]; then
+        local pkgs="" f
+        for f in /var/run/reboot-required.pkgs /run/reboot-required.pkgs; do
+            if [ -f "${f}" ]; then
+                pkgs="$(tr '\n' ' ' <"${f}" | sed 's/ *$//' || true)"
+                break
+            fi
+        done
+        if [ -n "${pkgs}" ]; then
+            printf '\360\237\224\204 Reboot required \342\200\224 %s\n' "${pkgs}"
+        else
+            printf '\360\237\224\204 Reboot required\n'
+        fi
+        return 0
+    fi
+
+    # RHEL/Fedora: needs-restarting -r returns 1 when a reboot is needed.
+    if command -v needs-restarting >/dev/null 2>&1; then
+        if ! needs-restarting -r >/dev/null 2>&1; then
+            printf '\360\237\224\204 Reboot required\n'
+        fi
+    fi
+    return 0
+}
+
+# _systemd_prop UNIT PROP -> value of a systemd unit property ("" on failure).
+_systemd_prop() {
+    systemctl show "${1}" -p "${2}" --value 2>/dev/null || true
+}
+
+# _collect_ansible -> ansible-pull status line for hosts managed by the
+# DevSecNinja/docker project, or nothing when the host is unmanaged.
+_collect_ansible() {
+    local have_systemd=0 managed=0 load_state=""
+    if command -v systemctl >/dev/null 2>&1; then
+        load_state="$(_systemd_prop ansible-pull.service LoadState)"
+        if [ "${load_state}" = "loaded" ]; then
+            have_systemd=1
+            managed=1
+        fi
+    fi
+    [ -d "${ANSIBLE_WORKDIR}/.git" ] && managed=1
+    [ "${managed}" -eq 1 ] || return 0
+
+    # Short SHA of the checked-out configuration (best effort; the workdir is
+    # usually owned by a different user, hence safe.directory).
+    local cfg=""
+    if command -v git >/dev/null 2>&1 && [ -d "${ANSIBLE_WORKDIR}/.git" ]; then
+        cfg="$(git -C "${ANSIBLE_WORKDIR}" -c safe.directory='*' log -1 --format='%h' 2>/dev/null || true)"
+    fi
+
+    if [ "${have_systemd}" -eq 0 ]; then
+        # Managed but no systemd unit visible (e.g. cron-based scheduling).
+        if [ -n "${cfg}" ]; then
+            printf '\360\237\244\226 ansible-pull managed \302\267 config %s\n' "${cfg}"
+        else
+            printf '\360\237\244\226 ansible-pull managed\n'
+        fi
+        return 0
+    fi
+
+    local active result exit_code finished_ts now ran="" next=""
+    active="$(_systemd_prop ansible-pull.service ActiveState)"
+    result="$(_systemd_prop ansible-pull.service Result)"
+    exit_code="$(_systemd_prop ansible-pull.service ExecMainStatus)"
+    finished_ts="$(_systemd_prop ansible-pull.service InactiveEnterTimestamp)"
+    now="$(date +%s)"
+
+    if [ -n "${finished_ts}" ]; then
+        local finished_epoch
+        finished_epoch="$(date -d "${finished_ts}" +%s 2>/dev/null || echo 0)"
+        [ "${finished_epoch}" -gt 0 ] && ran="ran $(_reltime "$((now - finished_epoch))") ago"
+    fi
+
+    # Next scheduled run from the timer (microseconds since epoch).
+    local next_us next_epoch
+    next_us="$(_systemd_prop ansible-pull.timer NextElapseUSecRealtime)"
+    next_us="${next_us//[!0-9]/}"
+    if [ -n "${next_us}" ] && [ "${next_us}" -gt 0 ]; then
+        next_epoch=$((next_us / 1000000))
+        [ "${next_epoch}" -gt "${now}" ] && next="next in $(_reltime "$((next_epoch - now))")"
+    fi
+
+    local head tail="" part
+    if [ "${active}" = "activating" ] || [ "${active}" = "active" ]; then
+        head="\342\217\263 ansible-pull running\342\200\246"
+    elif [ "${result}" = "success" ] && [ "${exit_code:-0}" = "0" ]; then
+        head="\342\234\205 ansible-pull OK"
+    else
+        head="\342\235\214 ansible-pull FAILED"
+        [ -n "${exit_code:-}" ] && [ "${exit_code}" != "0" ] && head="${head} (exit ${exit_code})"
+    fi
+
+    for part in "${ran}" "${next}" "${cfg:+config ${cfg}}"; do
+        [ -n "${part}" ] && tail="${tail} \302\267 ${part}"
+    done
+
+    printf '%b%b\n' "${head}" "${tail}"
+}
+
+# --- refresh ----------------------------------------------------------------
+
+# _write_section NAME VALUE -> atomically write (or remove) a cache section.
+_write_section() {
+    local value="${2}" file="${CACHE_DIR}/${1}"
+    if [ -n "${value}" ]; then
+        printf '%s\n' "${value}" >"${file}.tmp" && mv -f "${file}.tmp" "${file}"
+    else
+        rm -f "${file}"
+    fi
+}
+
+_refresh() {
+    local force="${1:-}"
+    mkdir -p "${CACHE_DIR}"
+
+    # Single-runner lock via atomic mkdir. Recover a stale lock (older than
+    # 10 minutes) left behind by an interrupted refresh.
+    if ! mkdir "${LOCK_DIR}" 2>/dev/null; then
+        if [ "${force}" = "--force" ]; then
+            rmdir "${LOCK_DIR}" 2>/dev/null || true
+            mkdir "${LOCK_DIR}" 2>/dev/null || return 0
+        else
+            local now lock_epoch
+            now="$(date +%s)"
+            lock_epoch="$(_epoch_of "${LOCK_DIR}")"
+            if [ "$((now - lock_epoch))" -gt 600 ]; then
+                rmdir "${LOCK_DIR}" 2>/dev/null || true
+                mkdir "${LOCK_DIR}" 2>/dev/null || return 0
+            else
+                return 0
+            fi
+        fi
+    fi
+    trap 'rmdir "${LOCK_DIR}" 2>/dev/null || true' EXIT
+
+    local updates reboot ansible
+    updates="$(_collect_updates)"
+    reboot="$(_collect_reboot)"
+    ansible="$(_collect_ansible)"
+    _write_section updates "${updates}"
+    _write_section reboot "${reboot}"
+    _write_section ansible "${ansible}"
+
+    : >"${STAMP}"
+}
+
+_usage() {
+    sed -n '2,40p' "${0}" | sed 's/^# \{0,1\}//'
+}
+
+# --- dispatch ---------------------------------------------------------------
+
+case "${1:-}" in
+updates | reboot | ansible)
+    _emit "${1}"
+    ;;
+refresh)
+    _refresh "${2:-}"
+    ;;
+clear)
+    rm -rf "${CACHE_DIR}"
+    ;;
+-h | --help | help)
+    _usage
+    ;;
+"")
+    _usage
+    exit 1
+    ;;
+*)
+    echo "Unknown command: ${1}" >&2
+    echo "Use --help for usage information" >&2
+    exit 1
+    ;;
+esac

--- a/tests/bash/fastfetch-status.bats
+++ b/tests/bash/fastfetch-status.bats
@@ -1,0 +1,217 @@
+#!/usr/bin/env bats
+# Tests for the fastfetch status.sh cached-status script.
+#
+# The script lives at home/dot_config/fastfetch/executable_status.sh and is
+# applied by chezmoi to ~/.config/fastfetch/status.sh. It powers the extra
+# "Updates", "Reboot" and "Ansible" fastfetch modules.
+
+setup() {
+	REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+	export REPO_ROOT
+	SCRIPT="${REPO_ROOT}/home/dot_config/fastfetch/executable_status.sh"
+	export SCRIPT
+
+	# Isolated cache + a bin dir for command mocks, prepended to PATH.
+	XDG_CACHE_HOME="$(mktemp -d)"
+	export XDG_CACHE_HOME
+	TEST_BIN_DIR="$(mktemp -d)"
+	export TEST_BIN_DIR
+	ORIGINAL_PATH="${PATH}"
+	export ORIGINAL_PATH
+
+	# Point ansible detection at an empty (unmanaged) dir by default.
+	ANSIBLE_PULL_WORKDIR="$(mktemp -d)"
+	export ANSIBLE_PULL_WORKDIR
+}
+
+teardown() {
+	export PATH="${ORIGINAL_PATH}"
+	for d in "${XDG_CACHE_HOME}" "${TEST_BIN_DIR}" "${ANSIBLE_PULL_WORKDIR}"; do
+		[ -n "${d}" ] && [ -d "${d}" ] && rm -rf "${d}"
+	done
+}
+
+# Write a mock command into TEST_BIN_DIR and put it first on PATH.
+_mock() {
+	local name="$1"
+	cat >"${TEST_BIN_DIR}/${name}"
+	chmod +x "${TEST_BIN_DIR}/${name}"
+	export PATH="${TEST_BIN_DIR}:${ORIGINAL_PATH}"
+}
+
+@test "fastfetch-status: script exists and is executable" {
+	[ -f "${SCRIPT}" ]
+	[ -x "${SCRIPT}" ]
+}
+
+@test "fastfetch-status: has valid bash syntax" {
+	run bash -n "${SCRIPT}"
+	[ "$status" -eq 0 ]
+}
+
+@test "fastfetch-status: help option displays usage" {
+	run bash "${SCRIPT}" --help
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "Usage: status.sh" ]]
+	[[ "$output" =~ "updates" ]]
+	[[ "$output" =~ "ansible" ]]
+}
+
+@test "fastfetch-status: unknown command returns error" {
+	run bash "${SCRIPT}" bogus
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "Unknown command" ]]
+}
+
+@test "fastfetch-status: no command prints usage and fails" {
+	run bash "${SCRIPT}"
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "Usage: status.sh" ]]
+}
+
+@test "fastfetch-status: refresh creates cache and timestamp" {
+	run bash "${SCRIPT}" refresh
+	[ "$status" -eq 0 ]
+	[ -f "${XDG_CACHE_HOME}/fastfetch-status/.refreshed-at" ]
+}
+
+@test "fastfetch-status: section emits cached value" {
+	mkdir -p "${XDG_CACHE_HOME}/fastfetch-status"
+	printf 'cached-line\n' >"${XDG_CACHE_HOME}/fastfetch-status/updates"
+	: >"${XDG_CACHE_HOME}/fastfetch-status/.refreshed-at"
+
+	run bash "${SCRIPT}" updates
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "cached-line" ]]
+}
+
+@test "fastfetch-status: missing section prints nothing (hides fastfetch line)" {
+	mkdir -p "${XDG_CACHE_HOME}/fastfetch-status"
+	: >"${XDG_CACHE_HOME}/fastfetch-status/.refreshed-at"
+
+	run bash "${SCRIPT}" reboot
+	[ "$status" -eq 0 ]
+	[ -z "$output" ]
+}
+
+@test "fastfetch-status: FASTFETCH_STATUS_DISABLE silences all sections" {
+	mkdir -p "${XDG_CACHE_HOME}/fastfetch-status"
+	printf 'cached-line\n' >"${XDG_CACHE_HOME}/fastfetch-status/updates"
+	: >"${XDG_CACHE_HOME}/fastfetch-status/.refreshed-at"
+
+	run env FASTFETCH_STATUS_DISABLE=1 bash "${SCRIPT}" updates
+	[ "$status" -eq 0 ]
+	[ -z "$output" ]
+}
+
+@test "fastfetch-status: counts available apt updates" {
+	_mock apt-get <<'EOF'
+#!/bin/bash
+cat <<'PKGS'
+Inst bash [5.2] (5.2.15 Debian:13 [arm64])
+Inst coreutils [9.1] (9.4-3 Debian:13 [arm64])
+PKGS
+EOF
+	run bash "${SCRIPT}" refresh
+	[ "$status" -eq 0 ]
+	run cat "${XDG_CACHE_HOME}/fastfetch-status/updates"
+	[[ "$output" =~ "2 update(s) available (apt)" ]]
+}
+
+@test "fastfetch-status: no apt updates leaves updates section empty" {
+	_mock apt-get <<'EOF'
+#!/bin/bash
+echo "Reading package lists..."
+EOF
+	run bash "${SCRIPT}" refresh
+	[ "$status" -eq 0 ]
+	[ ! -f "${XDG_CACHE_HOME}/fastfetch-status/updates" ]
+}
+
+@test "fastfetch-status: counts outdated brew packages (macOS/Linuxbrew)" {
+	# Build a minimal PATH with only coreutils + a mock brew so the Linux
+	# package managers are treated as absent and the brew branch is used.
+	local t
+	for t in bash mkdir date grep tr sed mv rm rmdir stat cat; do
+		ln -sf "$(command -v "${t}")" "${TEST_BIN_DIR}/${t}"
+	done
+	cat >"${TEST_BIN_DIR}/brew" <<'EOF'
+#!/bin/bash
+# mock `brew outdated --quiet`
+printf 'wget\nneovim\nfastfetch\n'
+EOF
+	chmod +x "${TEST_BIN_DIR}/brew"
+
+	PATH="${TEST_BIN_DIR}" run bash "${SCRIPT}" refresh
+	[ "$status" -eq 0 ]
+	run cat "${XDG_CACHE_HOME}/fastfetch-status/updates"
+	[[ "$output" =~ "3 update(s) available (brew)" ]]
+}
+
+@test "fastfetch-status: reports ansible-pull success from systemd" {
+	_mock systemctl <<'EOF'
+#!/bin/bash
+unit=""; prop=""
+while [ $# -gt 0 ]; do
+	case "$1" in
+	show) shift ;;
+	-p) prop="$2"; shift 2 ;;
+	--value) shift ;;
+	*) [ -z "$unit" ] && unit="$1"; shift ;;
+	esac
+done
+case "${unit}:${prop}" in
+ansible-pull.service:LoadState) echo loaded ;;
+ansible-pull.service:ActiveState) echo inactive ;;
+ansible-pull.service:Result) echo success ;;
+ansible-pull.service:ExecMainStatus) echo 0 ;;
+ansible-pull.service:InactiveEnterTimestamp) date -d '10 minutes ago' ;;
+ansible-pull.timer:NextElapseUSecRealtime) echo $(( ($(date +%s) + 1800) * 1000000 )) ;;
+*) echo "" ;;
+esac
+EOF
+	run bash "${SCRIPT}" refresh
+	[ "$status" -eq 0 ]
+	run cat "${XDG_CACHE_HOME}/fastfetch-status/ansible"
+	[[ "$output" =~ "ansible-pull OK" ]]
+	[[ "$output" =~ "ran 10m ago" ]]
+	[[ "$output" =~ "next in" ]]
+}
+
+@test "fastfetch-status: reports ansible-pull failure from systemd" {
+	_mock systemctl <<'EOF'
+#!/bin/bash
+unit=""; prop=""
+while [ $# -gt 0 ]; do
+	case "$1" in
+	show) shift ;;
+	-p) prop="$2"; shift 2 ;;
+	--value) shift ;;
+	*) [ -z "$unit" ] && unit="$1"; shift ;;
+	esac
+done
+case "${unit}:${prop}" in
+ansible-pull.service:LoadState) echo loaded ;;
+ansible-pull.service:ActiveState) echo inactive ;;
+ansible-pull.service:Result) echo exit-code ;;
+ansible-pull.service:ExecMainStatus) echo 2 ;;
+ansible-pull.service:InactiveEnterTimestamp) date -d '2 hours ago' ;;
+*) echo "" ;;
+esac
+EOF
+	run bash "${SCRIPT}" refresh
+	[ "$status" -eq 0 ]
+	run cat "${XDG_CACHE_HOME}/fastfetch-status/ansible"
+	[[ "$output" =~ "ansible-pull FAILED (exit 2)" ]]
+}
+
+@test "fastfetch-status: unmanaged host omits ansible section" {
+	_mock systemctl <<'EOF'
+#!/bin/bash
+# Report the unit as absent for every query.
+echo ""
+EOF
+	run bash "${SCRIPT}" refresh
+	[ "$status" -eq 0 ]
+	[ ! -f "${XDG_CACHE_HOME}/fastfetch-status/ansible" ]
+}


### PR DESCRIPTION
## What

Extends fastfetch with three self-hiding status lines:

- **Updates** — count of available package updates
- **Reboot** — pending-reboot indicator
- **Ansible** — last `ansible-pull` run status for hosts managed by the [DevSecNinja/docker](https://github.com/DevSecNinja/docker) project (OK/FAILED, last-run age, next run, config SHA)

A line only appears when there's something to report (fastfetch hides a `command` module that prints nothing), so an up-to-date, unmanaged host looks exactly like before.

## Files

- `home/dot_config/fastfetch/executable_status.sh` → `~/.config/fastfetch/status.sh`
- `home/dot_config/fastfetch/config.jsonc` — default layout + the 3 `command` modules
- `home/.chezmoiignore` — skip this bash-driven dir on Windows
- `tests/bash/fastfetch-status.bats` — 15 tests

## Performance (runs on every shell login)

Section commands only `cat` a small cache under `~/.cache/fastfetch-status/`. When the cache is stale (TTL default 1h) they print the current value instantly and spawn a **fully-detached** background `refresh` (stale-while-revalidate). The expensive work needs **no root and no network** and never runs `apt update`. Verified: full render stays ~300ms even while a refresh runs in the background.

Update checks cover `apt`, `dnf`, `pacman`, `zypper`, `apk` (Linux) and `brew` (macOS / Linuxbrew). Reboot detection is Linux-only.

## Tunables

`FASTFETCH_STATUS_TTL`, `FASTFETCH_STATUS_DISABLE=1`, `ANSIBLE_PULL_WORKDIR`; `status.sh refresh --force` / `clear`.

## Testing

- `./tests/bash/run-tests.sh --test fastfetch-status.bats` → 15/15 pass
- shellcheck + shfmt clean; lefthook pre-commit green
- Rendered against a real host (this dev VM is ansible-managed): the Ansible line correctly showed its last failed pull; Updates/Reboot correctly hidden.