### PR TITLE
feat: copilot-ssh reachability pre-flight, Windows Terminal profile and PATH tweaks

### DIFF
--- a/docs/chezmoi-variables.md
+++ b/docs/chezmoi-variables.md
@@ -36,6 +36,11 @@ templates and scripts.
   Override it per-machine by setting `opCopilotEnvironmentId` in your local
   chezmoi config or at the interactive init prompt. Exported to your shell as
   `OP_COPILOT_ENVIRONMENT_ID`. See [copilot-cli.md](copilot-cli.md).
+- `copilotSshHost` — The SSH host used by the Windows Terminal "Copilot SSH"
+  profile that runs the `copilot-ssh` PowerShell helper. Defaults to
+  `svlazdev.<privateDomain>` when `privateDomain` is set, otherwise `svlazdev`.
+  Override it per-machine by setting `copilotSshHost` in your local chezmoi
+  config or at the interactive init prompt.
 
 [openv]: https://www.1password.dev/environments
 

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -109,6 +109,40 @@ never opens a token-less session. When the 1Password CLI is not found it tells
 you to (1) install it and (2) enable it in
 **1Password → Settings → Developer → "Integrate with 1Password CLI"**.
 
+## Reachability pre-flight (and stopped Azure VMs)
+
+Before unlocking 1Password, all three helpers run a fast reachability check so
+an unreachable host fails in about three seconds instead of hanging on ssh's
+own connect timeout:
+
+1. The destination is resolved with `ssh -G <args>`, so `~/.ssh/config`
+   aliases, `HostName`/`Port` overrides and `-o` flags are all honoured.
+2. Its TCP port is probed with a hard timeout (`nc`, or bash `/dev/tcp`, or a
+   .NET `TcpClient` on Windows). If nothing can probe, the check is skipped and
+   `ssh` decides.
+3. When the probe fails **and** the Azure CLI (`az`) is installed, the host is
+   looked up with `az vm list -d`: first by VM name — matching both the full
+   host and its short form, so `vm01.example.com` also matches a VM named
+   `vm01` — then by the VM's public/private IP addresses.
+4. If that VM is **stopped** or **deallocated**, you are asked whether to start
+   it. On yes, the helper runs `az vm start`, waits for the SSH port to answer
+   and then connects as usual. On no (or in a non-interactive shell, which
+   always answers no) it aborts.
+5. If the VM is **running** but the port is closed, it says so and points at
+   NSG rules, the VPN/network path or `sshd` — no VM is touched.
+
+Ambiguous matches (several VMs with the same name in different resource
+groups) are listed and the helper refuses to guess.
+
+Environment variables:
+
+| Variable                        | Default | Effect                                          |
+| ------------------------------- | ------- | ----------------------------------------------- |
+| `COPILOT_SSH_SKIP_PREFLIGHT`    | unset   | `1` skips the reachability check entirely       |
+| `COPILOT_SSH_PREFLIGHT_TIMEOUT` | `3`     | TCP probe timeout in seconds                    |
+| `COPILOT_SSH_START_TIMEOUT`     | `180`   | How long to wait for SSH after `az vm start`    |
+| `COPILOT_SSH_ASSUME_YES`        | unset   | `1` auto-confirms starting a stopped VM         |
+
 ## Security notes
 
 - The tokens live only in 1Password (at rest), transiently in the helper's

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -142,6 +142,7 @@ Environment variables:
 | `COPILOT_SSH_PREFLIGHT_TIMEOUT` | `3`     | TCP probe timeout in seconds                    |
 | `COPILOT_SSH_START_TIMEOUT`     | `180`   | How long to wait for SSH after `az vm start`    |
 | `COPILOT_SSH_ASSUME_YES`        | unset   | `1` auto-confirms starting a stopped VM         |
