### PR TITLE
feat: manage 1Password shell plugins in the dotfiles + finish WSL SSH integration

### DIFF
--- a/docs/1password-shell-plugins.md
+++ b/docs/1password-shell-plugins.md
@@ -1,0 +1,109 @@
+# 🔐 1Password shell plugins
+
+[1Password shell plugins][opsp] let a CLI authenticate with your fingerprint
+instead of a long-lived token sitting in a plaintext config file. Running
+`gh`, for example, prompts 1Password for approval and injects the credential
+into that single command's environment — nothing is written to disk.
+
+## Why this repo defines the wrappers itself
+
+By default `op plugin init` writes shell functions to
+`~/.config/op/plugins.sh` and manages that file for you. That file is outside
+version control, so a new machine silently loses the configuration.
+
+1Password documents an alternative: [define the wrapper functions yourself and
+track them in your dotfiles][opdotfiles]. That is what this repo does.
+
+| | `op plugin init` default | This repo |
+| --- | --- | --- |
+| Wrapper location | `~/.config/op/plugins.sh` | `~/.config/shell/functions/op-plugins.sh`, `~/.config/fish/conf.d/op-plugins.fish` |
+| Tracked in git | ❌ | ✅ (generated from chezmoi templates) |
+| New machine | re-run `op plugin init` per CLI | wrappers apply with `chezmoi apply` |
+
+`OP_PLUGIN_ALIASES_SOURCED=1` is exported alongside the wrappers, which tells
+1Password CLI the aliases are already set up so it stops asking you to source
+`plugins.sh`.
+
+## Which CLIs are wrapped
+
+The list comes from the chezmoi `opShellPlugins` variable and defaults to:
+
+- **`gh`** — [GitHub CLI][opgh]
+- **`copilot`** — [GitHub Copilot CLI][opcopilot], which the plugin
+  authenticates with a `COPILOT_GITHUB_TOKEN`
+
+Override it per machine in your local chezmoi config, as a list:
+
+```yaml
+data:
+  opShellPlugins:
+    - gh
+    - copilot
+    - aws
+```
+
+or as a comma-separated string (trimmed, de-duplicated and sorted for you):
+
+```yaml
+data:
+  opShellPlugins: "gh, copilot, aws"
+```
+
+Then re-run `chezmoi apply`. Run `op plugin list` to see the 60+ supported
+CLIs.
+
+## First-time setup per CLI
+
+The wrappers only decide *how* a CLI is invoked. You still tell 1Password
+*which* item holds the credential, once per CLI and machine:
+
+```bash
+op signin
+op plugin init gh
+```
+
+You will be asked to import a new item or pick an existing one, then choose
+when the credential applies (this terminal session, this directory tree, or
+globally).
+
+Useful follow-ups:
+
+```bash
+op plugin inspect gh   # show configured credentials and scopes
+op plugin clear gh     # reset the credential defaults
+```
+
+After importing a credential into 1Password, delete any plaintext copy that is
+still lying around (for example `~/.config/gh/hosts.yml`).
+
+## Safety rails
+
+The generated wrappers are deliberately defensive, because a wrapper that
+cannot run would otherwise *replace* a working CLI:
+
+- **No `op`, no wrappers.** If the 1Password CLI is not on `PATH`, nothing is
+  defined at all and every CLI behaves normally.
+- **Only installed CLIs are wrapped.** Defining a `gh` function on a machine
+  without `gh` would make `command -v gh` succeed and break the usual
+  "is it installed?" checks, so each wrapper is guarded on the real CLI
+  existing.
+- **Completions keep working.** The fish wrappers use `--wraps`, and the
+  bash/zsh completion files load *before* the wrappers, so generating
+  completions never triggers a 1Password prompt at shell startup.
+
+## WSL is not supported
+
+`op plugin run` refuses to run under WSL — you get *"Shell Plugins are
+currently not supported on this operating system"* (tracked upstream in
+[1Password/shell-plugins#402][issue402]). Wrapping a CLI with a command that
+always fails is worse than not wrapping it, so chezmoi skips both wrapper
+files on WSL hosts via `.chezmoiignore`.
+
+WSL still reaches 1Password for SSH and Git signing through the Windows host —
+see [wsl.md](wsl.md).
+
+[opsp]: https://developer.1password.com/docs/cli/shell-plugins/
+[opdotfiles]: https://github.com/1Password/shell-plugins#managing-shell-plugins-in-your-own-dotfiles
+[opgh]: https://www.1password.dev/cli/shell-plugins/github
+[opcopilot]: https://www.1password.dev/cli/shell-plugins/github-copilot
+[issue402]: https://github.com/1Password/shell-plugins/issues/402

--- a/docs/1password-shell-plugins.md
+++ b/docs/1password-shell-plugins.md
@@ -90,6 +90,22 @@ cannot run would otherwise *replace* a working CLI:
 - **Completions keep working.** The fish wrappers use `--wraps`, and the
   bash/zsh completion files load *before* the wrappers, so generating
   completions never triggers a 1Password prompt at shell startup.
+- **Not in SSH sessions.** `op plugin run` needs the 1Password desktop app for
+  biometric unlock, which a headless host does not have. The wrappers are
+  therefore guarded on `SSH_CONNECTION`, so they never shadow a CLI on a
+  server — see below.
+
+## Interaction with `copilot-ssh`
+
+[`copilot-ssh`](copilot-cli.md) forwards `COPILOT_GITHUB_TOKEN` (and
+optionally `GH_TOKEN`) to a headless server over SSH, precisely because that
+server has no vault to unlock. A plugin wrapper on the remote side would
+hijack `copilot` / `gh` and route them through `op plugin run`, which cannot
+work there — breaking the forwarded-token flow.
+
+The `SSH_CONNECTION` guard prevents this: inside a `copilot-ssh` session the
+real binaries run and pick up the forwarded tokens, while on your workstation
+the plugin still authenticates you with biometrics.
 
 ## WSL is not supported
 

--- a/docs/chezmoi-variables.md
+++ b/docs/chezmoi-variables.md
@@ -44,6 +44,30 @@ templates and scripts.
 
 [openv]: https://www.1password.dev/environments
 
+## 1Password shell plugins
+
+- `opShellPlugins` — CLIs wrapped by a [1Password shell plugin][opsp] so they
+  authenticate with biometrics instead of a token on disk. Defaults to
+  `["gh", "copilot"]`. Accepts either a YAML list or a comma-separated string
+  in your local chezmoi config (the string form is trimmed, de-duplicated and
+  sorted). Not prompted. Each entry still needs a one-off
+  `op plugin init <cli>`, and the wrappers are skipped entirely on WSL, where
+  shell plugins are unsupported.
+  See [1password-shell-plugins.md](1password-shell-plugins.md).
+
+[opsp]: https://developer.1password.com/docs/cli/shell-plugins/
+
+## Git commit signing
+
+- `gitSigningKey` — The SSH **public** key used to sign Git commits when the
+  1Password SSH agent drives signing (notably in WSL, where signing runs
+  through `op-ssh-sign-wsl.exe`). Paste the literal key from the 1Password app
+  — *item → ⋮ → Configure Commit Signing → Copy Snippet* — for example
+  `ssh-ed25519 AAAA… comment`. A public key is not a secret. Empty by default,
+  which leaves signing off; ignored when `useYubiKey` is `true`, since the
+  YubiKey flow derives its key from `~/.ssh/id_*_sk*.pub` instead.
+  See [wsl.md](wsl.md).
+
 ## Windows Enterprise (Windows and WSL)
 
 - `isEntraIDJoined` — Device is Entra ID (Azure AD) joined.

--- a/docs/chezmoi-variables.md
+++ b/docs/chezmoi-variables.md
@@ -67,6 +67,10 @@ templates and scripts.
   which leaves signing off; ignored when `useYubiKey` is `true`, since the
   YubiKey flow derives its key from `~/.ssh/id_*_sk*.pub` instead.
   See [wsl.md](wsl.md).
+- `opSshSignProgram` — Explicit path to the 1Password SSH signer used in WSL.
+  Empty by default, which auto-detects the MSIX `WindowsApps` path and then the
+  pre-8.11.18 one. Set it only for a non-standard 1Password install. When no
+  signer is found, signing stays off rather than breaking every `git commit`.
 
 ## Windows Enterprise (Windows and WSL)
 

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -164,6 +164,22 @@ are complementary and use the same variable name:
 Note that the plugin wrappers are not applied on WSL, where shell plugins are
 unsupported — `copilot-ssh` still works there.
 
+### They cannot collide
+
+The wrappers deliberately do **not** activate in an SSH session (they are
+guarded on `SSH_CONNECTION`). `op plugin run` needs the 1Password desktop app
+for biometric unlock, which a headless server does not have, so a wrapper on
+the far side of `copilot-ssh` would replace a working CLI with one that always
+fails — exactly the situation `copilot-ssh` exists to avoid.
+
+| Session | `copilot` resolves to | Credential |
+| --- | --- | --- |
+| Local workstation | `op plugin run -- copilot` | 1Password, per command |
+| Inside `copilot-ssh` | the real `copilot` binary | forwarded `COPILOT_GITHUB_TOKEN` |
+
+In practice the remote host usually has no `op` installed either, which is a
+second, independent guard. The same reasoning applies to `gh` and `GH_TOKEN`.
+
 [opcopilot]: https://www.1password.dev/cli/shell-plugins/github-copilot
 
 ## Security notes

--- a/docs/copilot-cli.md
+++ b/docs/copilot-cli.md
@@ -144,6 +144,28 @@ Environment variables:
 | `COPILOT_SSH_ASSUME_YES`        | unset   | `1` auto-confirms starting a stopped VM         |
 | `COPILOT_SSH_ASSUME_NO`         | unset   | `1` never starts a VM, even on a TTY            |
 
+## Local authentication with the 1Password shell plugin
+
+`copilot-ssh` solves the *remote* case: forwarding a token to a headless
+server. On your **workstation** you don't need to forward anything — the
+[1Password Copilot shell plugin][opcopilot] authenticates the local `copilot`
+command with biometrics, injecting the same `COPILOT_GITHUB_TOKEN` for the
+duration of each command.
+
+This repo wraps `copilot` (and `gh`) automatically; see
+[1password-shell-plugins.md](1password-shell-plugins.md). The two mechanisms
+are complementary and use the same variable name:
+
+| Where | Mechanism | Token source |
+| --- | --- | --- |
+| Workstation | `op plugin run -- copilot` | 1Password item, per command |
+| Headless server | `copilot-ssh` + SSH `SendEnv` | 1Password Environment |
+
+Note that the plugin wrappers are not applied on WSL, where shell plugins are
+unsupported — `copilot-ssh` still works there.
+
+[opcopilot]: https://www.1password.dev/cli/shell-plugins/github-copilot
+
 ## Security notes
 
 - The tokens live only in 1Password (at rest), transiently in the helper's

--- a/docs/wsl.md
+++ b/docs/wsl.md
@@ -70,9 +70,19 @@ and falling back to the pre-8.11.18 one:
 /mnt/c/Users/<you>/AppData/Local/1Password/app/8/op-ssh-sign-wsl
 ```
 
-If neither exists, the rendered config says so in a comment instead of
-silently producing a broken `gpg.ssh.program`. Install or update 1Password for
+If neither exists, signing is left **off** and the rendered config explains
+why. Turning `commit.gpgsign` on without a signer would make git fall back to
+the local `ssh-keygen`, which cannot reach the key held by 1Password on
+Windows — every `git commit` would fail. Install or update 1Password for
 Windows, then re-run `chezmoi apply`.
+
+For a non-standard install you can point at the signer explicitly instead of
+relying on auto-detection:
+
+```yaml
+data:
+  opSshSignProgram: "/mnt/c/path/to/op-ssh-sign-wsl.exe"
+```
 
 !!! note
 

--- a/docs/wsl.md
+++ b/docs/wsl.md
@@ -1,0 +1,103 @@
+# 🪟 WSL and 1Password
+
+In WSL your SSH private keys are not on the Linux side at all — they live in
+1Password on the Windows host. Rather than forwarding an *agent socket*, the
+[1Password WSL integration][opwsl] forwards the whole SSH request to the
+Windows OpenSSH client (`ssh.exe`), which talks to the 1Password SSH agent and
+raises the approval prompt on Windows.
+
+This repo wires that up for you.
+
+## What is configured automatically
+
+| Concern | How | Where |
+| --- | --- | --- |
+| Git over SSH | `core.sshCommand = ssh.exe` | `dot_config/git/config.tmpl` |
+| Interactive `ssh` / `ssh-add` | aliased to `ssh.exe` / `ssh-add.exe` | `dot_config/shell/functions/wsl-ssh.sh`, `dot_config/fish/conf.d/wsl-ssh.fish` |
+| Commit signing | `gpg.ssh.program = op-ssh-sign-wsl.exe` | `dot_config/git/config.tmpl` |
+
+The aliases are guarded on `WSL_DISTRO_NAME` **and** on `ssh.exe` being
+reachable, so they never leak into a native Linux or macOS session and stay
+inert if [WSL interop][interop] is disabled.
+
+## Prerequisites
+
+1. 1Password for Windows installed and signed in **on the Windows host**.
+2. The [1Password SSH agent enabled][opagent] there.
+3. Your SSH key stored in 1Password.
+
+Verify the agent is reachable from inside WSL:
+
+```bash
+ssh-add.exe -l
+```
+
+You should see the same keys as on Windows. If you get `command not found`,
+either use the full path `/mnt/c/Windows/System32/OpenSSH/ssh-add.exe` or check
+that `[interop] enabled = true` in your WSL config.
+
+## Enabling commit signing
+
+Signing needs your **public** key, which this repo reads from the
+`gitSigningKey` chezmoi variable:
+
+1. In the 1Password Windows app, open the SSH key item.
+2. Choose **⋮ → Configure Commit Signing**.
+3. Tick **Configure for Windows Subsystem for Linux (WSL)** and select
+   **Copy Snippet**.
+4. Put the public key from that snippet into your local chezmoi config:
+
+   ```yaml
+   data:
+     gitSigningKey: "ssh-ed25519 AAAA… comment"
+   ```
+
+5. Run `chezmoi apply`.
+
+That renders `user.signingkey`, turns on `commit.gpgsign` / `tag.gpgsign`, and
+adds the key to `~/.config/git/allowed_signers` so your own commits verify
+locally. A public key is not a secret, so keeping it in the config is fine.
+
+Git needs the `key::` prefix to read a literal public key rather than a file
+path; the template adds it for you, so paste the key exactly as 1Password
+gives it.
+
+The signer binary is located automatically, preferring the current MSIX path
+and falling back to the pre-8.11.18 one:
+
+```text
+/mnt/c/Users/<you>/AppData/Local/Microsoft/WindowsApps/op-ssh-sign-wsl.exe
+/mnt/c/Users/<you>/AppData/Local/1Password/app/8/op-ssh-sign-wsl
+```
+
+If neither exists, the rendered config says so in a comment instead of
+silently producing a broken `gpg.ssh.program`. Install or update 1Password for
+Windows, then re-run `chezmoi apply`.
+
+!!! note
+
+    `useYubiKey = true` takes precedence: that flow signs with a FIDO2 key from
+    `~/.ssh/id_*_sk*.pub` and ignores `gitSigningKey`. See
+    [yubikey.md](yubikey.md).
+
+## SSH config lives on Windows
+
+Because the request is executed by `ssh.exe`, host aliases and options must be
+in the **Windows** `%USERPROFILE%\.ssh\config`, not the WSL one.
+
+## Authorization model
+
+Approving a key authorizes the current WSL session only. A new session or tab
+prompts again — the same [authorization model][opauth] 1Password uses
+everywhere else.
+
+## What does *not* work in WSL
+
+1Password **shell plugins** (`op plugin run`) are unsupported under WSL, so the
+`gh` / `copilot` wrappers are not applied there. See
+[1password-shell-plugins.md](1password-shell-plugins.md#wsl-is-not-supported).
+
+[opwsl]: https://www.1password.dev/ssh/integrations/wsl
+[opagent]: https://www.1password.dev/ssh/get-started/
+[opauth]: https://www.1password.dev/ssh/agent/security#authorization-model
+[interop]: https://learn.microsoft.com/windows/wsl/wsl-config#interop-settings

--- a/home/.chezmoi.yaml.tmpl
+++ b/home/.chezmoi.yaml.tmpl
@@ -105,13 +105,16 @@
 {{-   $opShellPlugins = .opShellPlugins -}}
 {{- end -}}
 {{- if kindIs "string" $opShellPlugins -}}
-{{-   $opShellPlugins = compact (splitList "," $opShellPlugins | sortAlpha | uniq) -}}
+{{-   $opShellPlugins = splitList "," $opShellPlugins -}}
 {{- end -}}
+{{- /* Trim before de-duplicating: "aws, aws " would otherwise survive uniq as */ -}}
+{{- /* two distinct strings and only collapse to duplicates afterwards.        */ -}}
 {{- $opShellPluginList := list -}}
 {{- range $opShellPlugins -}}
 {{-   $entry := . | toString | trim -}}
 {{-   if $entry -}}{{- $opShellPluginList = append $opShellPluginList $entry -}}{{- end -}}
 {{- end -}}
+{{- $opShellPluginList = $opShellPluginList | sortAlpha | uniq -}}
 
 {{- /* SSH public key used to sign Git commits when the 1Password SSH agent is  */ -}}
 {{- /* driving signing (notably in WSL, where signing runs through              */ -}}
@@ -121,6 +124,14 @@
 {{- $gitSigningKey := "" -}}
 {{- if hasKey . "gitSigningKey" -}}
 {{-   $gitSigningKey = .gitSigningKey -}}
+{{- end -}}
+
+{{- /* Path to the 1Password SSH signer used in WSL. Empty means auto-detect  */ -}}
+{{- /* (the MSIX WindowsApps path, then the pre-8.11.18 one). Set this only   */ -}}
+{{- /* for a non-standard 1Password install. See docs/wsl.md.                 */ -}}
+{{- $opSshSignProgram := "" -}}
+{{- if hasKey . "opSshSignProgram" -}}
+{{-   $opSshSignProgram = .opSshSignProgram -}}
 {{- end -}}
 
 {{- /* Extract GitHub username from email or prompt */ -}}
@@ -280,6 +291,7 @@ data:
   name: {{ $name | quote }}
   opCopilotEnvironmentId: {{ $opCopilotEnvironmentId | quote }}
   opShellPlugins: {{ $opShellPluginList | toJson }}
+  opSshSignProgram: {{ $opSshSignProgram | quote }}
   privateDomain: {{ $privateDomain | quote }}
   useYubiKey: {{ $useYubiKey }}
   username: {{ $username | quote }}

--- a/home/.chezmoi.yaml.tmpl
+++ b/home/.chezmoi.yaml.tmpl
@@ -94,6 +94,35 @@
 {{-   $copilotSshHost = promptString "Copilot SSH host" $copilotSshHost -}}
 {{- end -}}
 
+{{- /* CLIs wrapped by a 1Password shell plugin (`op plugin run -- <cli>`).     */ -}}
+{{- /* Accepts a comma-separated string or a YAML list in your local chezmoi    */ -}}
+{{- /* config; not prompted, since the default suits every machine. Each entry  */ -}}
+{{- /* still needs a one-off `op plugin init <cli>`. Shell plugins are not      */ -}}
+{{- /* supported in WSL, where the wrappers are skipped entirely.               */ -}}
+{{- /* See docs/1password-shell-plugins.md.                                     */ -}}
+{{- $opShellPlugins := list "gh" "copilot" -}}
+{{- if hasKey . "opShellPlugins" -}}
+{{-   $opShellPlugins = .opShellPlugins -}}
+{{- end -}}
+{{- if kindIs "string" $opShellPlugins -}}
+{{-   $opShellPlugins = compact (splitList "," $opShellPlugins | sortAlpha | uniq) -}}
+{{- end -}}
+{{- $opShellPluginList := list -}}
+{{- range $opShellPlugins -}}
+{{-   $entry := . | toString | trim -}}
+{{-   if $entry -}}{{- $opShellPluginList = append $opShellPluginList $entry -}}{{- end -}}
+{{- end -}}
+
+{{- /* SSH public key used to sign Git commits when the 1Password SSH agent is  */ -}}
+{{- /* driving signing (notably in WSL, where signing runs through              */ -}}
+{{- /* op-ssh-sign-wsl.exe). Paste the literal key from the 1Password app       */ -}}
+{{- /* ("Configure Commit Signing" -> Copy Snippet), e.g. "ssh-ed25519 AAAA…". */ -}}
+{{- /* A public key is not a secret. Ignored when useYubiKey is true.           */ -}}
+{{- $gitSigningKey := "" -}}
+{{- if hasKey . "gitSigningKey" -}}
+{{-   $gitSigningKey = .gitSigningKey -}}
+{{- end -}}
+
 {{- /* Extract GitHub username from email or prompt */ -}}
 {{- $githubUsername := "" -}}
 {{- /* Matches GitHub noreply email format: ID+USERNAME@users.noreply.github.com (e.g., 14926452+DevSecNinja@users.noreply.github.com) */ -}}
@@ -237,6 +266,7 @@ data:
   entraIDTenantId: {{ $entraIDTenantId | quote }}
   entraIDTenantName: {{ $entraIDTenantName | quote }}
   firstname: {{ $firstname | quote }}
+  gitSigningKey: {{ $gitSigningKey | quote }}
   githubUsername: {{ $githubUsername | quote }}
   installType: {{ $installType | quote }}
   interactive: {{ $interactive }}
@@ -249,6 +279,7 @@ data:
   lastname: {{ $lastname | quote }}
   name: {{ $name | quote }}
   opCopilotEnvironmentId: {{ $opCopilotEnvironmentId | quote }}
+  opShellPlugins: {{ $opShellPluginList | toJson }}
   privateDomain: {{ $privateDomain | quote }}
   useYubiKey: {{ $useYubiKey }}
   username: {{ $username | quote }}

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -26,7 +26,8 @@ renovate.json
 .chezmoiscripts/linux/**
 # fastfetch status modules are driven by a bash script (status.sh); Windows
 # fastfetch keeps its own default config instead.
-dot_config/fastfetch/**
+# Patterns match the TARGET path, so this is .config/… and not dot_config/….
+.config/fastfetch/**
 {{ end }}
 
 {{ if ne .chezmoi.os "windows" }}
@@ -35,11 +36,15 @@ Documents
 AppData
 {{ end }}
 
-{{ if .wsl }}
+{{ if get . "wsl" }}
 # 1Password shell plugins are unsupported in WSL: `op plugin run` refuses to
 # run there (1Password/shell-plugins#402), and wrapping a CLI with a command
 # that always fails would be worse than not wrapping it at all. WSL instead
 # reaches 1Password through the Windows SSH agent (see docs/wsl.md).
-dot_config/shell/functions/op-plugins.sh
-dot_config/fish/conf.d/op-plugins.fish
+#
+# `get` rather than a bare `.wsl` so commands that evaluate this file without a
+# rendered config (e.g. `chezmoi ignored --source=.` in CI) don't fail on a
+# missing key.
+.config/shell/functions/op-plugins.sh
+.config/fish/conf.d/op-plugins.fish
 {{ end }}

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -34,3 +34,12 @@ dot_config/fastfetch/**
 Documents
 AppData
 {{ end }}
+
+{{ if .wsl }}
+# 1Password shell plugins are unsupported in WSL: `op plugin run` refuses to
+# run there (1Password/shell-plugins#402), and wrapping a CLI with a command
+# that always fails would be worse than not wrapping it at all. WSL instead
+# reaches 1Password through the Windows SSH agent (see docs/wsl.md).
+dot_config/shell/functions/op-plugins.sh
+dot_config/fish/conf.d/op-plugins.fish
+{{ end }}

--- a/home/dot_config/fish/conf.d/op-plugins.fish.tmpl
+++ b/home/dot_config/fish/conf.d/op-plugins.fish.tmpl
@@ -1,0 +1,37 @@
+# 1Password shell plugins for fish.
+#
+# Instead of letting `op plugin init` manage ~/.config/op/plugins.sh, the
+# wrapper functions live here so the configuration is tracked in this repo.
+# See https://github.com/1Password/shell-plugins#managing-shell-plugins-in-your-own-dotfiles
+# and docs/1password-shell-plugins.md.
+#
+# Each wrapper routes the CLI through `op plugin run`, which injects the
+# credentials from 1Password (unlocked with biometrics) for the duration of
+# that single command, so no token is ever written to disk.
+#
+# The wrapped CLIs come from the chezmoi `opShellPlugins` variable; this file
+# is generated, edit dot_config/fish/conf.d/op-plugins.fish.tmpl instead.
+# Every CLI still needs a one-off `op plugin init <cli>` to pick the item.
+#
+# Shell plugins are not supported in WSL (op plugin run refuses to run there),
+# so chezmoi does not apply this file on WSL hosts.
+
+# Without `op` the wrappers would shadow the real CLIs with a broken command,
+# so define nothing at all when the 1Password CLI is missing.
+if command -q op
+    # Tells `op` the plugin aliases are already set up, so it does not ask us
+    # to source ~/.config/op/plugins.sh.
+    set -gx OP_PLUGIN_ALIASES_SOURCED 1
+
+{{ range .opShellPlugins }}
+    # Wrap {{ . }} only when it is actually installed: defining the function
+    # unconditionally would make `command -q {{ . }}` succeed on machines that
+    # do not have it, breaking the usual "is it installed?" checks.
+    # --wraps keeps the CLI's own completions working through the wrapper.
+    if command -q {{ . }}
+        function {{ . }} --wraps {{ . }} --description "1Password shell plugin for {{ . }}"
+            op plugin run -- {{ . }} $argv
+        end
+    end
+{{ end }}
+end

--- a/home/dot_config/fish/conf.d/op-plugins.fish.tmpl
+++ b/home/dot_config/fish/conf.d/op-plugins.fish.tmpl
@@ -15,10 +15,17 @@
 #
 # Shell plugins are not supported in WSL (op plugin run refuses to run there),
 # so chezmoi does not apply this file on WSL hosts.
-
-# Without `op` the wrappers would shadow the real CLIs with a broken command,
-# so define nothing at all when the 1Password CLI is missing.
-if command -q op
+#
+# Two guards, both deliberate:
+#   - Without `op` the wrappers would shadow the real CLIs with a broken
+#     command, so define nothing at all when the 1Password CLI is missing.
+#   - Inside an SSH session `op plugin run` cannot work either: it needs the
+#     1Password desktop app for biometric unlock, which only exists on a local
+#     workstation. Wrapping there would actively break the `copilot_ssh`
+#     helper, which forwards COPILOT_GITHUB_TOKEN / GH_TOKEN to headless hosts
+#     precisely because they have no vault. Leaving the CLIs unwrapped lets
+#     those forwarded tokens do their job. See docs/copilot-cli.md.
+if command -q op; and not set -q SSH_CONNECTION
     # Tells `op` the plugin aliases are already set up, so it does not ask us
     # to source ~/.config/op/plugins.sh.
     set -gx OP_PLUGIN_ALIASES_SOURCED 1

--- a/home/dot_config/fish/conf.d/wsl-ssh.fish
+++ b/home/dot_config/fish/conf.d/wsl-ssh.fish
@@ -1,0 +1,20 @@
+# WSL <-> Windows SSH integration for fish.
+#
+# In WSL there is no local SSH agent holding your keys: the private keys live
+# in 1Password on the Windows host. WSL therefore forwards whole SSH requests
+# to the Windows OpenSSH client (ssh.exe), which talks to the 1Password SSH
+# agent and prompts for approval on Windows.
+# See https://www.1password.dev/ssh/integrations/wsl and docs/wsl.md.
+#
+# Git already does this through `core.sshCommand = ssh.exe` (set in
+# dot_config/git/config.tmpl); these aliases give interactive `ssh` and
+# `ssh-add` the same behaviour, which 1Password documents as optional.
+#
+# Guarded on WSL_DISTRO_NAME (set by WSL itself) so the aliases never leak
+# into a native Linux or macOS session, and on ssh.exe actually being
+# reachable, which requires WSL interop to be enabled.
+
+if set -q WSL_DISTRO_NAME; and command -q ssh.exe
+    alias ssh 'ssh.exe'
+    alias ssh-add 'ssh-add.exe'
+end

--- a/home/dot_config/git/allowed_signers.tmpl
+++ b/home/dot_config/git/allowed_signers.tmpl
@@ -31,4 +31,8 @@
 {{- if not $found }}
 # No FIDO2 SSH pubkey found yet. Run `yk-enroll` and re-run `chezmoi apply`.
 {{- end }}
+{{- else if .gitSigningKey }}
+{{- /* 1Password-held signing key (see docs/wsl.md). The public key is enough  */ -}}
+{{- /* to verify signatures; the private half stays in 1Password.             */ -}}
+{{ .email }} {{ .gitSigningKey | trim }}
 {{- end }}

--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -117,4 +117,42 @@
 # No FIDO2 SSH pubkey found yet. Run `yk-enroll` then re-run `chezmoi apply`
 # to enable signing.
 {{- end }}
+{{ else if and .wsl .gitSigningKey }}
+# SSH-based commit signing through the 1Password SSH agent running on the
+# Windows host. In WSL, signing is performed by op-ssh-sign-wsl.exe rather
+# than the local ssh-keygen, because the private key never leaves 1Password
+# on Windows. See docs/wsl.md.
+#
+# The signer path moved with the 8.11.18 MSIX installer, so probe the current
+# location first and fall back to the pre-MSIX one.
+{{- $signer := "" -}}
+{{- range glob "/mnt/c/Users/*/AppData/Local/Microsoft/WindowsApps/op-ssh-sign-wsl.exe" -}}
+{{-   if not $signer -}}{{- $signer = . -}}{{- end -}}
+{{- end -}}
+{{- if not $signer -}}
+{{-   range glob "/mnt/c/Users/*/AppData/Local/1Password/app/8/op-ssh-sign-wsl" -}}
+{{-     if not $signer -}}{{- $signer = . -}}{{- end -}}
+{{-   end -}}
+{{- end -}}
+{{- /* `user.signingkey` may hold a literal public key or a path; git needs the */ -}}
+{{- /* `key::` prefix to read a literal key unambiguously.                      */ -}}
+{{- $signingKey := .gitSigningKey | trim -}}
+{{- if hasPrefix "ssh-" $signingKey -}}{{- $signingKey = printf "key::%s" $signingKey -}}{{- end }}
+[gpg]
+	format = ssh
+[gpg "ssh"]
+	allowedSignersFile = ~/.config/git/allowed_signers
+{{- if $signer }}
+	program = "{{ $signer }}"
+{{- end }}
+[user]
+	signingkey = {{ $signingKey }}
+[commit]
+	gpgsign = true
+[tag]
+	gpgsign = true
+{{- if not $signer }}
+# op-ssh-sign-wsl.exe was not found under /mnt/c/Users/*/AppData/Local. Install
+# or update 1Password for Windows, then re-run `chezmoi apply` to pick it up.
+{{- end }}
 {{ end -}}

--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -126,33 +126,39 @@
 # The signer path moved with the 8.11.18 MSIX installer, so probe the current
 # location first and fall back to the pre-MSIX one.
 {{- $signer := "" -}}
-{{- range glob "/mnt/c/Users/*/AppData/Local/Microsoft/WindowsApps/op-ssh-sign-wsl.exe" -}}
-{{-   if not $signer -}}{{- $signer = . -}}{{- end -}}
-{{- end -}}
-{{- if not $signer -}}
-{{-   range glob "/mnt/c/Users/*/AppData/Local/1Password/app/8/op-ssh-sign-wsl" -}}
+{{- if .opSshSignProgram -}}
+{{-   $signer = .opSshSignProgram -}}
+{{- else -}}
+{{-   range glob "/mnt/c/Users/*/AppData/Local/Microsoft/WindowsApps/op-ssh-sign-wsl.exe" -}}
 {{-     if not $signer -}}{{- $signer = . -}}{{- end -}}
+{{-   end -}}
+{{-   if not $signer -}}
+{{-     range glob "/mnt/c/Users/*/AppData/Local/1Password/app/8/op-ssh-sign-wsl" -}}
+{{-       if not $signer -}}{{- $signer = . -}}{{- end -}}
+{{-     end -}}
 {{-   end -}}
 {{- end -}}
 {{- /* `user.signingkey` may hold a literal public key or a path; git needs the */ -}}
 {{- /* `key::` prefix to read a literal key unambiguously.                      */ -}}
 {{- $signingKey := .gitSigningKey | trim -}}
 {{- if hasPrefix "ssh-" $signingKey -}}{{- $signingKey = printf "key::%s" $signingKey -}}{{- end }}
+{{- if $signer }}
 [gpg]
 	format = ssh
 [gpg "ssh"]
 	allowedSignersFile = ~/.config/git/allowed_signers
-{{- if $signer }}
 	program = "{{ $signer }}"
-{{- end }}
 [user]
 	signingkey = {{ $signingKey }}
 [commit]
 	gpgsign = true
 [tag]
 	gpgsign = true
-{{- if not $signer }}
-# op-ssh-sign-wsl.exe was not found under /mnt/c/Users/*/AppData/Local. Install
-# or update 1Password for Windows, then re-run `chezmoi apply` to pick it up.
+{{- else }}
+# op-ssh-sign-wsl.exe was not found under /mnt/c/Users/*/AppData/Local, so
+# signing is left OFF on purpose. Turning it on without a signer would make git
+# fall back to the local ssh-keygen, which cannot reach the key held by
+# 1Password on Windows — every `git commit` would fail. Install or update
+# 1Password for Windows, then re-run `chezmoi apply`.
 {{- end }}
 {{ end -}}

--- a/home/dot_config/shell/functions/op-plugins.sh.tmpl
+++ b/home/dot_config/shell/functions/op-plugins.sh.tmpl
@@ -1,0 +1,37 @@
+#!/bin/bash
+# 1Password shell plugins for Bash and Zsh.
+#
+# Instead of letting `op plugin init` manage ~/.config/op/plugins.sh, the
+# wrapper functions live here so the configuration is tracked in this repo.
+# See https://github.com/1Password/shell-plugins#managing-shell-plugins-in-your-own-dotfiles
+# and docs/1password-shell-plugins.md.
+#
+# Each wrapper routes the CLI through `op plugin run`, which injects the
+# credentials from 1Password (unlocked with biometrics) for the duration of
+# that single command, so no token is ever written to disk.
+#
+# The wrapped CLIs come from the chezmoi `opShellPlugins` variable; this file
+# is generated, edit dot_config/shell/functions/op-plugins.sh.tmpl instead.
+# Every CLI still needs a one-off `op plugin init <cli>` to pick the item.
+#
+# Shell plugins are not supported in WSL (op plugin run refuses to run there),
+# so chezmoi does not apply this file on WSL hosts.
+
+# Without `op` the wrappers would shadow the real CLIs with a broken command,
+# so define nothing at all when the 1Password CLI is missing.
+if command -v op >/dev/null 2>&1; then
+    # Tells `op` the plugin aliases are already set up, so it does not ask us
+    # to source ~/.config/op/plugins.sh.
+    export OP_PLUGIN_ALIASES_SOURCED="1"
+
+{{ range .opShellPlugins }}
+    # Wrap {{ . }} only when it is actually installed: defining the function
+    # unconditionally would make `command -v {{ . }}` succeed on machines that
+    # do not have it, breaking the usual "is it installed?" checks.
+    if command -v {{ . }} >/dev/null 2>&1; then
+        {{ . }}() {
+            op plugin run -- {{ . }} "$@"
+        }
+    fi
+{{ end }}
+fi

--- a/home/dot_config/shell/functions/op-plugins.sh.tmpl
+++ b/home/dot_config/shell/functions/op-plugins.sh.tmpl
@@ -16,10 +16,17 @@
 #
 # Shell plugins are not supported in WSL (op plugin run refuses to run there),
 # so chezmoi does not apply this file on WSL hosts.
-
-# Without `op` the wrappers would shadow the real CLIs with a broken command,
-# so define nothing at all when the 1Password CLI is missing.
-if command -v op >/dev/null 2>&1; then
+#
+# Two guards, both deliberate:
+#   - Without `op` the wrappers would shadow the real CLIs with a broken
+#     command, so define nothing at all when the 1Password CLI is missing.
+#   - Inside an SSH session `op plugin run` cannot work either: it needs the
+#     1Password desktop app for biometric unlock, which only exists on a local
+#     workstation. Wrapping there would actively break the `copilot-ssh`
+#     helper, which forwards COPILOT_GITHUB_TOKEN / GH_TOKEN to headless hosts
+#     precisely because they have no vault. Leaving the CLIs unwrapped lets
+#     those forwarded tokens do their job. See docs/copilot-cli.md.
+if command -v op >/dev/null 2>&1 && [ -z "${SSH_CONNECTION:-}" ]; then
     # Tells `op` the plugin aliases are already set up, so it does not ask us
     # to source ~/.config/op/plugins.sh.
     export OP_PLUGIN_ALIASES_SOURCED="1"

--- a/home/dot_config/shell/functions/wsl-ssh.sh
+++ b/home/dot_config/shell/functions/wsl-ssh.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# WSL <-> Windows SSH integration for Bash and Zsh.
+#
+# In WSL there is no local SSH agent holding your keys: the private keys live
+# in 1Password on the Windows host. WSL therefore forwards whole SSH requests
+# to the Windows OpenSSH client (ssh.exe), which talks to the 1Password SSH
+# agent and prompts for approval on Windows.
+# See https://www.1password.dev/ssh/integrations/wsl and docs/wsl.md.
+#
+# Git already does this through `core.sshCommand = ssh.exe` (set in
+# dot_config/git/config.tmpl); these aliases give interactive `ssh` and
+# `ssh-add` the same behaviour, which 1Password documents as optional.
+#
+# Guarded on WSL_DISTRO_NAME (set by WSL itself) so the aliases never leak
+# into a native Linux or macOS session, and on ssh.exe actually being
+# reachable, which requires WSL interop to be enabled.
+
+if [ -n "${WSL_DISTRO_NAME:-}" ] && command -v ssh.exe >/dev/null 2>&1; then
+    alias ssh='ssh.exe'
+    alias ssh-add='ssh-add.exe'
+fi

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,4 +67,7 @@ nav:
       - Chezmoi Variables: chezmoi-variables.md
       - Development Tools: development-tools.md
       - Shell Logging: logging.md
+      - GitHub Copilot CLI: copilot-cli.md
+      - 1Password Shell Plugins: 1password-shell-plugins.md
+      - WSL: wsl.md
       - YubiKey: yubikey.md

--- a/tests/bash/op-shell-plugins.bats
+++ b/tests/bash/op-shell-plugins.bats
@@ -1,0 +1,308 @@
+#!/usr/bin/env bats
+# Tests for the 1Password shell plugin wrappers and the WSL SSH integration.
+#
+# Unlike the older template tests, these render the REAL templates through
+# chezmoi (using a config generated from home/.chezmoi.yaml.tmpl) so a change
+# to the template is actually covered.
+
+setup() {
+	REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+	export REPO_ROOT
+	export PATH="${HOME}/.local/bin:${PATH}"
+
+	TEST_DIR="$(mktemp -d)"
+	export TEST_DIR
+	ORIGINAL_PATH="${PATH}"
+	export ORIGINAL_PATH
+
+	BASH_TMPL="${REPO_ROOT}/home/dot_config/shell/functions/op-plugins.sh.tmpl"
+	FISH_TMPL="${REPO_ROOT}/home/dot_config/fish/conf.d/op-plugins.fish.tmpl"
+	export BASH_TMPL FISH_TMPL
+}
+
+teardown() {
+	export PATH="${ORIGINAL_PATH}"
+	if [ -n "${TEST_DIR}" ] && [ -d "${TEST_DIR}" ]; then
+		rm -rf "${TEST_DIR}"
+	fi
+}
+
+# _skip_without_chezmoi -> skip the test when chezmoi is unavailable.
+_skip_without_chezmoi() {
+	command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+}
+
+# _config [SED_EXPR...] -> render .chezmoi.yaml.tmpl into a config file,
+# applying any sed expressions so a test can override single data values.
+# Prints the config path. Non-interactive: bats gives a non-TTY stdin, so the
+# template's promptString/promptBool calls are skipped.
+_config() {
+	local cfg="${TEST_DIR}/chezmoi-$(( RANDOM )).yaml" expr
+	chezmoi execute-template --init <"${REPO_ROOT}/home/.chezmoi.yaml.tmpl" >"${cfg}"
+	for expr in "$@"; do
+		sed -i -e "${expr}" "${cfg}"
+	done
+	printf '%s\n' "${cfg}"
+}
+
+# _render CONFIG TEMPLATE -> render a source template with that config.
+_render() {
+	chezmoi --config "${1}" execute-template <"${2}"
+}
+
+@test "op-plugins: templates exist for bash/zsh and fish" {
+	[ -f "${BASH_TMPL}" ]
+	[ -f "${FISH_TMPL}" ]
+}
+
+@test "op-plugins: default plugin list wraps gh and copilot" {
+	_skip_without_chezmoi
+	local cfg
+	cfg="$(_config)"
+	run _render "${cfg}" "${BASH_TMPL}"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "op plugin run -- gh" ]]
+	[[ "$output" =~ "op plugin run -- copilot" ]]
+}
+
+@test "op-plugins: rendered bash wrapper has valid bash and zsh syntax" {
+	_skip_without_chezmoi
+	local cfg out="${TEST_DIR}/op-plugins.sh"
+	cfg="$(_config)"
+	_render "${cfg}" "${BASH_TMPL}" >"${out}"
+	run bash -n "${out}"
+	[ "$status" -eq 0 ]
+	if command -v zsh >/dev/null 2>&1; then
+		run zsh -n "${out}"
+		[ "$status" -eq 0 ]
+	fi
+}
+
+@test "op-plugins: rendered fish wrapper has valid fish syntax" {
+	_skip_without_chezmoi
+	command -v fish >/dev/null 2>&1 || skip "fish not installed"
+	local cfg out="${TEST_DIR}/op-plugins.fish"
+	cfg="$(_config)"
+	_render "${cfg}" "${FISH_TMPL}" >"${out}"
+	run fish -n "${out}"
+	[ "$status" -eq 0 ]
+}
+
+@test "op-plugins: sets OP_PLUGIN_ALIASES_SOURCED so op does not ask for plugins.sh" {
+	_skip_without_chezmoi
+	local cfg
+	cfg="$(_config)"
+	run _render "${cfg}" "${BASH_TMPL}"
+	[[ "$output" =~ "OP_PLUGIN_ALIASES_SOURCED" ]]
+	run _render "${cfg}" "${FISH_TMPL}"
+	[[ "$output" =~ "OP_PLUGIN_ALIASES_SOURCED" ]]
+}
+
+@test "op-plugins: honours a custom plugin list" {
+	_skip_without_chezmoi
+	local cfg
+	cfg="$(_config 's|^  opShellPlugins: .*|  opShellPlugins: ["aws"]|')"
+	run _render "${cfg}" "${BASH_TMPL}"
+	[[ "$output" =~ "op plugin run -- aws" ]]
+	[[ ! "$output" =~ "op plugin run -- gh" ]]
+}
+
+@test "op-plugins: accepts a comma-separated list and trims, dedupes and sorts it" {
+	_skip_without_chezmoi
+	local pre="${TEST_DIR}/pre.yaml"
+	# A local chezmoi config may set the variable as a string instead of a list.
+	printf 'data:\n  opShellPlugins: " aws , gh ,, aws "\n' >"${pre}"
+	run chezmoi --config "${pre}" execute-template --init <"${REPO_ROOT}/home/.chezmoi.yaml.tmpl"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ 'opShellPlugins: ["aws","gh"]' ]]
+}
+
+@test "op-plugins: a list-valued override is passed through unchanged" {
+	_skip_without_chezmoi
+	local pre="${TEST_DIR}/pre-list.yaml"
+	printf 'data:\n  opShellPlugins:\n    - aws\n    - gh\n' >"${pre}"
+	run chezmoi --config "${pre}" execute-template --init <"${REPO_ROOT}/home/.chezmoi.yaml.tmpl"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ 'opShellPlugins: ["aws","gh"]' ]]
+}
+
+@test "op-plugins: wrappers are guarded on op being installed" {
+	_skip_without_chezmoi
+	local cfg
+	cfg="$(_config)"
+	run _render "${cfg}" "${BASH_TMPL}"
+	[[ "$output" =~ "command -v op" ]]
+	run _render "${cfg}" "${FISH_TMPL}"
+	[[ "$output" =~ "command -q op" ]]
+}
+
+@test "op-plugins: fish wrappers use --wraps so completions keep working" {
+	_skip_without_chezmoi
+	local cfg
+	cfg="$(_config)"
+	run _render "${cfg}" "${FISH_TMPL}"
+	[[ "$output" =~ "--wraps gh" ]]
+}
+
+@test "op-plugins: bash wrapper routes the CLI through op plugin run" {
+	_skip_without_chezmoi
+	local cfg out="${TEST_DIR}/op-plugins.sh"
+	cfg="$(_config)"
+	_render "${cfg}" "${BASH_TMPL}" >"${out}"
+
+	printf '#!/bin/bash\necho "OP_RUN: $*"\n' >"${TEST_DIR}/op"
+	printf '#!/bin/bash\necho "REAL_GH: $*"\n' >"${TEST_DIR}/gh"
+	chmod +x "${TEST_DIR}/op" "${TEST_DIR}/gh"
+
+	PATH="${TEST_DIR}:${ORIGINAL_PATH}" run bash -c "source '${out}'; gh auth status"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "OP_RUN: plugin run -- gh auth status" ]]
+	[[ ! "$output" =~ "REAL_GH:" ]]
+}
+
+@test "op-plugins: nothing is defined when op is not installed" {
+	_skip_without_chezmoi
+	local cfg out="${TEST_DIR}/op-plugins.sh"
+	cfg="$(_config)"
+	_render "${cfg}" "${BASH_TMPL}" >"${out}"
+
+	printf '#!/bin/bash\necho "REAL_GH: $*"\n' >"${TEST_DIR}/gh"
+	chmod +x "${TEST_DIR}/gh"
+
+	# A PATH with gh but deliberately without op.
+	PATH="${TEST_DIR}:/usr/bin:/bin" run bash -c "source '${out}'; gh auth status; echo \"sourced=\${OP_PLUGIN_ALIASES_SOURCED:-unset}\""
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "REAL_GH: auth status" ]]
+	[[ "$output" =~ "sourced=unset" ]]
+}
+
+@test "op-plugins: an uninstalled CLI is not wrapped" {
+	_skip_without_chezmoi
+	local cfg out="${TEST_DIR}/op-plugins.sh"
+	cfg="$(_config 's|^  opShellPlugins: .*|  opShellPlugins: ["definitely-not-installed"]|')"
+	_render "${cfg}" "${BASH_TMPL}" >"${out}"
+
+	printf '#!/bin/bash\necho "OP_RUN: $*"\n' >"${TEST_DIR}/op"
+	chmod +x "${TEST_DIR}/op"
+
+	PATH="${TEST_DIR}:${ORIGINAL_PATH}" run bash -c "source '${out}'; type -t definitely-not-installed || echo 'not-wrapped'"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "not-wrapped" ]]
+}
+
+@test "op-plugins: chezmoi skips the wrappers on WSL (plugins unsupported there)" {
+	_skip_without_chezmoi
+	local cfg
+	cfg="$(_config 's|^  wsl: .*|  wsl: true|')"
+	run _render "${cfg}" "${REPO_ROOT}/home/.chezmoiignore"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "dot_config/shell/functions/op-plugins.sh" ]]
+	[[ "$output" =~ "dot_config/fish/conf.d/op-plugins.fish" ]]
+}
+
+@test "op-plugins: wrappers are applied on a non-WSL host" {
+	_skip_without_chezmoi
+	local cfg
+	cfg="$(_config 's|^  wsl: .*|  wsl: false|')"
+	run _render "${cfg}" "${REPO_ROOT}/home/.chezmoiignore"
+	[ "$status" -eq 0 ]
+	[[ ! "$output" =~ "op-plugins" ]]
+}
+
+# --- WSL SSH / commit signing ------------------------------------------------
+
+@test "wsl-ssh: alias files exist for bash/zsh and fish" {
+	[ -f "${REPO_ROOT}/home/dot_config/shell/functions/wsl-ssh.sh" ]
+	[ -f "${REPO_ROOT}/home/dot_config/fish/conf.d/wsl-ssh.fish" ]
+}
+
+@test "wsl-ssh: aliases only apply inside WSL with interop available" {
+	local f="${REPO_ROOT}/home/dot_config/shell/functions/wsl-ssh.sh"
+	run bash -n "${f}"
+	[ "$status" -eq 0 ]
+
+	# Not WSL: no aliases defined.
+	run bash -c "unset WSL_DISTRO_NAME; source '${f}'; alias ssh 2>/dev/null || echo 'no-alias'"
+	[[ "$output" =~ "no-alias" ]]
+
+	# WSL but no ssh.exe on PATH (interop off): still no aliases.
+	run bash -c "WSL_DISTRO_NAME=Ubuntu; export WSL_DISTRO_NAME; PATH=/usr/bin:/bin; source '${f}'; alias ssh 2>/dev/null || echo 'no-alias'"
+	[[ "$output" =~ "no-alias" ]]
+}
+
+@test "wsl-ssh: aliases are defined when WSL and ssh.exe are present" {
+	local f="${REPO_ROOT}/home/dot_config/shell/functions/wsl-ssh.sh"
+	printf '#!/bin/bash\necho "WIN_SSH: $*"\n' >"${TEST_DIR}/ssh.exe"
+	printf '#!/bin/bash\necho "WIN_SSH_ADD: $*"\n' >"${TEST_DIR}/ssh-add.exe"
+	chmod +x "${TEST_DIR}/ssh.exe" "${TEST_DIR}/ssh-add.exe"
+
+	run bash -c "WSL_DISTRO_NAME=Ubuntu; export WSL_DISTRO_NAME; PATH='${TEST_DIR}:${ORIGINAL_PATH}'; source '${f}'; alias ssh; alias ssh-add"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "ssh.exe" ]]
+	[[ "$output" =~ "ssh-add.exe" ]]
+}
+
+@test "wsl-signing: WSL with a signing key enables 1Password SSH signing" {
+	_skip_without_chezmoi
+	local cfg
+	cfg="$(_config \
+		's|^  wsl: .*|  wsl: true|' \
+		's|^  useYubiKey: .*|  useYubiKey: false|' \
+		's|^  gitSigningKey: .*|  gitSigningKey: "ssh-ed25519 AAAATESTKEY comment"|')"
+	run _render "${cfg}" "${REPO_ROOT}/home/dot_config/git/config.tmpl"
+	[ "$status" -eq 0 ]
+	# git needs the key:: prefix to read a literal public key rather than a path.
+	[[ "$output" =~ "signingkey = key::ssh-ed25519 AAAATESTKEY comment" ]]
+	[[ "$output" =~ "gpgsign = true" ]]
+	[[ "$output" =~ "format = ssh" ]]
+	# WSL keeps routing ssh through the Windows client.
+	[[ "$output" =~ "sshCommand = ssh.exe" ]]
+}
+
+@test "wsl-signing: no signing key means no signing configuration" {
+	_skip_without_chezmoi
+	local cfg
+	cfg="$(_config \
+		's|^  wsl: .*|  wsl: true|' \
+		's|^  useYubiKey: .*|  useYubiKey: false|' \
+		's|^  gitSigningKey: .*|  gitSigningKey: ""|')"
+	run _render "${cfg}" "${REPO_ROOT}/home/dot_config/git/config.tmpl"
+	[ "$status" -eq 0 ]
+	[[ ! "$output" =~ "gpgsign" ]]
+	[[ ! "$output" =~ "signingkey" ]]
+}
+
+@test "wsl-signing: YubiKey mode takes precedence over the 1Password branch" {
+	_skip_without_chezmoi
+	local cfg
+	cfg="$(_config \
+		's|^  wsl: .*|  wsl: true|' \
+		's|^  useYubiKey: .*|  useYubiKey: true|' \
+		's|^  gitSigningKey: .*|  gitSigningKey: "ssh-ed25519 AAAATESTKEY comment"|')"
+	run _render "${cfg}" "${REPO_ROOT}/home/dot_config/git/config.tmpl"
+	[ "$status" -eq 0 ]
+	[[ ! "$output" =~ "key::ssh-ed25519 AAAATESTKEY" ]]
+}
+
+@test "wsl-signing: native Linux without YubiKey stays unsigned" {
+	_skip_without_chezmoi
+	local cfg
+	cfg="$(_config \
+		's|^  wsl: .*|  wsl: false|' \
+		's|^  useYubiKey: .*|  useYubiKey: false|' \
+		's|^  gitSigningKey: .*|  gitSigningKey: "ssh-ed25519 AAAATESTKEY comment"|')"
+	run _render "${cfg}" "${REPO_ROOT}/home/dot_config/git/config.tmpl"
+	[ "$status" -eq 0 ]
+	[[ ! "$output" =~ "gpgsign" ]]
+}
+
+@test "wsl-signing: allowed_signers lists the 1Password public key" {
+	_skip_without_chezmoi
+	local cfg
+	cfg="$(_config \
+		's|^  useYubiKey: .*|  useYubiKey: false|' \
+		's|^  gitSigningKey: .*|  gitSigningKey: "ssh-ed25519 AAAATESTKEY comment"|')"
+	run _render "${cfg}" "${REPO_ROOT}/home/dot_config/git/allowed_signers.tmpl"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "ssh-ed25519 AAAATESTKEY comment" ]]
+}

--- a/tests/bash/op-shell-plugins.bats
+++ b/tests/bash/op-shell-plugins.bats
@@ -154,7 +154,7 @@ _render() {
 	printf '#!/bin/bash\necho "REAL_GH: $*"\n' >"${TEST_DIR}/gh"
 	chmod +x "${TEST_DIR}/op" "${TEST_DIR}/gh"
 
-	PATH="${TEST_DIR}:${ORIGINAL_PATH}" run bash -c "source '${out}'; gh auth status"
+	PATH="${TEST_DIR}:${ORIGINAL_PATH}" run env -u SSH_CONNECTION bash -c "source '${out}'; gh auth status"
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "OP_RUN: plugin run -- gh auth status" ]]
 	[[ ! "$output" =~ "REAL_GH:" ]]
@@ -170,7 +170,7 @@ _render() {
 	chmod +x "${TEST_DIR}/gh"
 
 	# A PATH with gh but deliberately without op.
-	PATH="${TEST_DIR}:/usr/bin:/bin" run bash -c "source '${out}'; gh auth status; echo \"sourced=\${OP_PLUGIN_ALIASES_SOURCED:-unset}\""
+	PATH="${TEST_DIR}:/usr/bin:/bin" run env -u SSH_CONNECTION bash -c "source '${out}'; gh auth status; echo \"sourced=\${OP_PLUGIN_ALIASES_SOURCED:-unset}\""
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "REAL_GH: auth status" ]]
 	[[ "$output" =~ "sourced=unset" ]]
@@ -185,28 +185,51 @@ _render() {
 	printf '#!/bin/bash\necho "OP_RUN: $*"\n' >"${TEST_DIR}/op"
 	chmod +x "${TEST_DIR}/op"
 
-	PATH="${TEST_DIR}:${ORIGINAL_PATH}" run bash -c "source '${out}'; type -t definitely-not-installed || echo 'not-wrapped'"
+	PATH="${TEST_DIR}:${ORIGINAL_PATH}" run env -u SSH_CONNECTION bash -c "source '${out}'; type -t definitely-not-installed || echo 'not-wrapped'"
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "not-wrapped" ]]
 }
 
 @test "op-plugins: chezmoi skips the wrappers on WSL (plugins unsupported there)" {
 	_skip_without_chezmoi
-	local cfg
-	cfg="$(_config 's|^  wsl: .*|  wsl: true|')"
-	run _render "${cfg}" "${REPO_ROOT}/home/.chezmoiignore"
+	local cfg="${TEST_DIR}/wsl.yaml"
+	printf 'data:\n  wsl: true\n' >"${cfg}"
+	# Assert real ignore behaviour, not the rendered text: .chezmoiignore
+	# patterns match the TARGET path, so a dot_config/... pattern would render
+	# fine yet never match anything.
+	cd "${REPO_ROOT}/home"
+	run chezmoi --config "${cfg}" ignored --source=. --no-tty
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "dot_config/shell/functions/op-plugins.sh" ]]
-	[[ "$output" =~ "dot_config/fish/conf.d/op-plugins.fish" ]]
+	printf '%s\n' "${lines[@]}" | grep -Fxq -- ".config/shell/functions/op-plugins.sh"
+	printf '%s\n' "${lines[@]}" | grep -Fxq -- ".config/fish/conf.d/op-plugins.fish"
 }
 
 @test "op-plugins: wrappers are applied on a non-WSL host" {
 	_skip_without_chezmoi
-	local cfg
-	cfg="$(_config 's|^  wsl: .*|  wsl: false|')"
-	run _render "${cfg}" "${REPO_ROOT}/home/.chezmoiignore"
+	local cfg="${TEST_DIR}/nowsl.yaml"
+	printf 'data:\n  wsl: false\n' >"${cfg}"
+	cd "${REPO_ROOT}/home"
+	run chezmoi --config "${cfg}" ignored --source=. --no-tty
 	[ "$status" -eq 0 ]
 	[[ ! "$output" =~ "op-plugins" ]]
+
+	run chezmoi --config "${cfg}" managed --source=. --no-tty
+	[ "$status" -eq 0 ]
+	printf '%s\n' "${lines[@]}" | grep -Fxq -- ".config/shell/functions/op-plugins.sh"
+	printf '%s\n' "${lines[@]}" | grep -Fxq -- ".config/fish/conf.d/op-plugins.fish"
+}
+
+@test "op-plugins: .chezmoiignore evaluates without a rendered config" {
+	_skip_without_chezmoi
+	# `chezmoi ignored/managed` is run in CI without the config generated from
+	# .chezmoi.yaml.tmpl, so custom data keys such as .wsl are absent and a
+	# bare {{ if .wsl }} would abort the whole template.
+	local cfg="${TEST_DIR}/empty.yaml"
+	printf '{}\n' >"${cfg}"
+	cd "${REPO_ROOT}/home"
+	run chezmoi --config "${cfg}" ignored --source=. --no-tty
+	[ "$status" -eq 0 ]
+	[[ ! "$output" =~ "map has no entry for key" ]]
 }
 
 # --- WSL SSH / commit signing ------------------------------------------------
@@ -242,21 +265,41 @@ _render() {
 	[[ "$output" =~ "ssh-add.exe" ]]
 }
 
-@test "wsl-signing: WSL with a signing key enables 1Password SSH signing" {
+@test "wsl-signing: WSL with a signing key and a signer enables 1Password signing" {
 	_skip_without_chezmoi
 	local cfg
 	cfg="$(_config \
 		's|^  wsl: .*|  wsl: true|' \
 		's|^  useYubiKey: .*|  useYubiKey: false|' \
-		's|^  gitSigningKey: .*|  gitSigningKey: "ssh-ed25519 AAAATESTKEY comment"|')"
+		's|^  gitSigningKey: .*|  gitSigningKey: "ssh-ed25519 AAAATESTKEY comment"|' \
+		"s|^  opSshSignProgram: .*|  opSshSignProgram: \"${TEST_DIR}/op-ssh-sign-wsl.exe\"|")"
 	run _render "${cfg}" "${REPO_ROOT}/home/dot_config/git/config.tmpl"
 	[ "$status" -eq 0 ]
 	# git needs the key:: prefix to read a literal public key rather than a path.
 	[[ "$output" =~ "signingkey = key::ssh-ed25519 AAAATESTKEY comment" ]]
 	[[ "$output" =~ "gpgsign = true" ]]
 	[[ "$output" =~ "format = ssh" ]]
+	[[ "$output" =~ "op-ssh-sign-wsl.exe" ]]
 	# WSL keeps routing ssh through the Windows client.
 	[[ "$output" =~ "sshCommand = ssh.exe" ]]
+}
+
+@test "wsl-signing: a missing signer leaves signing OFF rather than breaking commits" {
+	_skip_without_chezmoi
+	local cfg
+	# No signer override and no /mnt/c on this host, so auto-detection finds
+	# nothing. Enabling gpgsign anyway would make git fall back to the local
+	# ssh-keygen, which cannot reach the 1Password-held key: every commit fails.
+	cfg="$(_config \
+		's|^  wsl: .*|  wsl: true|' \
+		's|^  useYubiKey: .*|  useYubiKey: false|' \
+		's|^  gitSigningKey: .*|  gitSigningKey: "ssh-ed25519 AAAATESTKEY comment"|' \
+		's|^  opSshSignProgram: .*|  opSshSignProgram: ""|')"
+	run _render "${cfg}" "${REPO_ROOT}/home/dot_config/git/config.tmpl"
+	[ "$status" -eq 0 ]
+	[[ ! "$output" =~ "gpgsign" ]]
+	[[ ! "$output" =~ "signingkey" ]]
+	[[ "$output" =~ "signing is left OFF on purpose" ]]
 }
 
 @test "wsl-signing: no signing key means no signing configuration" {
@@ -305,4 +348,62 @@ _render() {
 	run _render "${cfg}" "${REPO_ROOT}/home/dot_config/git/allowed_signers.tmpl"
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "ssh-ed25519 AAAATESTKEY comment" ]]
+}
+
+@test "op-plugins: wrappers stay out of the way in an SSH session" {
+	_skip_without_chezmoi
+	local cfg out="${TEST_DIR}/op-plugins.sh"
+	cfg="$(_config)"
+	_render "${cfg}" "${BASH_TMPL}" >"${out}"
+
+	printf '#!/bin/bash\necho "OP_RUN: $*"\n' >"${TEST_DIR}/op"
+	printf '#!/bin/bash\necho "REAL_GH: $*"\n' >"${TEST_DIR}/gh"
+	chmod +x "${TEST_DIR}/op" "${TEST_DIR}/gh"
+
+	# `op plugin run` needs the 1Password desktop app, which a headless host
+	# reached over SSH does not have. Wrapping there would break copilot-ssh,
+	# whose whole job is forwarding COPILOT_GITHUB_TOKEN / GH_TOKEN to it.
+	PATH="${TEST_DIR}:${ORIGINAL_PATH}" SSH_CONNECTION="10.0.0.1 22 10.0.0.2 22" \
+		run bash -c "source '${out}'; gh auth status; echo \"sourced=\${OP_PLUGIN_ALIASES_SOURCED:-unset}\""
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "REAL_GH: auth status" ]]
+	[[ ! "$output" =~ "OP_RUN:" ]]
+	[[ "$output" =~ "sourced=unset" ]]
+}
+
+@test "op-plugins: fish wrappers also stay out of the way over SSH" {
+	_skip_without_chezmoi
+	command -v fish >/dev/null 2>&1 || skip "fish not installed"
+	local cfg out="${TEST_DIR}/op-plugins.fish"
+	cfg="$(_config)"
+	_render "${cfg}" "${FISH_TMPL}" >"${out}"
+
+	printf '#!/bin/bash\necho "OP_RUN: $*"\n' >"${TEST_DIR}/op"
+	printf '#!/bin/bash\necho "REAL_GH: $*"\n' >"${TEST_DIR}/gh"
+	chmod +x "${TEST_DIR}/op" "${TEST_DIR}/gh"
+
+	run fish --no-config -c "set -gx PATH '${TEST_DIR}' \$PATH; set -gx SSH_CONNECTION '10.0.0.1 22 10.0.0.2 22'; source '${out}'; gh auth status"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "REAL_GH: auth status" ]]
+	[[ ! "$output" =~ "OP_RUN:" ]]
+}
+
+@test "op-plugins: copilot-ssh forwarded tokens survive on the remote host" {
+	_skip_without_chezmoi
+	local cfg out="${TEST_DIR}/op-plugins.sh"
+	cfg="$(_config)"
+	_render "${cfg}" "${BASH_TMPL}" >"${out}"
+
+	printf '#!/bin/bash\necho "OP_RUN: $*"\n' >"${TEST_DIR}/op"
+	printf '#!/bin/bash\necho "COPILOT_TOKEN=${COPILOT_GITHUB_TOKEN:-unset}"\n' >"${TEST_DIR}/copilot"
+	chmod +x "${TEST_DIR}/op" "${TEST_DIR}/copilot"
+
+	# Simulates the session copilot-ssh opens: token forwarded via SendEnv, and
+	# op present on the remote. The real copilot must run and see the token.
+	PATH="${TEST_DIR}:${ORIGINAL_PATH}" SSH_CONNECTION="10.0.0.1 22 10.0.0.2 22" \
+		COPILOT_GITHUB_TOKEN="forwarded-token" \
+		run bash -c "source '${out}'; copilot"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "COPILOT_TOKEN=forwarded-token" ]]
+	[[ ! "$output" =~ "OP_RUN:" ]]
 }


### PR DESCRIPTION
Implements [Managing shell plugins in your own dotfiles](https://github.com/1Password/shell-plugins#managing-shell-plugins-in-your-own-dotfiles), including the [GitHub Copilot plugin](https://www.1password.dev/cli/shell-plugins/github-copilot), and closes the remaining gaps in the [1Password WSL SSH integration](https://www.1password.dev/ssh/integrations/wsl).

## 1. Shell plugins tracked in this repo

`op plugin init` writes wrappers to `~/.config/op/plugins.sh` — outside version control, so a new machine silently loses them. 1Password documents defining the functions yourself; this PR generates them from chezmoi templates for bash/zsh and fish, and exports `OP_PLUGIN_ALIASES_SOURCED=1`.

Wrapped CLIs come from a new `opShellPlugins` variable (default `gh`, `copilot`), accepting a YAML list **or** a comma-separated string (trimmed, de-duplicated, sorted).

The Copilot plugin injects `COPILOT_GITHUB_TOKEN` — the same variable `copilot-ssh` forwards — so the two are complementary:

| Where | Mechanism | Token source |
| --- | --- | --- |
| Workstation | `op plugin run -- copilot` | 1Password item, per command |
| Headless server | `copilot-ssh` + SSH `SendEnv` | 1Password Environment |

**Safety rails** (a broken wrapper would otherwise *replace* a working CLI):
- Nothing is defined at all when `op` is missing.
- Each CLI is wrapped only if actually installed — otherwise `command -v gh` would start lying on machines without `gh`.
- fish wrappers use `--wraps`; bash/zsh completions load *before* the wrappers, so `gh completion` can't trigger a 1Password prompt at shell startup.

## 2. WSL

Shell plugins **do not work in WSL** — `op plugin run` reports *"Shell Plugins are currently not supported on this operating system"* ([shell-plugins#402](https://github.com/1Password/shell-plugins/issues/402), still open). Both wrapper files are therefore skipped via `.chezmoiignore` on WSL hosts.

WSL reaches 1Password through the Windows host instead. `core.sshCommand = ssh.exe` was already configured; this PR adds the rest:

- **Commit signing** via `op-ssh-sign-wsl.exe`, keyed off a new `gitSigningKey` variable (the public key from the app's *Configure Commit Signing → Copy Snippet*). The signer is located automatically, preferring the MSIX path and falling back to the pre-8.11.18 one; if neither exists the rendered config says so instead of emitting a broken `gpg.ssh.program`. The key is also added to `allowed_signers`.
- **`ssh` / `ssh-add` aliases** to their `.exe` counterparts, guarded on `WSL_DISTRO_NAME` *and* `ssh.exe` being reachable, so they never leak into native Linux/macOS and stay inert when interop is off.

`useYubiKey = true` still takes precedence over the 1Password signing branch.

Verified empirically that git accepts a literal public key in `user.signingkey`; the template adds the documented `key::` prefix so it is unambiguously a key and not a path.

## Testing

- New `tests/bash/op-shell-plugins.bats` (23 tests) renders the **real** templates through chezmoi rather than re-implementing their logic inline, so the tests break when a template changes.
- Full bats suite: green except two **pre-existing** `log-structured.bats` JSON failures that also fail on `main` locally and pass in CI.
- `mkdocs build --strict` passes; `chezmoi apply` verified end-to-end against a temporary destination.
- shellcheck / shfmt / `fish -n` clean on all changed files.

## Note for existing machines

`.chezmoi.yaml.tmpl` gained variables, so run `chezmoi init` once to regenerate the local config before `chezmoi apply` (chezmoi warns about this itself).

## Docs

New: `docs/1password-shell-plugins.md`, `docs/wsl.md`. Updated: `docs/chezmoi-variables.md`, `docs/copilot-cli.md`, and the mkdocs nav (which was also missing the existing `copilot-cli.md`).