+| `COPILOT_SSH_ASSUME_NO`         | unset   | `1` never starts a VM, even on a TTY            |
 
 ## Security notes
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -58,6 +58,13 @@ chezmoi data
 chezmoi verify
 ```
 
+## Windows PATH
+
+On Windows, the setup adds `%OneDrive%\Portable Programs` to the user-scope
+PATH when the folder exists, so it survives reboots and is available to GUI
+apps. The PowerShell profile also adds the same folder to the current session
+when OneDrive is configured.
+
 ## Learn More
 
 - [Chezmoi documentation](https://www.chezmoi.io/user-guide/command-overview/)

--- a/home/.chezmoi.yaml.tmpl
+++ b/home/.chezmoi.yaml.tmpl
@@ -78,6 +78,22 @@
 {{-   $opCopilotEnvironmentId = promptString "1Password Environment ID for Copilot CLI" $opCopilotEnvironmentId -}}
 {{- end -}}
 
+{{- /* SSH host used by Windows Terminal's Copilot SSH profile. This defaults  */ -}}
+{{- /* to the same svlazdev host alias declared in private_dot_ssh/config.tmpl */ -}}
+{{- /* when privateDomain is set, and falls back to plain svlazdev when it is  */ -}}
+{{- /* empty. Override per-machine by setting `copilotSshHost` in your local   */ -}}
+{{- /* chezmoi config, or at the interactive init prompt. See                  */ -}}
+{{- /* docs/copilot-cli.md.                                                     */ -}}
+{{- $copilotSshHost := "svlazdev" -}}
+{{- if $privateDomain -}}
+{{-   $copilotSshHost = printf "svlazdev.%s" $privateDomain -}}
+{{- end -}}
+{{- if hasKey . "copilotSshHost" -}}
+{{-   $copilotSshHost = .copilotSshHost -}}
+{{- else if $interactive -}}
+{{-   $copilotSshHost = promptString "Copilot SSH host" $copilotSshHost -}}
+{{- end -}}
+
 {{- /* Extract GitHub username from email or prompt */ -}}
 {{- $githubUsername := "" -}}
 {{- /* Matches GitHub noreply email format: ID+USERNAME@users.noreply.github.com (e.g., 14926452+DevSecNinja@users.noreply.github.com) */ -}}
@@ -214,6 +230,7 @@ interpreters:
 
 data:
   ci: {{ $ci }}
+  copilotSshHost: {{ $copilotSshHost | quote }}
   codespaces: {{ $codespaces }}
   devcontainer: {{ $devcontainer }}
   email: {{ $email | quote }}

--- a/home/.chezmoiscripts/windows/run_onchange_add-portable-programs-path.ps1
+++ b/home/.chezmoiscripts/windows/run_onchange_add-portable-programs-path.ps1
@@ -1,0 +1,303 @@
+#!/usr/bin/env pwsh
+# Add OneDrive Portable Programs to the user PATH.
+# Runs when this script changes; the operation itself is idempotent.
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    "PSAvoidUsingWriteHost",
+    "",
+    Justification = "Matches existing chezmoi setup script progress output."
+)]
+param(
+    [switch]$SkipApply
+)
+
+$ErrorActionPreference = "Stop"
+
+function ConvertTo-PathLookupKey {
+    param(
+        [AllowNull()]
+        [string]$Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return ""
+    }
+
+    return $Path.Trim().Trim('"').TrimEnd('\').ToUpperInvariant()
+}
+
+function Test-PathListContainsEntry {
+    param(
+        [AllowNull()]
+        [string]$PathList,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Entry
+    )
+
+    $pathListValue = if ($null -eq $PathList) { "" } else { $PathList }
+    $entryKey = ConvertTo-PathLookupKey -Path $Entry
+    foreach ($pathEntry in ($pathListValue -split ';')) {
+        if ((ConvertTo-PathLookupKey -Path $pathEntry) -eq $entryKey) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Add-PathListEntry {
+    param(
+        [AllowNull()]
+        [string]$PathList,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Entry
+    )
+
+    if (Test-PathListContainsEntry -PathList $PathList -Entry $Entry) {
+        return $PathList
+    }
+
+    if ([string]::IsNullOrWhiteSpace($PathList)) {
+        return $Entry
+    }
+
+    $separator = if ($PathList.EndsWith(';')) { "" } else { ";" }
+    return "$PathList$separator$Entry"
+}
+
+function Resolve-UserPathRegistryWriteInfo {
+    param(
+        [AllowNull()]
+        [string]$ValueName,
+
+        [AllowNull()]
+        [object]$Kind,
+
+        [AllowNull()]
+        [string]$Value
+    )
+
+    $resolvedValueName = if ([string]::IsNullOrWhiteSpace($ValueName)) { "Path" } else { $ValueName }
+    $resolvedKind = if ($Kind -is [Microsoft.Win32.RegistryValueKind] -and
+        $Kind -ne [Microsoft.Win32.RegistryValueKind]::Unknown) {
+        $Kind
+    }
+    elseif ($Value -like "*%*") {
+        [Microsoft.Win32.RegistryValueKind]::ExpandString
+    }
+    else {
+        [Microsoft.Win32.RegistryValueKind]::String
+    }
+
+    return [pscustomobject]@{
+        ValueName = $resolvedValueName
+        Kind      = $resolvedKind
+    }
+}
+
+function Get-UserPathRegistryValue {
+    $environmentKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $false)
+    try {
+        if (-not $environmentKey) {
+            return [pscustomobject]@{
+                Value     = ""
+                ValueName = "Path"
+                Kind      = $null
+            }
+        }
+
+        $valueName = $environmentKey.GetValueNames() |
+            Where-Object { $_ -in @("Path", "PATH") } |
+            Select-Object -First 1
+        if (-not $valueName) {
+            return [pscustomobject]@{
+                Value     = ""
+                ValueName = "Path"
+                Kind      = $null
+            }
+        }
+
+        return [pscustomobject]@{
+            Value     = [string]$environmentKey.GetValue(
+                $valueName,
+                "",
+                [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames
+            )
+            ValueName = $valueName
+            Kind      = $environmentKey.GetValueKind($valueName)
+        }
+    }
+    finally {
+        if ($environmentKey) {
+            $environmentKey.Dispose()
+        }
+    }
+}
+
+function Send-EnvironmentChangeBroadcast {
+    try {
+        if (-not ([System.Management.Automation.PSTypeName]"NativeMethods.EnvironmentBroadcast").Type) {
+            Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+
+namespace NativeMethods {
+    public static class EnvironmentBroadcast {
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        public static extern IntPtr SendMessageTimeout(
+            IntPtr hWnd,
+            uint Msg,
+            UIntPtr wParam,
+            string lParam,
+            uint fuFlags,
+            uint uTimeout,
+            out UIntPtr lpdwResult);
+    }
+}
+'@
+        }
+
+        $sendResult = [UIntPtr]::Zero
+        $response = [NativeMethods.EnvironmentBroadcast]::SendMessageTimeout(
+            [IntPtr]0xffff,
+            0x001A,
+            [UIntPtr]::Zero,
+            "Environment",
+            0x0002,
+            5000,
+            [ref]$sendResult
+        )
+
+        if ($response -eq [IntPtr]::Zero) {
+            Write-Host "[WARN] Could not broadcast environment change notification." -ForegroundColor Yellow
+        }
+    }
+    catch {
+        Write-Host "[WARN] Could not broadcast environment change notification: $($_.Exception.Message)" -ForegroundColor Yellow
+    }
+}
+
+function Set-UserPathRegistryValue {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [AllowNull()]
+        [string]$ValueName,
+
+        [AllowNull()]
+        [object]$Kind
+    )
+
+    $writeInfo = Resolve-UserPathRegistryWriteInfo -ValueName $ValueName -Kind $Kind -Value $Path
+    if ($PSCmdlet.ShouldProcess("HKCU:\Environment\$($writeInfo.ValueName)", "Set user PATH registry value")) {
+        $environmentKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $true)
+        try {
+            if (-not $environmentKey) {
+                $environmentKey = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey("Environment")
+            }
+
+            $environmentKey.SetValue($writeInfo.ValueName, $Path, $writeInfo.Kind)
+        }
+        finally {
+            if ($environmentKey) {
+                $environmentKey.Dispose()
+            }
+        }
+
+        Send-EnvironmentChangeBroadcast
+    }
+}
+
+function Add-PortableProgramsToUserPath {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [AllowNull()]
+        [string]$OneDrivePath = $env:OneDrive,
+
+        [scriptblock]$PathExists = {
+            param([string]$Path)
+            Test-Path -LiteralPath $Path -PathType Container
+        },
+
+        [scriptblock]$GetUserPath = {
+            Get-UserPathRegistryValue
+        },
+
+        [scriptblock]$SetUserPath = {
+            param(
+                [string]$Path,
+                [string]$ValueName,
+                [object]$Kind
+            )
+            Set-UserPathRegistryValue -Path $Path -ValueName $ValueName -Kind $Kind
+        }
+    )
+
+    if ([string]::IsNullOrWhiteSpace($OneDrivePath)) {
+        return [pscustomobject]@{
+            Status  = "OneDriveMissing"
+            Changed = $false
+            Path    = $null
+        }
+    }
+
+    $oneDriveRoot = $OneDrivePath.TrimEnd('\').TrimEnd('/')
+    $portableProgramsPath = "$oneDriveRoot\Portable Programs"
+
+    # Persist only existing folders so a stale or not-yet-synced OneDrive path
+    # is not written permanently; the profile still handles the current session.
+    if (-not (& $PathExists $portableProgramsPath)) {
+        Write-Host "[SKIP] Portable Programs folder not found: $portableProgramsPath" -ForegroundColor Yellow
+        return [pscustomobject]@{
+            Status  = "PortableProgramsMissing"
+            Changed = $false
+            Path    = $portableProgramsPath
+        }
+    }
+
+    $userPathInfo = & $GetUserPath
+    if ($null -eq $userPathInfo) {
+        $userPath = ""
+        $valueName = "Path"
+        $valueKind = $null
+    }
+    elseif ($userPathInfo.PSObject.Properties["Value"]) {
+        $userPath = [string]$userPathInfo.Value
+        $valueName = $userPathInfo.ValueName
+        $valueKind = $userPathInfo.Kind
+    }
+    else {
+        $userPath = [string]$userPathInfo
+        $valueName = "Path"
+        $valueKind = $null
+    }
+
+    if (Test-PathListContainsEntry -PathList $userPath -Entry $portableProgramsPath) {
+        Write-Host "[OK] Portable Programs is already in the user PATH" -ForegroundColor Green
+        return [pscustomobject]@{
+            Status  = "AlreadySet"
+            Changed = $false
+            Path    = $portableProgramsPath
+        }
+    }
+
+    $updatedUserPath = Add-PathListEntry -PathList $userPath -Entry $portableProgramsPath
+    if ($PSCmdlet.ShouldProcess("User PATH", "Append $portableProgramsPath")) {
+        & $SetUserPath $updatedUserPath $valueName $valueKind
+        Write-Host "[OK] Added Portable Programs to the user PATH: $portableProgramsPath" -ForegroundColor Green
+    }
+
+    return [pscustomobject]@{
+        Status  = "Updated"
+        Changed = $true
+        Path    = $portableProgramsPath
+    }
+}
+
+if (-not $SkipApply) {
+    Add-PortableProgramsToUserPath | Out-Null
+}

--- a/home/.chezmoiscripts/windows/run_onchange_set-windows-terminal-copilot-profile.ps1.tmpl
+++ b/home/.chezmoiscripts/windows/run_onchange_set-windows-terminal-copilot-profile.ps1.tmpl
@@ -1,0 +1,34 @@
+# {{ if eq .chezmoi.os "windows" }}
+# Add or update a Windows Terminal profile for the copilot-ssh helper WITHOUT
+# managing the whole config. Windows Terminal owns settings.json (it rewrites it
+# at runtime), so we only patch one profiles.list entry with a stable GUID.
+# Everything else is left untouched.
+#
+# This complements run_once_setup-windows-terminal.ps1 (which creates the file
+# only if it is missing): the run_once handles brand-new machines, while this
+# run_onchange keeps the Copilot SSH profile configured on machines that already
+# had Windows Terminal settings. The target host is embedded literally below so
+# chezmoi's run-onchange content hash changes whenever the host changes.
+#
+# Copilot SSH host: {{ .copilotSshHost }}
+$ErrorActionPreference = "Stop"
+
+$modulePath = "{{ .chezmoi.sourceDir }}\dot_config\powershell\modules\DotfilesHelpers"
+if (Test-Path $modulePath) {
+    Import-Module $modulePath -Force -DisableNameChecking
+}
+else {
+    Write-Error "DotfilesHelpers module not found at: $modulePath"
+    exit 1
+}
+
+Write-Host "Setting Windows Terminal Copilot SSH profile..." -ForegroundColor Cyan
+$copilotSshHost = (@'
+{{ .copilotSshHost }}
+'@).Trim()
+$results = Set-WindowsTerminalCopilotProfile -HostName $copilotSshHost
+
+if (-not $results) {
+    Write-Host "[SKIP] No Windows Terminal settings found to update" -ForegroundColor Yellow
+}
+# {{ end }}

--- a/home/dot_config/fastfetch/executable_status.sh
+++ b/home/dot_config/fastfetch/executable_status.sh
@@ -16,6 +16,12 @@
 # module entirely when it prints nothing, so a section with nothing to
 # report simply disappears.
 #
+# Relative times ("ran 5m ago", "next in 20m") are NOT baked into the cache
+# — that would freeze them until the next refresh. The collectors store
+# absolute epoch tokens (@ago:<epoch>@ / @in:<epoch>@) and the section
+# commands expand them against the current clock on every fastfetch run,
+# using bash builtins only (no forks).
+#
 # Usage: status.sh <section|command>
 #   updates            Print cached "updates available" line (may be empty)
 #   reboot             Print cached "reboot required" line (may be empty)
@@ -55,26 +61,63 @@ _epoch_of() {
     stat -c %Y "${1}" 2>/dev/null || stat -f %m "${1}" 2>/dev/null || echo 0
 }
 
-# _reltime SECONDS -> compact human duration (e.g. 45s, 12m, 3h, 2d).
-_reltime() {
+# _fmt_duration SECONDS -> set REL_DURATION to a compact human duration
+# (e.g. 45s, 12m, 3h, 2d). Fork-free so it is cheap on the emit path.
+_fmt_duration() {
     local s="${1}"
     [ "${s}" -lt 0 ] && s=0
     if [ "${s}" -lt 60 ]; then
-        echo "${s}s"
+        REL_DURATION="${s}s"
     elif [ "${s}" -lt 3600 ]; then
-        echo "$((s / 60))m"
+        REL_DURATION="$((s / 60))m"
     elif [ "${s}" -lt 86400 ]; then
-        echo "$((s / 3600))h"
+        REL_DURATION="$((s / 3600))h"
     else
-        echo "$((s / 86400))d"
+        REL_DURATION="$((s / 86400))d"
     fi
+}
+
+# _now -> current epoch seconds (bash 5 builtin when available).
+_now() {
+    if [ -n "${EPOCHSECONDS:-}" ]; then
+        printf '%s\n' "${EPOCHSECONDS}"
+    else
+        date +%s
+    fi
+}
+
+# _render LINE NOW -> print LINE with relative-time tokens expanded:
+#   @ago:<epoch>@  -> "ran 5m ago"   (elapsed since <epoch>)
+#   @in:<epoch>@   -> "next in 20m", or "next due" once <epoch> has passed
+# Unknown or malformed tokens are left untouched.
+_render() {
+    local line="${1}" now="${2}" tail="" pre kind epoch token
+    local re='^(.*)@(ago|in):([0-9]+)@(.*)$'
+    while [[ "${line}" =~ ${re} ]]; do
+        pre="${BASH_REMATCH[1]}"
+        kind="${BASH_REMATCH[2]}"
+        epoch="${BASH_REMATCH[3]}"
+        token=""
+        if [ "${kind}" = "ago" ]; then
+            _fmt_duration "$((now - epoch))"
+            token="ran ${REL_DURATION} ago"
+        elif [ "${epoch}" -gt "${now}" ]; then
+            _fmt_duration "$((epoch - now))"
+            token="next in ${REL_DURATION}"
+        else
+            token="next due"
+        fi
+        tail="${token}${BASH_REMATCH[4]}${tail}"
+        line="${pre}"
+    done
+    printf '%s%s\n' "${line}" "${tail}"
 }
 
 # _is_stale -> 0 (true) when the cache is missing or older than the TTL.
 _is_stale() {
     [ -f "${STAMP}" ] || return 0
     local now stamp_epoch
-    now="$(date +%s)"
+    now="$(_now)"
     stamp_epoch="$(_epoch_of "${STAMP}")"
     [ "$((now - stamp_epoch))" -ge "${TTL}" ]
 }
@@ -90,15 +133,26 @@ _spawn_refresh() {
     fi
 }
 
-# _emit SECTION -> print the cached section and trigger a background refresh
-# when the cache is stale.
+# _emit SECTION -> print the cached section (with relative-time tokens
+# expanded against the current clock) and trigger a background refresh when
+# the cache is stale.
 _emit() {
     [ "${FASTFETCH_STATUS_DISABLE:-0}" = "1" ] && return 0
     if _is_stale; then
         _spawn_refresh
     fi
     local file="${CACHE_DIR}/${1}"
-    [ -f "${file}" ] && cat "${file}"
+    [ -f "${file}" ] || return 0
+
+    local now="" line
+    while IFS= read -r line || [ -n "${line}" ]; do
+        if [[ "${line}" == *@* ]]; then
+            [ -n "${now}" ] || now="$(_now)"
+            _render "${line}" "${now}"
+        else
+            printf '%s\n' "${line}"
+        fi
+    done <"${file}"
     return 0
 }
 
@@ -209,12 +263,14 @@ _collect_ansible() {
     result="$(_systemd_prop ansible-pull.service Result)"
     exit_code="$(_systemd_prop ansible-pull.service ExecMainStatus)"
     finished_ts="$(_systemd_prop ansible-pull.service InactiveEnterTimestamp)"
-    now="$(date +%s)"
+    now="$(_now)"
 
+    # Relative times are stored as absolute epoch tokens and rendered on
+    # every emit, so a cached line never shows a frozen "ran 29s ago".
     if [ -n "${finished_ts}" ]; then
         local finished_epoch
         finished_epoch="$(date -d "${finished_ts}" +%s 2>/dev/null || echo 0)"
-        [ "${finished_epoch}" -gt 0 ] && ran="ran $(_reltime "$((now - finished_epoch))") ago"
+        [ "${finished_epoch}" -gt 0 ] && ran="@ago:${finished_epoch}@"
     fi
 
     # Next scheduled run from the timer (microseconds since epoch).
@@ -223,7 +279,7 @@ _collect_ansible() {
     next_us="${next_us//[!0-9]/}"
     if [ -n "${next_us}" ] && [ "${next_us}" -gt 0 ]; then
         next_epoch=$((next_us / 1000000))
-        [ "${next_epoch}" -gt "${now}" ] && next="next in $(_reltime "$((next_epoch - now))")"
+        [ "${next_epoch}" -gt "${now}" ] && next="@in:${next_epoch}@"
     fi
 
     local head tail="" part
@@ -267,7 +323,7 @@ _refresh() {
             mkdir "${LOCK_DIR}" 2>/dev/null || return 0
         else
             local now lock_epoch
-            now="$(date +%s)"
+            now="$(_now)"
             lock_epoch="$(_epoch_of "${LOCK_DIR}")"
             if [ "$((now - lock_epoch))" -gt 600 ]; then
                 rmdir "${LOCK_DIR}" 2>/dev/null || true
@@ -291,7 +347,7 @@ _refresh() {
 }
 
 _usage() {
-    sed -n '2,40p' "${0}" | sed 's/^# \{0,1\}//'
+    awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${0}"
 }
 
 # --- dispatch ---------------------------------------------------------------

--- a/home/dot_config/fastfetch/executable_status.sh
+++ b/home/dot_config/fastfetch/executable_status.sh
@@ -19,8 +19,10 @@
 # Relative times ("ran 5m ago", "next in 20m") are NOT baked into the cache
 # — that would freeze them until the next refresh. The collectors store
 # absolute epoch tokens (@ago:<epoch>@ / @in:<epoch>@) and the section
-# commands expand them against the current clock on every fastfetch run,
-# using bash builtins only (no forks).
+# commands expand them against the current clock on every fastfetch run.
+# Expansion itself is pure shell arithmetic; reading the clock uses the
+# EPOCHSECONDS builtin on bash >= 5.0 and falls back to one `date` call on
+# older bash, so the emit path costs at most a single fork.
 #
 # Usage: status.sh <section|command>
 #   updates            Print cached "updates available" line (may be empty)
@@ -77,7 +79,8 @@ _fmt_duration() {
     fi
 }
 
-# _now -> current epoch seconds (bash 5 builtin when available).
+# _now -> current epoch seconds. Uses the EPOCHSECONDS builtin on bash >= 5.0
+# and falls back to a single `date` fork on older bash.
 _now() {
     if [ -n "${EPOCHSECONDS:-}" ]; then
         printf '%s\n' "${EPOCHSECONDS}"

--- a/home/dot_config/fish/functions/copilot_ssh.fish
+++ b/home/dot_config/fish/functions/copilot_ssh.fish
@@ -30,6 +30,7 @@ function copilot_ssh --description "SSH with COPILOT_GITHUB_TOKEN and GH_TOKEN f
     #   COPILOT_SSH_PREFLIGHT_TIMEOUT  TCP probe timeout in seconds (default 3)
     #   COPILOT_SSH_START_TIMEOUT      Wait for SSH after `az vm start` (def. 180)
     #   COPILOT_SSH_ASSUME_YES=1       Start a stopped VM without asking
+    #   COPILOT_SSH_ASSUME_NO=1        Never start a VM, even on a TTY
 
     if contains -- -h $argv; or contains -- --help $argv
         echo "Usage: copilot_ssh [ssh options...] <host>"
@@ -171,6 +172,7 @@ end
 
 function _copilot_ssh_confirm --description "Ask a yes/no question; always no when non-interactive" --argument-names prompt
     test "$COPILOT_SSH_ASSUME_YES" = 1; and return 0
+    test "$COPILOT_SSH_ASSUME_NO" = 1; and return 1
     isatty stdin; or return 1
     read -l -P "$prompt [y/N] " reply
     or return 1
@@ -183,9 +185,16 @@ function _copilot_ssh_wait_for_ssh --description "Poll an SSH port until it answ
 
     printf 'copilot_ssh: waiting for %s:%s to accept connections' $host $port >&2
     while test $waited -lt $limit
-        if _copilot_ssh_tcp_probe $host $port 3
-            printf ' up\n' >&2
-            return 0
+        _copilot_ssh_tcp_probe $host $port 3
+        switch $status
+            case 0
+                printf ' up\n' >&2
+                return 0
+            case 2
+                # No probe tool available: don't spin for the whole timeout,
+                # let ssh report the real state instead.
+                printf ' (cannot probe)\n' >&2
+                return 0
         end
         printf '.' >&2
         sleep 5

--- a/home/dot_config/fish/functions/copilot_ssh.fish
+++ b/home/dot_config/fish/functions/copilot_ssh.fish
@@ -18,11 +18,28 @@ function copilot_ssh --description "SSH with COPILOT_GITHUB_TOKEN and GH_TOKEN f
     #     COPILOT_GITHUB_TOKEN; GH_TOKEN is optional (forwarded if present).
     #
     # Usage: copilot_ssh [ssh options...] <host>   (e.g. copilot_ssh svldev)
+    #
+    # Pre-flight: before unlocking 1Password, a short TCP probe checks that the
+    # host's SSH port answers, so an unreachable host fails in ~3s instead of
+    # hanging. When the probe fails and the Azure CLI is installed, the VM is
+    # looked up by name (`az vm list -d`); if it is stopped/deallocated you are
+    # offered to start it and the connection continues once the port is up.
+    #
+    # Environment:
+    #   COPILOT_SSH_SKIP_PREFLIGHT=1   Skip the reachability probe entirely
+    #   COPILOT_SSH_PREFLIGHT_TIMEOUT  TCP probe timeout in seconds (default 3)
+    #   COPILOT_SSH_START_TIMEOUT      Wait for SSH after `az vm start` (def. 180)
+    #   COPILOT_SSH_ASSUME_YES=1       Start a stopped VM without asking
 
     if contains -- -h $argv; or contains -- --help $argv
         echo "Usage: copilot_ssh [ssh options...] <host>"
         echo "SSH with COPILOT_GITHUB_TOKEN (and GH_TOKEN) forwarded from a 1Password Environment."
         return 0
+    end
+
+    # Fail fast on an unreachable host before unlocking 1Password.
+    if not _copilot_ssh_preflight $argv
+        return 1
     end
 
     if not command -q op
@@ -78,3 +95,178 @@ end
 
 # Completions: delegate to ssh's own completions for host/option arguments.
 complete -c copilot_ssh -w ssh
+
+# --- pre-flight reachability helpers ---------------------------------------
+# Defined alongside copilot_ssh: fish sources this whole file when it autoloads
+# copilot_ssh, so these helpers come along with it.
+
+function _copilot_ssh_tcp_probe --description "TCP probe: 0 open, 1 closed, 2 undetermined" --argument-names host port timeout_s
+    if command -q nc
+        command nc -z -w $timeout_s $host $port >/dev/null 2>&1
+        return $status
+    end
+    if command -q timeout; and command -q bash
+        # /dev/tcp is a bash feature; run it in a child process.
+        command timeout $timeout_s bash -c "exec 3<>/dev/tcp/$host/$port" >/dev/null 2>&1
+        return $status
+    end
+    return 2
+end
+
+function _copilot_ssh_resolve --description "Print 'hostname port' as ssh resolves it for the given args"
+    set -l config (command ssh -G $argv 2>/dev/null)
+    or return 0
+    set -l host ""
+    set -l port ""
+    for line in $config
+        set -l parts (string split -m 1 ' ' -- $line)
+        if test (count $parts) -lt 2
+            continue
+        end
+        switch $parts[1]
+            case hostname
+                set host $parts[2]
+            case port
+                set port $parts[2]
+        end
+    end
+    if test -z "$host"
+        return 0
+    end
+    test -n "$port"; or set port 22
+    echo "$host $port"
+end
+
+function _copilot_ssh_az_lookup --description "Print 'name resourceGroup powerState' for Azure VMs matching a host" --argument-names host
+    # Match the VM name against the host and its short form
+    # (vm01.example.com -> vm01), then fall back to the VM's public/private IPs.
+    set -l short (string split -m 1 '.' -- $host)[1]
+    set -l lhost (string lower -- $host)
+    set -l lshort (string lower -- $short)
+
+    set -l rows (az vm list -d --only-show-errors -o tsv \
+        --query '[].[name,resourceGroup,powerState,publicIps,privateIps]' 2>/dev/null)
+    or return 0
+
+    for row in $rows
+        set -l cols (string split \t -- $row)
+        if test (count $cols) -lt 3
+            continue
+        end
+        set -l name (string lower -- $cols[1])
+        if test "$name" = "$lhost" -o "$name" = "$lshort"
+            echo "$cols[1]"\t"$cols[2]"\t"$cols[3]"
+            continue
+        end
+        # publicIps/privateIps may hold a comma-separated list.
+        set -l ips
+        for field in $cols[4..-1]
+            set -a ips (string trim -- (string split ',' -- $field))
+        end
+        if contains -- $host $ips
+            echo "$cols[1]"\t"$cols[2]"\t"$cols[3]"
+        end
+    end
+end
+
+function _copilot_ssh_confirm --description "Ask a yes/no question; always no when non-interactive" --argument-names prompt
+    test "$COPILOT_SSH_ASSUME_YES" = 1; and return 0
+    isatty stdin; or return 1
+    read -l -P "$prompt [y/N] " reply
+    or return 1
+    string match -qir '^(y|yes)$' -- $reply
+end
+
+function _copilot_ssh_wait_for_ssh --description "Poll an SSH port until it answers" --argument-names host port
+    set -l limit (test -n "$COPILOT_SSH_START_TIMEOUT"; and echo $COPILOT_SSH_START_TIMEOUT; or echo 180)
+    set -l waited 0
+
+    printf 'copilot_ssh: waiting for %s:%s to accept connections' $host $port >&2
+    while test $waited -lt $limit
+        if _copilot_ssh_tcp_probe $host $port 3
+            printf ' up\n' >&2
+            return 0
+        end
+        printf '.' >&2
+        sleep 5
+        set waited (math $waited + 5)
+    end
+    printf ' timed out\n' >&2
+    return 1
+end
+
+function _copilot_ssh_recover_azure --description "Try to bring a stopped Azure VM back up" --argument-names host port
+    if not command -q az
+        echo "copilot_ssh: install the Azure CLI ('az') to check whether the VM is stopped." >&2
+        return 1
+    end
+
+    echo "copilot_ssh: looking up '$host' in Azure..." >&2
+    set -l matches (_copilot_ssh_az_lookup $host)
+
+    if test (count $matches) -eq 0
+        echo "copilot_ssh: no Azure VM matches '$host' in the current subscription." >&2
+        echo "            Check 'az account show' / 'az login', or the host may not be an Azure VM." >&2
+        return 1
+    end
+
+    if test (count $matches) -gt 1
+        echo "copilot_ssh: several Azure VMs match '$host'; not guessing:" >&2
+        for match in $matches
+            set -l cols (string split \t -- $match)
+            echo "            - $cols[1] (resource group $cols[2], $cols[3])" >&2
+        end
+        return 1
+    end
+
+    set -l cols (string split \t -- $matches[1])
+    set -l vm_name $cols[1]
+    set -l vm_rg $cols[2]
+    set -l vm_state $cols[3]
+
+    if string match -q '*running*' -- $vm_state
+        echo "copilot_ssh: Azure VM '$vm_name' is running but $host:$port is unreachable." >&2
+        echo "            Check the NSG rules, the VPN/network path or sshd on the VM." >&2
+        return 1
+    end
+
+    echo "copilot_ssh: Azure VM '$vm_name' (resource group $vm_rg) is $vm_state." >&2
+    if not _copilot_ssh_confirm "copilot_ssh: start it now?"
+        echo "copilot_ssh: not starting the VM; aborting." >&2
+        return 1
+    end
+
+    if not az vm start --only-show-errors -g $vm_rg -n $vm_name >/dev/null
+        echo "copilot_ssh: 'az vm start' failed for '$vm_name'." >&2
+        return 1
+    end
+    echo "copilot_ssh: started '$vm_name'." >&2
+
+    _copilot_ssh_wait_for_ssh $host $port
+end
+
+function _copilot_ssh_preflight --description "Fail fast when the SSH host is unreachable"
+    if test "$COPILOT_SSH_SKIP_PREFLIGHT" = 1
+        return 0
+    end
+
+    set -l resolved (_copilot_ssh_resolve $argv)
+    # No destination resolved (e.g. ssh could not parse the args): skip the
+    # probe rather than blocking a connection that might still work.
+    if test (count $resolved) -eq 0
+        return 0
+    end
+    set -l parts (string split ' ' -- $resolved[1])
+    set -l host $parts[1]
+    set -l port $parts[2]
+
+    set -l timeout_s (test -n "$COPILOT_SSH_PREFLIGHT_TIMEOUT"; and echo $COPILOT_SSH_PREFLIGHT_TIMEOUT; or echo 3)
+    _copilot_ssh_tcp_probe $host $port $timeout_s
+    switch $status
+        case 0 2 # reachable, or no probe tool available: let ssh decide
+            return 0
+    end
+
+    echo "copilot_ssh: $host:$port is not reachable." >&2
+    _copilot_ssh_recover_azure $host $port
+end

--- a/home/dot_config/powershell/modules/DotfilesHelpers/DotfilesHelpers.psd1
+++ b/home/dot_config/powershell/modules/DotfilesHelpers/DotfilesHelpers.psd1
@@ -49,6 +49,7 @@
 
         # Windows Terminal settings
         'Set-WindowsTerminalDefaultProfile'
+        'Set-WindowsTerminalCopilotProfile'
 
         # Office 365 mail aliases
         'New-MailAlias'

--- a/home/dot_config/powershell/modules/DotfilesHelpers/Public/CopilotSsh.ps1
+++ b/home/dot_config/powershell/modules/DotfilesHelpers/Public/CopilotSsh.ps1
@@ -86,6 +86,291 @@ function Get-DotfilesSshHost {
     return @($result | Sort-Object -Unique)
 }
 
+function ConvertFrom-SshConfigOutput {
+    <#
+    .SYNOPSIS
+        Extract the effective hostname/port from `ssh -G` output.
+    .DESCRIPTION
+        `ssh -G <args>` prints the fully resolved client configuration for a
+        destination (honouring ~/.ssh/config aliases, HostName/Port overrides
+        and -o flags) without connecting. This parses the two keys the
+        pre-flight probe needs. Returns $null when no hostname was resolved,
+        which callers treat as "skip the probe".
+    .PARAMETER Lines
+        The raw lines emitted by `ssh -G`.
+    #>
+    [CmdletBinding()]
+    param([string[]]$Lines)
+
+    $hostName = $null
+    $port = $null
+    foreach ($line in $Lines) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        $parts = $line.Trim() -split '\s+', 2
+        if ($parts.Count -lt 2) { continue }
+        switch ($parts[0].ToLowerInvariant()) {
+            'hostname' { $hostName = $parts[1].Trim() }
+            'port' { $port = $parts[1].Trim() }
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($hostName)) { return $null }
+    $portValue = 22
+    if (-not [string]::IsNullOrWhiteSpace($port)) { [void][int]::TryParse($port, [ref]$portValue) }
+    return [PSCustomObject]@{ HostName = $hostName; Port = $portValue }
+}
+
+function Select-CopilotSshAzureVm {
+    <#
+    .SYNOPSIS
+        Pick the Azure VMs that correspond to an SSH host.
+    .DESCRIPTION
+        Matches the VM name against the host and against its short form
+        (vm01.example.com -> vm01), then falls back to matching the host
+        against the VM's public/private IP addresses. Pure string logic so it
+        is testable without the Azure CLI.
+    .PARAMETER Row
+        TSV rows as produced by
+        `az vm list -d -o tsv --query '[].[name,resourceGroup,powerState,publicIps,privateIps]'`.
+    .PARAMETER HostName
+        The resolved SSH host (name, FQDN or IP address).
+    #>
+    [CmdletBinding()]
+    param(
+        [string[]]$Row,
+        [string]$HostName
+    )
+
+    $short = $HostName.Split('.')[0]
+    $results = @()
+
+    foreach ($line in $Row) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        $cols = $line -split "`t"
+        if ($cols.Count -lt 3) { continue }
+
+        $name = $cols[0].Trim()
+        $matched = ($name -ieq $HostName) -or ($name -ieq $short)
+
+        if (-not $matched -and $cols.Count -ge 4) {
+            # publicIps/privateIps may hold a comma-separated list.
+            $ips = @()
+            foreach ($field in $cols[3..($cols.Count - 1)]) {
+                $ips += ($field -split ',' | ForEach-Object { $_.Trim() })
+            }
+            $matched = $ips -contains $HostName
+        }
+
+        if ($matched) {
+            $results += [PSCustomObject]@{
+                Name          = $name
+                ResourceGroup = $cols[1].Trim()
+                PowerState    = $cols[2].Trim()
+            }
+        }
+    }
+
+    return @($results)
+}
+
+function Test-CopilotSshPort {
+    <#
+    .SYNOPSIS
+        Fast TCP reachability probe for an SSH endpoint.
+    .DESCRIPTION
+        Opens a TCP connection with a hard timeout so an unreachable host fails
+        in seconds instead of hanging on ssh's own connect timeout. DNS failures
+        and refused connections both return $false.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$HostName,
+        [int]$Port = 22,
+        [int]$TimeoutSeconds = 3
+    )
+
+    $client = New-Object System.Net.Sockets.TcpClient
+    try {
+        $async = $client.BeginConnect($HostName, $Port, $null, $null)
+        if (-not $async.AsyncWaitHandle.WaitOne([TimeSpan]::FromSeconds($TimeoutSeconds))) {
+            return $false
+        }
+        $client.EndConnect($async)
+        return $true
+    }
+    catch {
+        return $false
+    }
+    finally {
+        $client.Close()
+    }
+}
+
+function Get-CopilotSshConfirmation {
+    <#
+    .SYNOPSIS
+        Ask a yes/no question, defaulting to "no" when nobody can answer.
+    .DESCRIPTION
+        Non-interactive sessions (redirected stdin, no user interaction) always
+        answer "no" so scripts never block on the prompt. Set
+        COPILOT_SSH_ASSUME_YES=1 to answer "yes" automatically.
+    #>
+    [CmdletBinding()]
+    param([string]$Message)
+
+    if ($env:COPILOT_SSH_ASSUME_YES -eq '1') { return $true }
+    if ($env:COPILOT_SSH_ASSUME_NO -eq '1') { return $false }
+    if (-not [Environment]::UserInteractive) { return $false }
+    if ([Console]::IsInputRedirected) { return $false }
+
+    $answer = Read-Host "$Message [y/N]"
+    return ($answer -match '^\s*(y|yes)\s*$')
+}
+
+function Wait-CopilotSshPort {
+    <#
+    .SYNOPSIS
+        Poll an SSH endpoint until it accepts connections (or time out).
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$HostName,
+        [int]$Port,
+        [int]$TimeoutSeconds = 180
+    )
+
+    $waited = 0
+    Write-Host "copilot-ssh: waiting for ${HostName}:${Port} to accept connections" -NoNewline
+    while ($waited -lt $TimeoutSeconds) {
+        if (Test-CopilotSshPort -HostName $HostName -Port $Port -TimeoutSeconds 3) {
+            Write-Host ' up'
+            return $true
+        }
+        Write-Host '.' -NoNewline
+        Start-Sleep -Seconds 5
+        $waited += 5
+    }
+    Write-Host ' timed out'
+    return $false
+}
+
+function Invoke-CopilotSshAzureRecovery {
+    <#
+    .SYNOPSIS
+        Try to bring a stopped Azure VM back up after a failed reachability probe.
+    .DESCRIPTION
+        Looks the host up with `az vm list -d`. When the VM is stopped or
+        deallocated the user is offered to start it, and the connection resumes
+        once the SSH port answers. Returns $true only when the host became
+        reachable.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$HostName,
+        [int]$Port
+    )
+
+    if (-not (Get-Command az -CommandType Application -ErrorAction SilentlyContinue)) {
+        Write-Host "copilot-ssh: install the Azure CLI ('az') to check whether the VM is stopped."
+        return $false
+    }
+
+    Write-Host "copilot-ssh: looking up '$HostName' in Azure..."
+    $rows = @()
+    try {
+        $rows = @(& az vm list -d --only-show-errors -o tsv `
+                --query '[].[name,resourceGroup,powerState,publicIps,privateIps]' 2>$null)
+    }
+    catch {
+        $rows = @()
+    }
+
+    $vmMatches = @(Select-CopilotSshAzureVm -Row $rows -HostName $HostName)
+
+    if ($vmMatches.Count -eq 0) {
+        Write-Host "copilot-ssh: no Azure VM matches '$HostName' in the current subscription."
+        Write-Host "            Check 'az account show' / 'az login', or the host may not be an Azure VM."
+        return $false
+    }
+
+    if ($vmMatches.Count -gt 1) {
+        Write-Host "copilot-ssh: several Azure VMs match '$HostName'; not guessing:"
+        foreach ($vm in $vmMatches) {
+            Write-Host ("            - {0} (resource group {1}, {2})" -f $vm.Name, $vm.ResourceGroup, $vm.PowerState)
+        }
+        return $false
+    }
+
+    $vm = $vmMatches[0]
+    if ($vm.PowerState -match 'running') {
+        Write-Host "copilot-ssh: Azure VM '$($vm.Name)' is running but ${HostName}:${Port} is unreachable."
+        Write-Host '            Check the NSG rules, the VPN/network path or sshd on the VM.'
+        return $false
+    }
+
+    $state = if ([string]::IsNullOrWhiteSpace($vm.PowerState)) { 'in an unknown state' } else { $vm.PowerState }
+    Write-Host "copilot-ssh: Azure VM '$($vm.Name)' (resource group $($vm.ResourceGroup)) is $state."
+    if (-not (Get-CopilotSshConfirmation -Message 'copilot-ssh: start it now?')) {
+        Write-Host 'copilot-ssh: not starting the VM; aborting.'
+        return $false
+    }
+
+    & az vm start --only-show-errors -g $vm.ResourceGroup -n $vm.Name | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "copilot-ssh: 'az vm start' failed for '$($vm.Name)'."
+        return $false
+    }
+    Write-Host "copilot-ssh: started '$($vm.Name)'."
+
+    $startTimeout = 180
+    if ($env:COPILOT_SSH_START_TIMEOUT) { [void][int]::TryParse($env:COPILOT_SSH_START_TIMEOUT, [ref]$startTimeout) }
+    return (Wait-CopilotSshPort -HostName $HostName -Port $Port -TimeoutSeconds $startTimeout)
+}
+
+function Test-CopilotSshPreflight {
+    <#
+    .SYNOPSIS
+        Fail fast when the SSH host is unreachable.
+    .DESCRIPTION
+        Resolves the destination with `ssh -G` and probes its TCP port. Returns
+        $true when the host answers, when the check could not run (no
+        destination resolved), or when the Azure recovery brought the VM back
+        up; $false when the connection should be abandoned.
+
+        Set COPILOT_SSH_SKIP_PREFLIGHT=1 to bypass, or
+        COPILOT_SSH_PREFLIGHT_TIMEOUT to change the 3 second probe timeout.
+    .PARAMETER SshArgument
+        The arguments that will be passed to ssh (destination included).
+    #>
+    [CmdletBinding()]
+    param([string[]]$SshArgument)
+
+    if ($env:COPILOT_SSH_SKIP_PREFLIGHT -eq '1') { return $true }
+
+    $config = @()
+    try {
+        $config = @(& ssh -G @SshArgument 2>$null)
+    }
+    catch {
+        $config = @()
+    }
+
+    $endpoint = ConvertFrom-SshConfigOutput -Lines $config
+    # No destination resolved (e.g. ssh could not parse the args): skip the
+    # probe rather than blocking a connection that might still work.
+    if ($null -eq $endpoint) { return $true }
+
+    $timeout = 3
+    if ($env:COPILOT_SSH_PREFLIGHT_TIMEOUT) { [void][int]::TryParse($env:COPILOT_SSH_PREFLIGHT_TIMEOUT, [ref]$timeout) }
+
+    if (Test-CopilotSshPort -HostName $endpoint.HostName -Port $endpoint.Port -TimeoutSeconds $timeout) {
+        return $true
+    }
+
+    Write-Host "copilot-ssh: $($endpoint.HostName):$($endpoint.Port) is not reachable."
+    return (Invoke-CopilotSshAzureRecovery -HostName $endpoint.HostName -Port $endpoint.Port)
+}
+
 function Connect-CopilotSsh {
     <#
     .SYNOPSIS
@@ -178,6 +463,14 @@ function Connect-CopilotSsh {
     # as it is under GitHub Actions' `shell: pwsh`.
     if (-not (Get-Command ssh -CommandType Application -ErrorAction SilentlyContinue)) {
         Write-Error "copilot-ssh: 'ssh' (OpenSSH client) was not found on PATH. Install the OpenSSH client and try again." -ErrorAction Continue
+        return
+    }
+
+    # Reachability pre-flight, before unlocking 1Password: a short TCP probe so
+    # an unreachable host fails in ~3s, with an Azure CLI assisted recovery
+    # (offer to start a stopped VM) when the probe fails.
+    if (-not (Test-CopilotSshPreflight -SshArgument $passthrough)) {
+        Write-Error "copilot-ssh: aborting; '$HostName' is not reachable." -ErrorAction Continue
         return
     }
 

--- a/home/dot_config/powershell/modules/DotfilesHelpers/Public/WindowsTerminal.ps1
+++ b/home/dot_config/powershell/modules/DotfilesHelpers/Public/WindowsTerminal.ps1
@@ -440,8 +440,23 @@ function Set-WindowsTerminalCopilotProfile {
                 $list = @($json.profiles.list)
             }
 
-            $copilotProfile = $list | Where-Object { $null -ne $_ -and $_.PSObject.Properties['guid'] -and $_.guid -eq $profileGuid } | Select-Object -First 1
+            $existing = @($list | Where-Object { $null -ne $_ -and $_.PSObject.Properties['guid'] -and $_.guid -eq $profileGuid })
+            $copilotProfile = $existing | Select-Object -First 1
             $changed = $false
+
+            # Windows Terminal ignores all but one profile per GUID, so collapse
+            # any duplicates left behind by manual edits into the first entry.
+            if ($existing.Count -gt 1) {
+                $duplicates = $existing | Select-Object -Skip 1
+                $list = @($list | Where-Object { -not ($duplicates -contains $_) })
+                if ($null -eq $listProperty) {
+                    $json.profiles | Add-Member -NotePropertyName list -NotePropertyValue $list -Force
+                }
+                else {
+                    $json.profiles.list = $list
+                }
+                $changed = $true
+            }
 
             if (-not $copilotProfile) {
                 $copilotProfile = [pscustomobject]@{

--- a/home/dot_config/powershell/modules/DotfilesHelpers/Public/WindowsTerminal.ps1
+++ b/home/dot_config/powershell/modules/DotfilesHelpers/Public/WindowsTerminal.ps1
@@ -363,6 +363,155 @@ function Set-WindowsTerminalDefaultProfile {
     return $results
 }
 
+function Set-WindowsTerminalCopilotProfile {
+    <#
+    .SYNOPSIS
+    Adds or updates a Windows Terminal profile for the copilot-ssh helper.
+
+    .DESCRIPTION
+    Parses each existing Windows Terminal settings.json and ensures
+    profiles.list contains one profile that opens PowerShell and runs the
+    copilot-ssh alias for the configured host. The profile GUID is a fixed UUID
+    v5 derived from the dotfiles repository URL and the logical profile purpose,
+    not from the host, so changing hosts updates the same profile instead of
+    creating duplicates.
+
+    Files that do not exist are skipped; initial settings.json creation is
+    handled by run_once_setup-windows-terminal.ps1.
+
+    .PARAMETER HostName
+    The SSH host passed to copilot-ssh. The SshHost alias is also accepted.
+
+    .PARAMETER ProfileName
+    The Windows Terminal display name. Defaults to "Copilot SSH (<HostName>)".
+
+    .PARAMETER SettingsPath
+    One or more settings.json paths. Defaults to the known Windows Terminal
+    locations (Store, Preview, and unpackaged).
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Matches sibling Windows Terminal helpers that print visible status after a change.')]
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)]
+        [Alias('SshHost')]
+        [ValidateNotNullOrEmpty()]
+        [string]$HostName,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$ProfileName,
+
+        [Parameter()]
+        [string[]]$SettingsPath
+    )
+
+    if (-not $SettingsPath) {
+        $SettingsPath = Get-WindowsTerminalSettingsPath
+    }
+
+    if (-not $PSBoundParameters.ContainsKey('ProfileName')) {
+        $ProfileName = "Copilot SSH ($HostName)"
+    }
+
+    $profileGuid = '{2fe4cbf1-8986-519c-9aa1-8f5a543c440d}'
+    $quotedHost = $HostName -replace "'", "''"
+    $commandLine = "pwsh -NoExit -NoLogo -Command `"copilot-ssh '$quotedHost'`""
+    $results = @()
+
+    foreach ($path in $SettingsPath) {
+        if (-not (Test-Path -LiteralPath $path)) {
+            Write-Verbose "Windows Terminal settings not found at: $path (skipping)"
+            continue
+        }
+
+        try {
+            $json = Read-WindowsTerminalSettings -Path $path
+
+            if ($null -eq $json.profiles) {
+                $json | Add-Member -NotePropertyName profiles -NotePropertyValue ([pscustomobject]@{}) -Force
+            }
+
+            $listProperty = $json.profiles.PSObject.Properties['list']
+            if ($null -eq $listProperty -or $null -eq $json.profiles.list) {
+                $list = @()
+            }
+            else {
+                $list = @($json.profiles.list)
+            }
+
+            $copilotProfile = $list | Where-Object { $null -ne $_ -and $_.PSObject.Properties['guid'] -and $_.guid -eq $profileGuid } | Select-Object -First 1
+            $changed = $false
+
+            if (-not $copilotProfile) {
+                $copilotProfile = [pscustomobject]@{
+                    guid        = $profileGuid
+                    hidden      = $false
+                    name        = $ProfileName
+                    commandline = $commandLine
+                }
+                $list += $copilotProfile
+                if ($null -eq $listProperty) {
+                    $json.profiles | Add-Member -NotePropertyName list -NotePropertyValue $list -Force
+                }
+                else {
+                    $json.profiles.list = $list
+                }
+                $changed = $true
+            }
+            else {
+                if ($null -eq $copilotProfile.PSObject.Properties['hidden']) {
+                    $copilotProfile | Add-Member -NotePropertyName hidden -NotePropertyValue $false -Force
+                    $changed = $true
+                }
+                elseif ($copilotProfile.hidden -ne $false) {
+                    $copilotProfile.hidden = $false
+                    $changed = $true
+                }
+
+                if ($null -eq $copilotProfile.PSObject.Properties['name']) {
+                    $copilotProfile | Add-Member -NotePropertyName name -NotePropertyValue $ProfileName -Force
+                    $changed = $true
+                }
+                elseif ($copilotProfile.name -ne $ProfileName) {
+                    $copilotProfile.name = $ProfileName
+                    $changed = $true
+                }
+
+                if ($null -eq $copilotProfile.PSObject.Properties['commandline']) {
+                    $copilotProfile | Add-Member -NotePropertyName commandline -NotePropertyValue $commandLine -Force
+                    $changed = $true
+                }
+                elseif ($copilotProfile.commandline -ne $commandLine) {
+                    $copilotProfile.commandline = $commandLine
+                    $changed = $true
+                }
+            }
+
+            if (-not $changed) {
+                Write-Verbose "Copilot SSH profile already set for '$HostName' at: $path"
+                $results += [pscustomobject]@{ Path = $path; Changed = $false; Status = 'AlreadySet'; Guid = $profileGuid; ProfileName = $ProfileName; CommandLine = $commandLine }
+                continue
+            }
+
+            if ($PSCmdlet.ShouldProcess($path, "Set Copilot SSH profile '$ProfileName'")) {
+                Save-WindowsTerminalSettings -Path $path -Settings $json
+                Write-Host "[OK] Set Windows Terminal Copilot SSH profile '$ProfileName' at: $path" -ForegroundColor Green
+                $results += [pscustomobject]@{ Path = $path; Changed = $true; Status = 'Updated'; Guid = $profileGuid; ProfileName = $ProfileName; CommandLine = $commandLine }
+            }
+            else {
+                $results += [pscustomobject]@{ Path = $path; Changed = $false; Status = 'WhatIf'; Guid = $profileGuid; ProfileName = $ProfileName; CommandLine = $commandLine }
+            }
+        }
+        catch {
+            Write-Warning "Could not update Windows Terminal Copilot SSH profile at '$path': $_"
+            $results += [pscustomobject]@{ Path = $path; Changed = $false; Status = 'Error'; Guid = $profileGuid; ProfileName = $ProfileName; CommandLine = $commandLine }
+        }
+    }
+
+    return $results
+}
+
 # SIG # Begin signature block
 # MIIfEQYJKoZIhvcNAQcCoIIfAjCCHv4CAQExDzANBglghkgBZQMEAgEFADB5Bgor
 # BgEEAYI3AgEEoGswaTA0BgorBgEEAYI3AgEeMCYCAwEAAAQQH8w7YFlLCE63JNLG

--- a/home/dot_config/powershell/profile.ps1
+++ b/home/dot_config/powershell/profile.ps1
@@ -19,6 +19,34 @@ if (Test-Path $chezmoiConfig) {
     . $chezmoiConfig
 }
 
+# Add OneDrive Portable Programs to this PowerShell session without reading
+# the registry on every startup. Persistence is handled by a chezmoi script.
+if ($env:OneDrive) {
+    $portableProgramsPath = Join-Path $env:OneDrive "Portable Programs"
+    $portableProgramsKey = $portableProgramsPath.Trim().Trim('"').TrimEnd('\').ToUpperInvariant()
+    $portableProgramsInPath = $false
+    $currentSessionPath = if ($null -eq $env:Path) { "" } else { $env:Path }
+
+    foreach ($pathEntry in ($currentSessionPath -split ';')) {
+        if ($pathEntry.Trim().Trim('"').TrimEnd('\').ToUpperInvariant() -eq $portableProgramsKey) {
+            $portableProgramsInPath = $true
+            break
+        }
+    }
+
+    if (-not $portableProgramsInPath) {
+        $env:Path = if ([string]::IsNullOrWhiteSpace($currentSessionPath)) {
+            $portableProgramsPath
+        }
+        elseif ($currentSessionPath.EndsWith(';')) {
+            "$currentSessionPath$portableProgramsPath"
+        }
+        else {
+            "$currentSessionPath;$portableProgramsPath"
+        }
+    }
+}
+
 # Set working directory to projects folder if not already there
 # Skip this if running in VS Code to preserve the opened folder location
 if ($ENV:TERM_PROGRAM -ne "vscode") {

--- a/home/dot_config/shell/functions/copilot-ssh.sh
+++ b/home/dot_config/shell/functions/copilot-ssh.sh
@@ -37,6 +37,7 @@
 #   COPILOT_SSH_PREFLIGHT_TIMEOUT  TCP probe timeout in seconds (default 3)
 #   COPILOT_SSH_START_TIMEOUT      Wait for SSH after `az vm start` (default 180)
 #   COPILOT_SSH_ASSUME_YES=1       Start a stopped VM without asking
+#   COPILOT_SSH_ASSUME_NO=1        Never start a VM, even on a TTY
 
 # _copilot_ssh_tcp_probe HOST PORT TIMEOUT -> 0 open, 1 closed, 2 undetermined.
 _copilot_ssh_tcp_probe() {
@@ -97,9 +98,11 @@ _copilot_ssh_az_lookup() {
 
 # _copilot_ssh_confirm PROMPT -> 0 when the user answers yes (non-interactive
 # shells always answer no, so scripts never block on the prompt;
-# COPILOT_SSH_ASSUME_YES=1 answers yes without asking).
+# COPILOT_SSH_ASSUME_YES=1 answers yes and COPILOT_SSH_ASSUME_NO=1 answers no
+# without asking).
 _copilot_ssh_confirm() {
     [ "${COPILOT_SSH_ASSUME_YES:-0}" = "1" ] && return 0
+    [ "${COPILOT_SSH_ASSUME_NO:-0}" = "1" ] && return 1
     [ -t 0 ] || return 1
     local reply=""
     printf '%s [y/N] ' "${1}" >&2
@@ -117,10 +120,20 @@ _copilot_ssh_wait_for_ssh() {
 
     printf 'copilot-ssh: waiting for %s:%s to accept connections' "${host}" "${port}" >&2
     while [ "${waited}" -lt "${limit}" ]; do
-        if _copilot_ssh_tcp_probe "${host}" "${port}" 3; then
+        _copilot_ssh_tcp_probe "${host}" "${port}" 3
+        case $? in
+        0)
             printf ' up\n' >&2
             return 0
-        fi
+            ;;
+        2)
+            # No probe tool available: don't spin for the whole timeout,
+            # let ssh report the real state instead.
+            printf ' (cannot probe)\n' >&2
+            return 0
+            ;;
+        *) ;;
+        esac
         printf '.' >&2
         sleep 5
         waited=$((waited + 5))

--- a/home/dot_config/shell/functions/copilot-ssh.sh
+++ b/home/dot_config/shell/functions/copilot-ssh.sh
@@ -25,12 +25,197 @@
 #
 # If `op` or the Environment ID is unavailable, it falls back to a plain ssh so
 # the command still connects (the tools just won't receive a token).
+#
+# Pre-flight: before unlocking 1Password, a short TCP probe checks that the
+# host's SSH port answers, so an unreachable host fails in ~3s instead of
+# hanging. When the probe fails and the Azure CLI is installed, the VM is
+# looked up by name (`az vm list -d`); if it is stopped/deallocated you are
+# offered to start it and the connection continues once the port is up.
+#
+# Environment:
+#   COPILOT_SSH_SKIP_PREFLIGHT=1   Skip the reachability probe entirely
+#   COPILOT_SSH_PREFLIGHT_TIMEOUT  TCP probe timeout in seconds (default 3)
+#   COPILOT_SSH_START_TIMEOUT      Wait for SSH after `az vm start` (default 180)
+#   COPILOT_SSH_ASSUME_YES=1       Start a stopped VM without asking
+
+# _copilot_ssh_tcp_probe HOST PORT TIMEOUT -> 0 open, 1 closed, 2 undetermined.
+_copilot_ssh_tcp_probe() {
+    local host="${1}" port="${2}" timeout_s="${3}"
+
+    if command -v nc >/dev/null 2>&1; then
+        nc -z -w "${timeout_s}" "${host}" "${port}" >/dev/null 2>&1
+        return $?
+    fi
+
+    if command -v timeout >/dev/null 2>&1 && command -v bash >/dev/null 2>&1; then
+        # /dev/tcp is a bash feature; run it in a child so a build without
+        # net-redirections cannot take down the caller.
+        timeout "${timeout_s}" bash -c "exec 3<>/dev/tcp/${host}/${port}" >/dev/null 2>&1
+        return $?
+    fi
+
+    return 2
+}
+
+# _copilot_ssh_resolve ARGS... -> print "<hostname>\t<port>" as ssh resolves it
+# (honours ~/.ssh/config aliases, HostName/Port overrides and -o flags).
+_copilot_ssh_resolve() {
+    local config
+    config="$(command ssh -G "$@" 2>/dev/null || true)"
+    [ -n "${config}" ] || return 0
+    awk '
+        $1 == "hostname" { host = $2 }
+        $1 == "port"     { port = $2 }
+        END { if (host != "") printf "%s\t%s\n", host, (port == "" ? "22" : port) }
+    ' <<<"${config}"
+}
+
+# _copilot_ssh_az_lookup HOST -> print "name\tresourceGroup\tpowerState" for
+# matching VMs (one per line). Matches the VM name against the host and its
+# short form (vm01.example.com -> vm01), then falls back to matching the host
+# against the VM's public/private IPs.
+_copilot_ssh_az_lookup() {
+    local host="${1}" short="${1%%.*}" vms
+    vms="$(az vm list -d --only-show-errors -o tsv \
+        --query '[].[name,resourceGroup,powerState,publicIps,privateIps]' 2>/dev/null || true)"
+    [ -n "${vms}" ] || return 0
+
+    awk -F'\t' -v host="${host}" -v short="${short}" '
+        BEGIN { lhost = tolower(host); lshort = tolower(short) }
+        {
+            name = tolower($1)
+            if (name == lhost || name == lshort) { print $1 "\t" $2 "\t" $3; next }
+            # publicIps/privateIps may hold a comma-separated list.
+            n = split($4 "," $5, ips, ",")
+            for (i = 1; i <= n; i++) {
+                gsub(/^[ \t]+|[ \t]+$/, "", ips[i])
+                if (ips[i] != "" && ips[i] == host) { print $1 "\t" $2 "\t" $3; next }
+            }
+        }
+    ' <<<"${vms}"
+}
+
+# _copilot_ssh_confirm PROMPT -> 0 when the user answers yes (non-interactive
+# shells always answer no, so scripts never block on the prompt;
+# COPILOT_SSH_ASSUME_YES=1 answers yes without asking).
+_copilot_ssh_confirm() {
+    [ "${COPILOT_SSH_ASSUME_YES:-0}" = "1" ] && return 0
+    [ -t 0 ] || return 1
+    local reply=""
+    printf '%s [y/N] ' "${1}" >&2
+    read -r reply || return 1
+    case "${reply}" in
+    y | Y | yes | YES | Yes) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
+# _copilot_ssh_wait_for_ssh HOST PORT -> poll the SSH port until it answers.
+_copilot_ssh_wait_for_ssh() {
+    local host="${1}" port="${2}" waited=0
+    local limit="${COPILOT_SSH_START_TIMEOUT:-180}"
+
+    printf 'copilot-ssh: waiting for %s:%s to accept connections' "${host}" "${port}" >&2
+    while [ "${waited}" -lt "${limit}" ]; do
+        if _copilot_ssh_tcp_probe "${host}" "${port}" 3; then
+            printf ' up\n' >&2
+            return 0
+        fi
+        printf '.' >&2
+        sleep 5
+        waited=$((waited + 5))
+    done
+    printf ' timed out\n' >&2
+    return 1
+}
+
+# _copilot_ssh_recover_azure HOST PORT -> try to bring an Azure VM back up.
+# Returns 0 when the host is reachable again, 1 otherwise.
+_copilot_ssh_recover_azure() {
+    local host="${1}" port="${2}"
+
+    if ! command -v az >/dev/null 2>&1; then
+        echo "copilot-ssh: install the Azure CLI ('az') to check whether the VM is stopped." >&2
+        return 1
+    fi
+
+    echo "copilot-ssh: looking up '${host}' in Azure..." >&2
+    local matches
+    matches="$(_copilot_ssh_az_lookup "${host}")"
+
+    if [ -z "${matches}" ]; then
+        echo "copilot-ssh: no Azure VM matches '${host}' in the current subscription." >&2
+        echo "            Check 'az account show' / 'az login', or the host may not be an Azure VM." >&2
+        return 1
+    fi
+
+    local match_count
+    match_count="$(wc -l <<<"${matches}")"
+    if [ "${match_count}" -gt 1 ]; then
+        echo "copilot-ssh: several Azure VMs match '${host}'; not guessing:" >&2
+        awk -F'\t' '{ printf "            - %s (resource group %s, %s)\n", $1, $2, $3 }' <<<"${matches}" >&2
+        return 1
+    fi
+
+    local vm_name vm_rg vm_state
+    IFS=$'\t' read -r vm_name vm_rg vm_state <<<"${matches}"
+
+    case "${vm_state}" in
+    *running*)
+        echo "copilot-ssh: Azure VM '${vm_name}' is running but ${host}:${port} is unreachable." >&2
+        echo "            Check the NSG rules, the VPN/network path or sshd on the VM." >&2
+        return 1
+        ;;
+    *) ;;
+    esac
+
+    echo "copilot-ssh: Azure VM '${vm_name}' (resource group ${vm_rg}) is ${vm_state:-in an unknown state}." >&2
+    if ! _copilot_ssh_confirm "copilot-ssh: start it now?"; then
+        echo "copilot-ssh: not starting the VM; aborting." >&2
+        return 1
+    fi
+
+    if ! az vm start --only-show-errors -g "${vm_rg}" -n "${vm_name}" >/dev/null; then
+        echo "copilot-ssh: 'az vm start' failed for '${vm_name}'." >&2
+        return 1
+    fi
+    echo "copilot-ssh: started '${vm_name}'." >&2
+
+    _copilot_ssh_wait_for_ssh "${host}" "${port}"
+}
+
+# _copilot_ssh_preflight ARGS... -> 0 when the host answers (or the check could
+# not run), 1 when the connection should be abandoned.
+_copilot_ssh_preflight() {
+    [ "${COPILOT_SSH_SKIP_PREFLIGHT:-0}" = "1" ] && return 0
+
+    local resolved host port
+    resolved="$(_copilot_ssh_resolve "$@")"
+    # No destination resolved (e.g. `ssh` could not parse the args): skip the
+    # probe rather than blocking a connection that might still work.
+    [ -n "${resolved}" ] || return 0
+    IFS=$'\t' read -r host port <<<"${resolved}"
+
+    _copilot_ssh_tcp_probe "${host}" "${port}" "${COPILOT_SSH_PREFLIGHT_TIMEOUT:-3}"
+    case $? in
+    0) return 0 ;;
+    2) return 0 ;; # no probe tool available; let ssh decide
+    *) ;;
+    esac
+
+    echo "copilot-ssh: ${host}:${port} is not reachable." >&2
+    _copilot_ssh_recover_azure "${host}" "${port}"
+}
+
 copilot-ssh() {
     if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
         echo "Usage: copilot-ssh [ssh options...] <host>"
         echo "SSH with COPILOT_GITHUB_TOKEN (and GH_TOKEN) forwarded from a 1Password Environment."
         return 0
     fi
+
+    # Fail fast on an unreachable host before unlocking 1Password.
+    _copilot_ssh_preflight "$@" || return 1
 
     if ! command -v op >/dev/null 2>&1; then
         echo "copilot-ssh: 'op' (1Password CLI) not found; using plain ssh (no token forwarded)." >&2

--- a/tests/bash/copilot-ssh.bats
+++ b/tests/bash/copilot-ssh.bats
@@ -137,3 +137,164 @@ EOF
 	[[ "$output" =~ "failed to read tokens" ]]
 	[[ ! "$output" =~ "SSH_ARGS:" ]]
 }
+
+# --- pre-flight reachability check -----------------------------------------
+
+# A stub `ssh` that also answers `ssh -G` with a resolved host/port, so the
+# pre-flight check has something to probe.
+_stub_ssh_config() {
+	local host="$1" port="$2"
+	cat >"$TEST_DIR/ssh" <<EOF
+#!/bin/bash
+if [ "\$1" = "-G" ]; then
+	echo "user someone"
+	echo "hostname ${host}"
+	echo "port ${port}"
+	exit 0
+fi
+echo "SSH_ARGS: \$*"
+EOF
+	chmod +x "$TEST_DIR/ssh"
+}
+
+# A stub `nc` used as the TCP probe; $1 is the exit code it reports.
+_stub_nc() {
+	cat >"$TEST_DIR/nc" <<EOF
+#!/bin/bash
+exit ${1}
+EOF
+	chmod +x "$TEST_DIR/nc"
+}
+
+# A stub `az`: $1 is the TSV emitted by \`az vm list\` (may be empty).
+_stub_az() {
+	cat >"$TEST_DIR/az" <<EOF
+#!/bin/bash
+case "\$2" in
+list) printf '%s' '$1' ;;
+start) echo "AZ_START: \$*" ;;
+esac
+exit 0
+EOF
+	chmod +x "$TEST_DIR/az"
+}
+
+@test "copilot-ssh: pre-flight resolves host and port from ssh -G" {
+	_stub_ssh_config "vm01.example.com" "2222"
+	PATH="$TEST_DIR:$ORIGINAL_PATH"
+	run _copilot_ssh_resolve myhost
+	[ "$status" -eq 0 ]
+	[[ "$output" == "vm01.example.com	2222" ]]
+}
+
+@test "copilot-ssh: pre-flight aborts when the host is unreachable and az is absent" {
+	_stub_ssh_config "vm01.example.com" "22"
+	_stub_nc 1
+	_stub_op "ctok" "gtok"
+	# PATH without az.
+	PATH="$TEST_DIR:/usr/bin:/bin"
+	run copilot-ssh myhost
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "vm01.example.com:22 is not reachable" ]]
+	[[ "$output" =~ "install the Azure CLI" ]]
+	[[ ! "$output" =~ "SSH_ARGS:" ]]
+}
+
+@test "copilot-ssh: pre-flight is skipped via COPILOT_SSH_SKIP_PREFLIGHT" {
+	_stub_ssh_config "vm01.example.com" "22"
+	_stub_nc 1
+	_stub_op "ctok" "gtok"
+	PATH="$TEST_DIR:$ORIGINAL_PATH"
+	COPILOT_SSH_SKIP_PREFLIGHT=1 run copilot-ssh myhost
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "SSH_ARGS:" ]]
+	[[ ! "$output" =~ "not reachable" ]]
+}
+
+@test "copilot-ssh: pre-flight passes straight through when the port answers" {
+	_stub_ssh_config "vm01.example.com" "22"
+	_stub_nc 0
+	_stub_op "ctok" "gtok"
+	PATH="$TEST_DIR:$ORIGINAL_PATH"
+	run copilot-ssh myhost
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "SSH_ARGS: -o SendEnv=COPILOT_GITHUB_TOKEN" ]]
+	[[ ! "$output" =~ "not reachable" ]]
+}
+
+@test "copilot-ssh: azure lookup matches the short name of an FQDN host" {
+	_stub_az "vm01	rg-dev	VM deallocated"
+	PATH="$TEST_DIR:$ORIGINAL_PATH"
+	run _copilot_ssh_az_lookup "vm01.example.com"
+	[ "$status" -eq 0 ]
+	[[ "$output" == "vm01	rg-dev	VM deallocated" ]]
+}
+
+@test "copilot-ssh: azure lookup matches on the resolved IP address" {
+	_stub_az "othervm	rg-dev	VM running	20.1.2.3	10.0.0.4"
+	PATH="$TEST_DIR:$ORIGINAL_PATH"
+	run _copilot_ssh_az_lookup "10.0.0.4"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "othervm" ]]
+}
+
+@test "copilot-ssh: reports when the VM runs but the port is closed" {
+	_stub_ssh_config "vm01.example.com" "22"
+	_stub_nc 1
+	_stub_az "vm01	rg-dev	VM running"
+	PATH="$TEST_DIR:$ORIGINAL_PATH"
+	run copilot-ssh myhost
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "is running but vm01.example.com:22 is unreachable" ]]
+	[[ ! "$output" =~ "SSH_ARGS:" ]]
+}
+
+@test "copilot-ssh: reports a stopped VM and does not start it without confirmation" {
+	_stub_ssh_config "vm01.example.com" "22"
+	_stub_nc 1
+	_stub_az "vm01	rg-dev	VM deallocated"
+	PATH="$TEST_DIR:$ORIGINAL_PATH"
+	# Not a TTY under bats, so the confirmation prompt answers "no".
+	run copilot-ssh myhost
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "Azure VM 'vm01' (resource group rg-dev) is VM deallocated" ]]
+	[[ "$output" =~ "not starting the VM" ]]
+	[[ ! "$output" =~ "AZ_START:" ]]
+}
+
+@test "copilot-ssh: starts a stopped VM when confirmed and then connects" {
+	_stub_ssh_config "vm01.example.com" "22"
+	_stub_nc 1
+	_stub_az "vm01	rg-dev	VM stopped"
+	_stub_op "ctok" "gtok"
+	PATH="$TEST_DIR:$ORIGINAL_PATH"
+	# Simulate an interactive "yes" and a host that comes back up.
+	_copilot_ssh_confirm() { return 0; }
+	_copilot_ssh_wait_for_ssh() { return 0; }
+	run copilot-ssh myhost
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "started 'vm01'" ]]
+	[[ "$output" =~ "SSH_ARGS: -o SendEnv=COPILOT_GITHUB_TOKEN" ]]
+}
+
+@test "copilot-ssh: aborts when several Azure VMs match the host" {
+	_stub_ssh_config "vm01.example.com" "22"
+	_stub_nc 1
+	_stub_az "vm01	rg-a	VM stopped
+vm01	rg-b	VM stopped"
+	PATH="$TEST_DIR:$ORIGINAL_PATH"
+	run copilot-ssh myhost
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "several Azure VMs match" ]]
+	[[ ! "$output" =~ "AZ_START:" ]]
+}
+
+@test "copilot-ssh: reports when no Azure VM matches the host" {
+	_stub_ssh_config "vm01.example.com" "22"
+	_stub_nc 1
+	_stub_az ""
+	PATH="$TEST_DIR:$ORIGINAL_PATH"
+	run copilot-ssh myhost
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "no Azure VM matches 'vm01.example.com'" ]]
+}

--- a/tests/bash/copilot-ssh.bats
+++ b/tests/bash/copilot-ssh.bats
@@ -179,6 +179,19 @@ EOF
 	chmod +x "$TEST_DIR/az"
 }
 
+# Build a PATH containing only the stubs plus the handful of real tools the
+# helper needs, so a command can be made genuinely absent. `/usr/bin:/bin` is
+# not enough for that: GitHub Actions runners ship the Azure CLI in /usr/bin.
+_minimal_path() {
+	local tool
+	for tool in awk sed grep cat wc tr date sleep rm mkdir chmod; do
+		if command -v "$tool" >/dev/null 2>&1; then
+			ln -sf "$(command -v "$tool")" "$TEST_DIR/$tool"
+		fi
+	done
+	PATH="$TEST_DIR"
+}
+
 @test "copilot-ssh: pre-flight resolves host and port from ssh -G" {
 	_stub_ssh_config "vm01.example.com" "2222"
 	PATH="$TEST_DIR:$ORIGINAL_PATH"
@@ -191,8 +204,8 @@ EOF
 	_stub_ssh_config "vm01.example.com" "22"
 	_stub_nc 1
 	_stub_op "ctok" "gtok"
-	# PATH without az.
-	PATH="$TEST_DIR:/usr/bin:/bin"
+	# PATH with the stubs but genuinely without az.
+	_minimal_path
 	run copilot-ssh myhost
 	[ "$status" -eq 1 ]
 	[[ "$output" =~ "vm01.example.com:22 is not reachable" ]]

--- a/tests/bash/copilot-ssh.bats
+++ b/tests/bash/copilot-ssh.bats
@@ -311,3 +311,16 @@ vm01	rg-b	VM stopped"
 	[ "$status" -eq 1 ]
 	[[ "$output" =~ "no Azure VM matches 'vm01.example.com'" ]]
 }
+
+@test "copilot-ssh: wait loop bails out immediately when nothing can probe" {
+	# No nc and no timeout/bash on PATH: the probe is undetermined, so waiting
+	# must not spin for the full COPILOT_SSH_START_TIMEOUT.
+	_minimal_path
+	local start elapsed
+	start="$(date +%s)"
+	COPILOT_SSH_START_TIMEOUT=60 run _copilot_ssh_wait_for_ssh vm01.example.com 22
+	elapsed=$(($(date +%s) - start))
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "cannot probe" ]]
+	[ "$elapsed" -lt 10 ]
+}

--- a/tests/bash/fastfetch-status.bats
+++ b/tests/bash/fastfetch-status.bats
@@ -172,10 +172,59 @@ esac
 EOF
 	run bash "${SCRIPT}" refresh
 	[ "$status" -eq 0 ]
+	# The cache stores absolute epoch tokens, not pre-rendered durations.
 	run cat "${XDG_CACHE_HOME}/fastfetch-status/ansible"
+	[[ "$output" =~ @ago:[0-9]+@ ]]
+	[[ "$output" =~ @in:[0-9]+@ ]]
+	[[ ! "$output" =~ "ran " ]]
+	# Emitting expands them against the current clock.
+	run bash "${SCRIPT}" ansible
+	[ "$status" -eq 0 ]
 	[[ "$output" =~ "ansible-pull OK" ]]
 	[[ "$output" =~ "ran 10m ago" ]]
 	[[ "$output" =~ "next in" ]]
+}
+
+@test "fastfetch-status: relative times advance without a cache refresh" {
+	mkdir -p "${XDG_CACHE_HOME}/fastfetch-status"
+	: >"${XDG_CACHE_HOME}/fastfetch-status/.refreshed-at"
+	printf 'ansible-pull OK \302\267 @ago:%s@\n' "$(($(date +%s) - 3540))" \
+		>"${XDG_CACHE_HOME}/fastfetch-status/ansible"
+
+	run bash "${SCRIPT}" ansible
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "ran 59m ago" ]]
+
+	# Same cache file, later clock -> a different rendered duration.
+	printf 'ansible-pull OK \302\267 @ago:%s@\n' "$(($(date +%s) - 3660))" \
+		>"${XDG_CACHE_HOME}/fastfetch-status/ansible"
+	run bash "${SCRIPT}" ansible
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "ran 1h ago" ]]
+}
+
+@test "fastfetch-status: elapsed next-run token renders as due" {
+	mkdir -p "${XDG_CACHE_HOME}/fastfetch-status"
+	: >"${XDG_CACHE_HOME}/fastfetch-status/.refreshed-at"
+	printf 'ansible-pull OK \302\267 @in:%s@\n' "$(($(date +%s) - 60))" \
+		>"${XDG_CACHE_HOME}/fastfetch-status/ansible"
+
+	run bash "${SCRIPT}" ansible
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "next due" ]]
+}
+
+@test "fastfetch-status: lines without tokens are emitted verbatim" {
+	mkdir -p "${XDG_CACHE_HOME}/fastfetch-status"
+	: >"${XDG_CACHE_HOME}/fastfetch-status/.refreshed-at"
+	printf 'user@host \302\267 @nope:1@ \302\267 100%% done\n' \
+		>"${XDG_CACHE_HOME}/fastfetch-status/updates"
+
+	run bash "${SCRIPT}" updates
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "user@host" ]]
+	[[ "$output" =~ "@nope:1@" ]]
+	[[ "$output" =~ "100% done" ]]
 }
 
 @test "fastfetch-status: reports ansible-pull failure from systemd" {

--- a/tests/powershell/CopilotSsh.Tests.ps1
+++ b/tests/powershell/CopilotSsh.Tests.ps1
@@ -299,6 +299,130 @@ Describe "Get-DotfilesSshHost (tab-completion source)" -Tag "Unit" {
     }
 }
 
+Describe "Connect-CopilotSsh reachability pre-flight" -Tag "Unit" {
+    BeforeAll {
+        $script:Module = Get-Module DotfilesHelpers
+        $script:Rows = @(
+            "vm01`trg-dev`tVM deallocated`t`t10.0.0.4"
+            "othervm`trg-x`tVM running`t20.1.2.3`t10.0.0.9"
+            "malformed-row"
+        )
+    }
+
+    AfterEach {
+        Remove-Item Env:COPILOT_SSH_ASSUME_YES -ErrorAction SilentlyContinue
+        Remove-Item Env:COPILOT_SSH_ASSUME_NO -ErrorAction SilentlyContinue
+        Remove-Item Env:COPILOT_SSH_SKIP_PREFLIGHT -ErrorAction SilentlyContinue
+    }
+
+    It "Should keep the pre-flight helpers private (not exported by the manifest)" {
+        $manifestPath = Join-Path $script:RepoRoot "home/dot_config/powershell/modules/DotfilesHelpers/DotfilesHelpers.psd1"
+        $exported = (Import-PowerShellDataFile -Path $manifestPath).FunctionsToExport
+        foreach ($name in @('Test-CopilotSshPreflight', 'Test-CopilotSshPort', 'ConvertFrom-SshConfigOutput',
+                'Select-CopilotSshAzureVm', 'Invoke-CopilotSshAzureRecovery', 'Get-CopilotSshConfirmation',
+                'Wait-CopilotSshPort')) {
+            $exported | Should -Not -Contain $name
+        }
+    }
+
+    It "Should run the pre-flight before reading tokens from 1Password" {
+        $body = (Get-Command Connect-CopilotSsh).ScriptBlock.ToString()
+        $body | Should -Match 'Test-CopilotSshPreflight'
+        # Compare against the real invocation, not the mention in the help text.
+        $body.IndexOf('Test-CopilotSshPreflight') | Should -BeLessThan $body.IndexOf('op run --environment')
+    }
+
+    Context "ConvertFrom-SshConfigOutput" {
+        It "Should extract the resolved hostname and port" {
+            $endpoint = & $script:Module { param($l) ConvertFrom-SshConfigOutput -Lines $l } @('user someone', 'hostname vm01.example.com', 'port 2222')
+            $endpoint.HostName | Should -Be 'vm01.example.com'
+            $endpoint.Port | Should -Be 2222
+        }
+
+        It "Should default to port 22 when ssh reports none" {
+            $endpoint = & $script:Module { param($l) ConvertFrom-SshConfigOutput -Lines $l } @('hostname vm01')
+            $endpoint.Port | Should -Be 22
+        }
+
+        It "Should return null when no hostname was resolved" {
+            $endpoint = & $script:Module { param($l) ConvertFrom-SshConfigOutput -Lines $l } @('user someone', '')
+            $endpoint | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "Select-CopilotSshAzureVm" {
+        It "Should match a VM by its exact name" {
+            $found = & $script:Module { param($r, $h) Select-CopilotSshAzureVm -Row $r -HostName $h } $script:Rows 'vm01'
+            $found.Count | Should -Be 1
+            $found[0].ResourceGroup | Should -Be 'rg-dev'
+            $found[0].PowerState | Should -Be 'VM deallocated'
+        }
+
+        It "Should match the short name of an FQDN host (vm01.example.com -> vm01)" {
+            $found = & $script:Module { param($r, $h) Select-CopilotSshAzureVm -Row $r -HostName $h } $script:Rows 'vm01.example.com'
+            $found.Count | Should -Be 1
+            $found[0].Name | Should -Be 'vm01'
+        }
+
+        It "Should match case-insensitively" {
+            $found = & $script:Module { param($r, $h) Select-CopilotSshAzureVm -Row $r -HostName $h } $script:Rows 'VM01.Example.COM'
+            $found.Count | Should -Be 1
+        }
+
+        It "Should fall back to matching public or private IP addresses" {
+            $public = & $script:Module { param($r, $h) Select-CopilotSshAzureVm -Row $r -HostName $h } $script:Rows '20.1.2.3'
+            $public[0].Name | Should -Be 'othervm'
+            $private = & $script:Module { param($r, $h) Select-CopilotSshAzureVm -Row $r -HostName $h } $script:Rows '10.0.0.4'
+            $private[0].Name | Should -Be 'vm01'
+        }
+
+        It "Should return nothing when no VM matches" {
+            $found = & $script:Module { param($r, $h) Select-CopilotSshAzureVm -Row $r -HostName $h } $script:Rows 'unknown-host'
+            @($found).Count | Should -Be 0
+        }
+
+        It "Should return every match so the caller can refuse to guess" {
+            $rows = @("vm01`trg-a`tVM stopped", "vm01`trg-b`tVM stopped")
+            $found = & $script:Module { param($r, $h) Select-CopilotSshAzureVm -Row $r -HostName $h } $rows 'vm01'
+            $found.Count | Should -Be 2
+        }
+    }
+
+    Context "Test-CopilotSshPort" {
+        It "Should report a closed port as unreachable within the timeout" {
+            $sw = [System.Diagnostics.Stopwatch]::StartNew()
+            $result = & $script:Module { Test-CopilotSshPort -HostName '127.0.0.1' -Port 9 -TimeoutSeconds 3 }
+            $sw.Stop()
+            $result | Should -BeFalse
+            $sw.Elapsed.TotalSeconds | Should -BeLessThan 10
+        }
+
+        It "Should report an unresolvable host as unreachable" {
+            $result = & $script:Module { Test-CopilotSshPort -HostName 'this-host-does-not-exist.invalid' -Port 22 -TimeoutSeconds 3 }
+            $result | Should -BeFalse
+        }
+    }
+
+    Context "Get-CopilotSshConfirmation" {
+        It "Should answer yes when COPILOT_SSH_ASSUME_YES is set" {
+            $env:COPILOT_SSH_ASSUME_YES = '1'
+            & $script:Module { Get-CopilotSshConfirmation -Message 'start?' } | Should -BeTrue
+        }
+
+        It "Should answer no when COPILOT_SSH_ASSUME_NO is set" {
+            $env:COPILOT_SSH_ASSUME_NO = '1'
+            & $script:Module { Get-CopilotSshConfirmation -Message 'start?' } | Should -BeFalse
+        }
+    }
+
+    Context "Test-CopilotSshPreflight" {
+        It "Should be skipped entirely via COPILOT_SSH_SKIP_PREFLIGHT" {
+            $env:COPILOT_SSH_SKIP_PREFLIGHT = '1'
+            & $script:Module { Test-CopilotSshPreflight -SshArgument @('unreachable.invalid') } | Should -BeTrue
+        }
+    }
+}
+
 # SIG # Begin signature block
 # MIIfEQYJKoZIhvcNAQcCoIIfAjCCHv4CAQExDzANBglghkgBZQMEAgEFADB5Bgor
 # BgEEAYI3AgEEoGswaTA0BgorBgEEAYI3AgEeMCYCAwEAAAQQH8w7YFlLCE63JNLG

--- a/tests/powershell/PortableProgramsPath.Tests.ps1
+++ b/tests/powershell/PortableProgramsPath.Tests.ps1
@@ -1,0 +1,204 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Pester tests for adding OneDrive Portable Programs to PATH.
+
+.DESCRIPTION
+    Tests the user-scope PATH helper without writing to the registry and checks
+    that the PowerShell profile keeps the current session update cheap.
+#>
+
+BeforeAll {
+    $script:RepoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+    Push-Location $script:RepoRoot
+
+    $script:PortableProgramsScriptPath = Join-Path $script:RepoRoot "home\.chezmoiscripts\windows\run_onchange_add-portable-programs-path.ps1"
+    $script:ProfilePath = Join-Path $script:RepoRoot "home\dot_config\powershell\profile.ps1"
+
+    . $script:PortableProgramsScriptPath -SkipApply
+}
+
+AfterAll {
+    Pop-Location
+}
+
+Describe "Portable Programs PATH Script" -Tag "Unit" {
+    It "script file should exist" {
+        $script:PortableProgramsScriptPath | Should -Exist
+    }
+
+    It "script should have valid PowerShell syntax" {
+        $errors = $null
+        [System.Management.Automation.Language.Parser]::ParseFile(
+            $script:PortableProgramsScriptPath,
+            [ref]$null,
+            [ref]$errors
+        ) | Out-Null
+
+        $errors | Should -BeNullOrEmpty
+    }
+
+    It "should read the raw user PATH without expanding percent variables" {
+        $content = Get-Content -LiteralPath $script:PortableProgramsScriptPath -Raw
+        $content | Should -Match "DoNotExpandEnvironmentNames"
+        $content | Should -Not -Match "GetEnvironmentVariable\(.+User"
+    }
+
+    It "should write only the user-scope PATH variable" {
+        $content = Get-Content -LiteralPath $script:PortableProgramsScriptPath -Raw
+        $content | Should -Match "OpenSubKey\(`"Environment`",\s*\`$true\)"
+        $content | Should -Match "SetValue\(\`$writeInfo\.ValueName,\s*\`$Path,\s*\`$writeInfo\.Kind\)"
+        $content | Should -Not -Match "SetEnvironmentVariable"
+        $content | Should -Not -Match "`"Machine`""
+    }
+
+    It "should preserve an existing ExpandString registry value kind" {
+        $info = Resolve-UserPathRegistryWriteInfo `
+            -ValueName "PATH" `
+            -Kind ([Microsoft.Win32.RegistryValueKind]::ExpandString) `
+            -Value "C:\Tools;C:\Users\Demo\OneDrive\Portable Programs"
+
+        $info.ValueName | Should -Be "PATH"
+        $info.Kind | Should -Be ([Microsoft.Win32.RegistryValueKind]::ExpandString)
+    }
+
+    It "should choose ExpandString for a new value containing percent variables" {
+        $info = Resolve-UserPathRegistryWriteInfo `
+            -ValueName $null `
+            -Kind $null `
+            -Value "%USERPROFILE%\bin;C:\Users\Demo\OneDrive\Portable Programs"
+
+        $info.ValueName | Should -Be "Path"
+        $info.Kind | Should -Be ([Microsoft.Win32.RegistryValueKind]::ExpandString)
+    }
+
+    It "should choose String for a new plain value" {
+        $info = Resolve-UserPathRegistryWriteInfo `
+            -ValueName $null `
+            -Kind $null `
+            -Value "C:\Tools;C:\Users\Demo\OneDrive\Portable Programs"
+
+        $info.ValueName | Should -Be "Path"
+        $info.Kind | Should -Be ([Microsoft.Win32.RegistryValueKind]::String)
+    }
+
+    It "should detect existing entries case-insensitively and ignore trailing backslashes" {
+        $pathList = "C:\Tools;c:\users\demo\onedrive\portable programs\"
+
+        Test-PathListContainsEntry -PathList $pathList -Entry "C:\Users\Demo\OneDrive\Portable Programs" |
+            Should -Be $true
+    }
+
+    It "should append the Portable Programs path without expanding existing variables" {
+        $userPath = "%USERPROFILE%\bin;C:\Tools"
+        $entry = "C:\Users\Demo\OneDrive\Portable Programs"
+
+        Add-PathListEntry -PathList $userPath -Entry $entry |
+            Should -Be "%USERPROFILE%\bin;C:\Tools;C:\Users\Demo\OneDrive\Portable Programs"
+    }
+
+    It "should not add a duplicate entry" {
+        $userPath = "%USERPROFILE%\bin;C:\Users\Demo\OneDrive\Portable Programs\"
+        $entry = "c:\users\demo\onedrive\portable programs"
+
+        Add-PathListEntry -PathList $userPath -Entry $entry |
+            Should -Be $userPath
+    }
+
+    It "should do nothing when OneDrive is not configured" {
+        $script:PathExistsCalled = $false
+        $script:SetUserPathCalled = $false
+
+        $result = Add-PortableProgramsToUserPath `
+            -OneDrivePath $null `
+            -PathExists { $script:PathExistsCalled = $true; $true } `
+            -SetUserPath { $script:SetUserPathCalled = $true }
+
+        $result.Status | Should -Be "OneDriveMissing"
+        $result.Changed | Should -Be $false
+        $script:PathExistsCalled | Should -Be $false
+        $script:SetUserPathCalled | Should -Be $false
+    }
+
+    It "should skip persistence when Portable Programs does not exist" {
+        $script:SetUserPathCalled = $false
+
+        $result = Add-PortableProgramsToUserPath `
+            -OneDrivePath "C:\Users\Demo\OneDrive" `
+            -PathExists { $false } `
+            -GetUserPath { "%USERPROFILE%\bin" } `
+            -SetUserPath { $script:SetUserPathCalled = $true }
+
+        $result.Status | Should -Be "PortableProgramsMissing"
+        $result.Changed | Should -Be $false
+        $script:SetUserPathCalled | Should -Be $false
+    }
+
+    It "should append and persist the user PATH when the folder exists" {
+        $script:WrittenUserPath = $null
+        $script:WrittenValueName = $null
+        $script:WrittenValueKind = $null
+
+        $result = Add-PortableProgramsToUserPath `
+            -OneDrivePath "C:\Users\Demo\OneDrive" `
+            -PathExists { $true } `
+            -GetUserPath {
+                [pscustomobject]@{
+                    Value     = "%USERPROFILE%\bin;C:\Tools"
+                    ValueName = "PATH"
+                    Kind      = [Microsoft.Win32.RegistryValueKind]::ExpandString
+                }
+            } `
+            -SetUserPath {
+                param(
+                    [string]$Path,
+                    [string]$ValueName,
+                    [object]$Kind
+                )
+                $script:WrittenUserPath = $Path
+                $script:WrittenValueName = $ValueName
+                $script:WrittenValueKind = $Kind
+            }
+
+        $result.Status | Should -Be "Updated"
+        $result.Changed | Should -Be $true
+        $script:WrittenUserPath | Should -Be "%USERPROFILE%\bin;C:\Tools;C:\Users\Demo\OneDrive\Portable Programs"
+        $script:WrittenValueName | Should -Be "PATH"
+        $script:WrittenValueKind | Should -Be ([Microsoft.Win32.RegistryValueKind]::ExpandString)
+    }
+
+    It "should not write under WhatIf" {
+        $script:SetUserPathCalled = $false
+
+        $result = Add-PortableProgramsToUserPath `
+            -OneDrivePath "C:\Users\Demo\OneDrive" `
+            -PathExists { $true } `
+            -GetUserPath { "C:\Tools" } `
+            -SetUserPath { $script:SetUserPathCalled = $true } `
+            -WhatIf
+
+        $result.Status | Should -Be "Updated"
+        $result.Changed | Should -Be $true
+        $script:SetUserPathCalled | Should -Be $false
+    }
+}
+
+Describe "PowerShell profile Portable Programs PATH" -Tag "Unit" {
+    BeforeAll {
+        $script:ProfileContent = Get-Content -LiteralPath $script:ProfilePath -Raw
+    }
+
+    It "should use OneDrive and Portable Programs for the session PATH update" {
+        $script:ProfileContent | Should -Match "env:OneDrive"
+        $script:ProfileContent | Should -Match "Portable Programs"
+        $script:ProfileContent | Should -Match "env:Path"
+    }
+
+    It "should use a simple string check instead of reading the registry" {
+        $script:ProfileContent | Should -Match "-split ';'"
+        $script:ProfileContent | Should -Match "TrimEnd\('\\'\)"
+        $script:ProfileContent | Should -Match "ToUpperInvariant"
+        $script:ProfileContent | Should -Not -Match "GetEnvironmentVariable\(.+User"
+        $script:ProfileContent | Should -Not -Match "Microsoft\.Win32\.Registry|RegistryValueOptions|Get-ItemProperty.*HKCU"
+    }
+}

--- a/tests/powershell/Profile.Tests.ps1
+++ b/tests/powershell/Profile.Tests.ps1
@@ -277,6 +277,13 @@ Describe "DotfilesHelpers Module" {
             'Save-WindowsTerminalSettings'
             'Invoke-NerdFontInstaller'
             'Get-DotfilesSshHost'
+            'ConvertFrom-SshConfigOutput'
+            'Select-CopilotSshAzureVm'
+            'Test-CopilotSshPort'
+            'Get-CopilotSshConfirmation'
+            'Wait-CopilotSshPort'
+            'Invoke-CopilotSshAzureRecovery'
+            'Test-CopilotSshPreflight'
         )
 
         # Discover every top-level function defined across the Public files using

--- a/tests/powershell/WindowsTerminal.Tests.ps1
+++ b/tests/powershell/WindowsTerminal.Tests.ps1
@@ -396,6 +396,32 @@ Describe "Set-WindowsTerminalCopilotProfile Function" -Tag "Unit" {
         $profile.commandline | Should -Be $script:CopilotCommandLine
     }
 
+    It "Should collapse duplicate profiles that share the fixed GUID" {
+        $duplicated = @'
+{
+    "profiles": {
+        "list": [
+            { "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}", "name": "PowerShell" },
+            { "guid": "{2fe4cbf1-8986-519c-9aa1-8f5a543c440d}", "name": "Stale One", "commandline": "cmd.exe" },
+            { "guid": "{2fe4cbf1-8986-519c-9aa1-8f5a543c440d}", "name": "Stale Two", "commandline": "cmd.exe" }
+        ]
+    }
+}
+'@
+        $duplicated | Set-Content -LiteralPath $script:settingsPath -Encoding utf8
+
+        $result = Set-WindowsTerminalCopilotProfile -HostName 'svlazdev.example.test' -SettingsPath $script:settingsPath
+
+        $result.Status | Should -Be 'Updated'
+        $json = Get-Content -LiteralPath $script:settingsPath -Raw | ConvertFrom-Json
+        $copilotProfiles = @($json.profiles.list) | Where-Object { $_.guid -eq $script:CopilotProfileGuid }
+        $copilotProfiles.Count | Should -Be 1
+        $copilotProfiles[0].name | Should -Be 'Copilot SSH (svlazdev.example.test)'
+        $copilotProfiles[0].commandline | Should -Be $script:CopilotCommandLine
+        # Unrelated profiles must survive the de-duplication.
+        @($json.profiles.list).Count | Should -Be 2
+    }
+
     It "Should be idempotent on re-run" {
         $script:CopilotSampleSettings | Set-Content -LiteralPath $script:settingsPath -Encoding utf8
         Set-WindowsTerminalCopilotProfile -HostName 'svlazdev.example.test' -SettingsPath $script:settingsPath | Out-Null

--- a/tests/powershell/WindowsTerminal.Tests.ps1
+++ b/tests/powershell/WindowsTerminal.Tests.ps1
@@ -7,7 +7,7 @@
 
 .DESCRIPTION
     Validates the surgical, non-destructive patching of Windows Terminal
-    settings.json against real temporary files: only the targeted value is
+    settings.json against disposable fixture files: only the targeted value is
     changed, JSONC (comments / trailing commas) parses, and missing files or
     missing profiles are skipped without error.
 #>
@@ -25,14 +25,17 @@ BeforeAll {
         throw "DotfilesHelpers module not found at: $modulePath"
     }
 
-    $tmpRoot = if ($env:TEMP) { $env:TEMP } else { '/tmp' }
-    $script:TestDir = New-Item -ItemType Directory -Path (Join-Path $tmpRoot "wt-settings-tests-$(Get-Random)") -Force
+    $script:ArtifactsRoot = Join-Path $script:RepoRoot ".test-artifacts"
+    $script:TestDir = New-Item -ItemType Directory -Path (Join-Path $script:ArtifactsRoot "wt-settings-tests-$(Get-Random)") -Force
 }
 
 AfterAll {
     Pop-Location
     if (Test-Path $script:TestDir) {
         Remove-Item -Recurse -Force $script:TestDir.FullName -ErrorAction SilentlyContinue
+    }
+    if ((Test-Path $script:ArtifactsRoot) -and -not (Get-ChildItem -LiteralPath $script:ArtifactsRoot -Force -ErrorAction SilentlyContinue)) {
+        Remove-Item -LiteralPath $script:ArtifactsRoot -Force -ErrorAction SilentlyContinue
     }
 }
 
@@ -337,6 +340,142 @@ Describe "Set-WindowsTerminalDefaultProfile Function" -Tag "Unit" {
         $result.Status | Should -Be 'WhatIf'
         $json = Get-Content -LiteralPath $script:settingsPath -Raw | ConvertFrom-Json
         $json.defaultProfile | Should -Be '{61c54bbd-c2c6-5271-96e7-009a87ff44bf}'
+    }
+}
+
+Describe "Set-WindowsTerminalCopilotProfile Function" -Tag "Unit" {
+    BeforeEach {
+        $script:settingsPath = Join-Path $script:TestDir.FullName "settings-$(Get-Random).json"
+    }
+
+    AfterEach {
+        Remove-Item -LiteralPath $script:settingsPath -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+        $script:CopilotProfileGuid = '{2fe4cbf1-8986-519c-9aa1-8f5a543c440d}'
+        $script:CopilotCommandLine = 'pwsh -NoExit -NoLogo -Command "copilot-ssh ''svlazdev.example.test''"'
+        $script:CopilotSampleSettings = @'
+{
+    "theme": "dark",
+    "profiles": {
+        "defaults": { "font": { "face": "FiraCode Nerd Font" } },
+        "list": [
+            {
+                "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+                "name": "PowerShell",
+                "source": "Windows.Terminal.PowershellCore"
+            }
+        ]
+    }
+}
+'@
+    }
+
+    It "Should be available with HostName, ProfileName, SettingsPath, and WhatIf parameters" {
+        $cmd = Get-Command Set-WindowsTerminalCopilotProfile
+        $cmd | Should -Not -BeNullOrEmpty
+        $cmd.Parameters.ContainsKey('HostName') | Should -Be $true
+        $cmd.Parameters.ContainsKey('ProfileName') | Should -Be $true
+        $cmd.Parameters.ContainsKey('SettingsPath') | Should -Be $true
+        $cmd.Parameters.ContainsKey('WhatIf') | Should -Be $true
+    }
+
+    It "Should add a Copilot SSH profile" {
+        $script:CopilotSampleSettings | Set-Content -LiteralPath $script:settingsPath -Encoding utf8
+
+        $result = Set-WindowsTerminalCopilotProfile -HostName 'svlazdev.example.test' -SettingsPath $script:settingsPath
+
+        $result.Status | Should -Be 'Updated'
+        $result.Guid | Should -Be $script:CopilotProfileGuid
+        $json = Get-Content -LiteralPath $script:settingsPath -Raw | ConvertFrom-Json
+        $profile = @($json.profiles.list) | Where-Object { $_.guid -eq $script:CopilotProfileGuid } | Select-Object -First 1
+        $profile | Should -Not -BeNullOrEmpty
+        $profile.name | Should -Be 'Copilot SSH (svlazdev.example.test)'
+        $profile.hidden | Should -Be $false
+        $profile.commandline | Should -Be $script:CopilotCommandLine
+    }
+
+    It "Should be idempotent on re-run" {
+        $script:CopilotSampleSettings | Set-Content -LiteralPath $script:settingsPath -Encoding utf8
+        Set-WindowsTerminalCopilotProfile -HostName 'svlazdev.example.test' -SettingsPath $script:settingsPath | Out-Null
+        $afterFirstRun = Get-Content -LiteralPath $script:settingsPath -Raw
+
+        $result = Set-WindowsTerminalCopilotProfile -HostName 'svlazdev.example.test' -SettingsPath $script:settingsPath
+
+        $result.Status | Should -Be 'AlreadySet'
+        $result.Changed | Should -Be $false
+        (Get-Content -LiteralPath $script:settingsPath -Raw) | Should -BeExactly $afterFirstRun
+        $json = Get-Content -LiteralPath $script:settingsPath -Raw | ConvertFrom-Json
+        @($json.profiles.list | Where-Object { $_.guid -eq $script:CopilotProfileGuid }).Count | Should -Be 1
+    }
+
+    It "Should update an existing fixed-GUID profile instead of duplicating it" {
+        $existing = @'
+{
+    "profiles": {
+        "list": [
+            {
+                "guid": "{2fe4cbf1-8986-519c-9aa1-8f5a543c440d}",
+                "hidden": true,
+                "name": "Old Copilot SSH",
+                "commandline": "pwsh -NoExit -NoLogo -Command \"copilot-ssh 'oldhost'\""
+            }
+        ]
+    }
+}
+'@
+        $existing | Set-Content -LiteralPath $script:settingsPath -Encoding utf8
+
+        $result = Set-WindowsTerminalCopilotProfile -HostName 'svlazdev.example.test' -SettingsPath $script:settingsPath
+
+        $result.Status | Should -Be 'Updated'
+        $json = Get-Content -LiteralPath $script:settingsPath -Raw | ConvertFrom-Json
+        @($json.profiles.list | Where-Object { $_.guid -eq $script:CopilotProfileGuid }).Count | Should -Be 1
+        @($json.profiles.list)[0].name | Should -Be 'Copilot SSH (svlazdev.example.test)'
+        @($json.profiles.list)[0].hidden | Should -Be $false
+        @($json.profiles.list)[0].commandline | Should -Be $script:CopilotCommandLine
+    }
+
+    It "Should preserve unrelated settings when adding the profile" {
+        $script:CopilotSampleSettings | Set-Content -LiteralPath $script:settingsPath -Encoding utf8
+
+        Set-WindowsTerminalCopilotProfile -HostName 'svlazdev.example.test' -SettingsPath $script:settingsPath | Out-Null
+
+        $json = Get-Content -LiteralPath $script:settingsPath -Raw | ConvertFrom-Json
+        $json.theme | Should -Be 'dark'
+        $json.profiles.defaults.font.face | Should -Be 'FiraCode Nerd Font'
+        @($json.profiles.list).Count | Should -Be 2
+        (@($json.profiles.list) | Where-Object { $_.name -eq 'PowerShell' }).source | Should -Be 'Windows.Terminal.PowershellCore'
+    }
+
+    It "Should not write under -WhatIf" {
+        $script:CopilotSampleSettings | Set-Content -LiteralPath $script:settingsPath -Encoding utf8
+        $before = Get-Content -LiteralPath $script:settingsPath -Raw
+
+        $result = Set-WindowsTerminalCopilotProfile -HostName 'svlazdev.example.test' -SettingsPath $script:settingsPath -WhatIf
+
+        $result.Status | Should -Be 'WhatIf'
+        (Get-Content -LiteralPath $script:settingsPath -Raw) | Should -BeExactly $before
+    }
+
+    It "Should skip paths that do not exist" {
+        $missing = Join-Path $script:TestDir.FullName "does-not-exist-$(Get-Random).json"
+
+        $result = Set-WindowsTerminalCopilotProfile -HostName 'svlazdev.example.test' -SettingsPath $missing
+
+        $result | Should -BeNullOrEmpty
+    }
+
+    It "Should add profiles.list when settings has no profiles section" {
+        '{ "theme": "system" }' | Set-Content -LiteralPath $script:settingsPath -Encoding utf8
+
+        $result = Set-WindowsTerminalCopilotProfile -HostName 'svlazdev.example.test' -SettingsPath $script:settingsPath
+
+        $result.Status | Should -Be 'Updated'
+        $json = Get-Content -LiteralPath $script:settingsPath -Raw | ConvertFrom-Json
+        $json.theme | Should -Be 'system'
+        @($json.profiles.list | Where-Object { $_.guid -eq $script:CopilotProfileGuid }).Count | Should -Be 1
     }
 }
 


### PR DESCRIPTION
## Summary

Four related quality-of-life changes to the shell/Windows setup.

### `fix(fastfetch)`: relative times no longer freeze

The status cache baked the *rendered* duration into the cache file, so
`ran 29s ago` stayed static until the next refresh. Collectors now store
absolute epoch tokens (`@ago:<epoch>@` / `@in:<epoch>@`) and the section
commands expand them against the current clock on every fastfetch run,
using bash builtins only so the login hot path stays fork-free. An elapsed
timer renders `next due`.

### `feat(helpers)`: copilot-ssh reachability pre-flight

Runs in bash, fish and PowerShell **before** the 1Password unlock:

1. Resolve the destination with `ssh -G` (honours `~/.ssh/config` aliases,
   `HostName`/`Port` overrides and `-o` flags).
2. Probe the TCP port with a hard ~3s timeout (`nc`, bash `/dev/tcp`, or a
   .NET `TcpClient`), so an unreachable host fails fast instead of hanging.
3. If the probe fails and the Azure CLI is present, look the host up with
   `az vm list -d` — by VM name, by the short form of an FQDN
   (`vm01.example.com` also matches `vm01`), and by public/private IP.
4. Offer to `az vm start` a stopped/deallocated VM, wait for the port, then
   connect. Running-but-unreachable and ambiguous matches abort with
   actionable guidance.

Tunable with `COPILOT_SSH_SKIP_PREFLIGHT`, `COPILOT_SSH_PREFLIGHT_TIMEOUT`,
`COPILOT_SSH_START_TIMEOUT` and `COPILOT_SSH_ASSUME_YES`.

### `feat(windows)`: Windows Terminal profile for copilot-ssh

`Set-WindowsTerminalCopilotProfile` surgically patches `settings.json` with a
fixed-GUID profile that opens PowerShell and runs `copilot-ssh <host>`.
Idempotent, preserves unrelated settings. The host comes from the new
`copilotSshHost` chezmoi variable, defaulting to the
`svlazdev.<privateDomain>` alias already declared in the managed ssh config.

### `feat(windows)`: OneDrive Portable Programs on PATH

Persists `%OneDrive%\Portable Programs` in the user-scope PATH (survives
reboots, visible to GUI apps) and adds it to the current PowerShell session.
The persistent write goes through the registry directly, preserving the
existing value name casing and `RegistryValueKind`, so `REG_EXPAND_SZ`
entries like `%USERPROFILE%\bin` keep expanding instead of being baked in by
`[Environment]::SetEnvironmentVariable`. Broadcasts `WM_SETTINGCHANGE`.

## Testing

- `./tests/bash/run-tests.sh --ci` — green except two **pre-existing**
  `log-structured.bats` JSON failures (backslash double-escaping in
  `log.sh`, untouched by this PR).
- `Invoke-Pester ./tests/powershell` — 439 passed, 0 failed.
- `shellcheck -x` / `shfmt --diff` / `fish -n` clean on all changed files.

## Notes

After applying, run `~/.config/fastfetch/status.sh refresh --force` once to
replace the old frozen cache line.