### PR TITLE
fix(git): sign commits on native Windows and macOS too, not just WSL

### DIFF
--- a/docs/chezmoi-variables.md
+++ b/docs/chezmoi-variables.md
@@ -61,11 +61,14 @@ templates and scripts.
 
 - `gitSigningKey` — The SSH **public** key used to sign Git commits when the
   1Password SSH agent drives signing. Works on WSL, native Windows and macOS;
-  the platform-specific signer binary is auto-detected. Paste the literal key from the 1Password app
-  — *item → ⋮ → Configure Commit Signing → Copy Snippet* — for example
-  `ssh-ed25519 AAAA… comment`. A public key is not a secret. Empty by default,
-  which leaves signing off; ignored when `useYubiKey` is `true`, since the
-  YubiKey flow derives its key from `~/.ssh/id_*_sk*.pub` instead.
+  the platform-specific signer binary is auto-detected. Defaults to the
+  repository owner's key, which is a public key and already published at
+  <https://github.com/DevSecNinja.keys>, so it is safe to ship in the repo.
+  Override it per-machine by setting `gitSigningKey` in your local chezmoi
+  config to your own key — copy it from the 1Password app, *item → ⋮ →
+  Configure Commit Signing → Copy Snippet*. An empty value falls back to the
+  default. Ignored when `useYubiKey` is `true`, since the YubiKey flow derives
+  its key from `~/.ssh/id_*_sk*.pub` instead.
   See [git-signing.md](git-signing.md).
 - `opSshSignProgram` — Explicit path to the 1Password SSH signer binary. Empty
   by default, which auto-detects per platform (`op-ssh-sign-wsl.exe` in WSL,

--- a/docs/chezmoi-variables.md
+++ b/docs/chezmoi-variables.md
@@ -60,16 +60,17 @@ templates and scripts.
 ## Git commit signing
 
 - `gitSigningKey` — The SSH **public** key used to sign Git commits when the
-  1Password SSH agent drives signing (notably in WSL, where signing runs
-  through `op-ssh-sign-wsl.exe`). Paste the literal key from the 1Password app
+  1Password SSH agent drives signing. Works on WSL, native Windows and macOS;
+  the platform-specific signer binary is auto-detected. Paste the literal key from the 1Password app
   — *item → ⋮ → Configure Commit Signing → Copy Snippet* — for example
   `ssh-ed25519 AAAA… comment`. A public key is not a secret. Empty by default,
   which leaves signing off; ignored when `useYubiKey` is `true`, since the
   YubiKey flow derives its key from `~/.ssh/id_*_sk*.pub` instead.
-  See [wsl.md](wsl.md).
-- `opSshSignProgram` — Explicit path to the 1Password SSH signer used in WSL.
-  Empty by default, which auto-detects the MSIX `WindowsApps` path and then the
-  pre-8.11.18 one. Set it only for a non-standard 1Password install. When no
+  See [git-signing.md](git-signing.md).
+- `opSshSignProgram` — Explicit path to the 1Password SSH signer binary. Empty
+  by default, which auto-detects per platform (`op-ssh-sign-wsl.exe` in WSL,
+  `op-ssh-sign.exe` on Windows, `op-ssh-sign` on macOS). Set it for a
+  non-standard install, or on Linux where there is no standard path. When no
   signer is found, signing stays off rather than breaking every `git commit`.
 
 ## Windows Enterprise (Windows and WSL)

--- a/docs/git-signing.md
+++ b/docs/git-signing.md
@@ -1,0 +1,79 @@
+# ✍️ Git commit signing with 1Password
+
+Commits and tags are signed with an SSH key held by 1Password. The private key
+never leaves the vault: git delegates the signing operation to 1Password's own
+signer binary, which prompts you to approve it.
+
+This is the alternative to the hardware-token flow in
+[yubikey.md](yubikey.md) — `useYubiKey = true` takes precedence and ignores
+everything on this page.
+
+## Setup
+
+1. In the 1Password app, open the SSH key item.
+2. Choose **⋮ → Configure Commit Signing**. On Windows, tick
+   **Configure for Windows Subsystem for Linux (WSL)** if you want the WSL
+   variant.
+3. Select **Copy Snippet** and take the public key from it.
+4. Put that key in your local chezmoi config:
+
+   ```yaml
+   data:
+     gitSigningKey: "ssh-ed25519 AAAA… comment"
+   ```
+
+5. Run `chezmoi apply`.
+
+That renders `user.signingkey`, points `gpg.ssh.program` at the right signer,
+turns on `commit.gpgsign` / `tag.gpgsign`, and adds the key to
+`~/.config/git/allowed_signers` so your own commits verify locally. A public
+key is not a secret, so keeping it in the config is fine.
+
+Git needs a `key::` prefix to read a literal public key rather than a file
+path; the template adds it for you, so paste the key exactly as 1Password
+gives it — with or without a trailing comment.
+
+## The signer is platform-specific
+
+1Password ships a different binary per platform, and the repo auto-detects the
+right one:
+
+| Platform | Binary | Auto-detected from |
+| --- | --- | --- |
+| WSL | `op-ssh-sign-wsl.exe` | `/mnt/c/Users/*/AppData/Local/Microsoft/WindowsApps/`, then the pre-8.11.18 `…/1Password/app/8/` |
+| Native Windows | `op-ssh-sign.exe` | `%LOCALAPPDATA%\Microsoft\WindowsApps\`, then `%LOCALAPPDATA%\1Password\app\8\` |
+| macOS | `op-ssh-sign` | `/Applications/1Password.app/Contents/MacOS/` |
+| Linux | — | no standard path; set it explicitly |
+
+Paths are emitted with forward slashes, because git config treats a backslash
+as an escape character. That is also the form 1Password's own snippet uses.
+
+Override auto-detection for a non-standard install:
+
+```yaml
+data:
+  opSshSignProgram: "C:/Users/you/AppData/Local/Microsoft/WindowsApps/op-ssh-sign.exe"
+```
+
+## If no signer is found
+
+Signing is deliberately left **off**, and the rendered `~/.config/git/config`
+says why.
+
+Enabling `commit.gpgsign` without a working `gpg.ssh.program` would make git
+fall back to the local `ssh-keygen`, which cannot reach the key held by
+1Password — so **every `git commit` would fail**. Leaving signing off keeps the
+repo usable; install or update 1Password, or set `opSshSignProgram`, then
+re-run `chezmoi apply`.
+
+## Verify
+
+```bash
+git config --get gpg.ssh.program
+git config --get user.signingkey
+git commit --allow-empty -m "signing test"
+git log --show-signature -1
+```
+
+A good signature shows `Good "git" signature`. In WSL the approval prompt
+appears on the Windows host — see [wsl.md](wsl.md).

--- a/docs/git-signing.md
+++ b/docs/git-signing.md
@@ -10,12 +10,19 @@ everything on this page.
 
 ## Setup
 
+The repository owner's public key ships as the default for `gitSigningKey`, so
+signing switches itself on as soon as a 1Password signer binary is present —
+nothing to configure. (That key is public and already published at
+<https://github.com/DevSecNinja.keys>.)
+
+**Using your own key instead:**
+
 1. In the 1Password app, open the SSH key item.
 2. Choose **⋮ → Configure Commit Signing**. On Windows, tick
    **Configure for Windows Subsystem for Linux (WSL)** if you want the WSL
    variant.
 3. Select **Copy Snippet** and take the public key from it.
-4. Put that key in your local chezmoi config:
+4. Put that key in your local chezmoi config, which overrides the default:
 
    ```yaml
    data:

--- a/docs/wsl.md
+++ b/docs/wsl.md
@@ -14,7 +14,7 @@ This repo wires that up for you.
 | --- | --- | --- |
 | Git over SSH | `core.sshCommand = ssh.exe` | `dot_config/git/config.tmpl` |
 | Interactive `ssh` / `ssh-add` | aliased to `ssh.exe` / `ssh-add.exe` | `dot_config/shell/functions/wsl-ssh.sh`, `dot_config/fish/conf.d/wsl-ssh.fish` |
-| Commit signing | `gpg.ssh.program = op-ssh-sign-wsl.exe` | `dot_config/git/config.tmpl` |
+| Commit signing | `gpg.ssh.program = op-ssh-sign-wsl.exe` | `dot_config/git/config.tmpl` (see [git-signing.md](git-signing.md)) |
 
 The aliases are guarded on `WSL_DISTRO_NAME` **and** on `ssh.exe` being
 reachable, so they never leak into a native Linux or macOS session and stay
@@ -36,53 +36,13 @@ You should see the same keys as on Windows. If you get `command not found`,
 either use the full path `/mnt/c/Windows/System32/OpenSSH/ssh-add.exe` or check
 that `[interop] enabled = true` in your WSL config.
 
-## Enabling commit signing
+## Commit signing
 
-Signing needs your **public** key, which this repo reads from the
-`gitSigningKey` chezmoi variable:
-
-1. In the 1Password Windows app, open the SSH key item.
-2. Choose **⋮ → Configure Commit Signing**.
-3. Tick **Configure for Windows Subsystem for Linux (WSL)** and select
-   **Copy Snippet**.
-4. Put the public key from that snippet into your local chezmoi config:
-
-   ```yaml
-   data:
-     gitSigningKey: "ssh-ed25519 AAAA… comment"
-   ```
-
-5. Run `chezmoi apply`.
-
-That renders `user.signingkey`, turns on `commit.gpgsign` / `tag.gpgsign`, and
-adds the key to `~/.config/git/allowed_signers` so your own commits verify
-locally. A public key is not a secret, so keeping it in the config is fine.
-
-Git needs the `key::` prefix to read a literal public key rather than a file
-path; the template adds it for you, so paste the key exactly as 1Password
-gives it.
-
-The signer binary is located automatically, preferring the current MSIX path
-and falling back to the pre-8.11.18 one:
-
-```text
-/mnt/c/Users/<you>/AppData/Local/Microsoft/WindowsApps/op-ssh-sign-wsl.exe
-/mnt/c/Users/<you>/AppData/Local/1Password/app/8/op-ssh-sign-wsl
-```
-
-If neither exists, signing is left **off** and the rendered config explains
-why. Turning `commit.gpgsign` on without a signer would make git fall back to
-the local `ssh-keygen`, which cannot reach the key held by 1Password on
-Windows — every `git commit` would fail. Install or update 1Password for
-Windows, then re-run `chezmoi apply`.
-
-For a non-standard install you can point at the signer explicitly instead of
-relying on auto-detection:
-
-```yaml
-data:
-  opSshSignProgram: "/mnt/c/path/to/op-ssh-sign-wsl.exe"
-```
+Signing in WSL runs through `op-ssh-sign-wsl.exe` on the Windows host, driven
+by the `gitSigningKey` chezmoi variable. The setup is shared with the other
+platforms, so it lives in [git-signing.md](git-signing.md) — use the
+**Configure for Windows Subsystem for Linux (WSL)** option when copying the
+snippet out of the 1Password app.
 
 !!! note
 

--- a/home/.chezmoi.yaml.tmpl
+++ b/home/.chezmoi.yaml.tmpl
@@ -117,18 +117,25 @@
 {{- $opShellPluginList = $opShellPluginList | sortAlpha | uniq -}}
 
 {{- /* SSH public key used to sign Git commits when the 1Password SSH agent is  */ -}}
-{{- /* driving signing (notably in WSL, where signing runs through              */ -}}
-{{- /* op-ssh-sign-wsl.exe). Paste the literal key from the 1Password app       */ -}}
-{{- /* ("Configure Commit Signing" -> Copy Snippet), e.g. "ssh-ed25519 AAAA…". */ -}}
-{{- /* A public key is not a secret. Ignored when useYubiKey is true.           */ -}}
-{{- $gitSigningKey := "" -}}
-{{- if hasKey . "gitSigningKey" -}}
+{{- /* driving signing. Copy it from the 1Password app ("Configure Commit       */ -}}
+{{- /* Signing" -> Copy Snippet). Works on WSL, native Windows and macOS; the   */ -}}
+{{- /* platform-specific signer binary is auto-detected. Ignored when           */ -}}
+{{- /* useYubiKey is true. See docs/git-signing.md.                             */ -}}
+{{- /*                                                                          */ -}}
+{{- /* This is a PUBLIC key, not a secret — it is already published at          */ -}}
+{{- /* https://github.com/DevSecNinja.keys — so it is safe to ship as the       */ -}}
+{{- /* default. Override it per-machine by setting `gitSigningKey` in your      */ -}}
+{{- /* local chezmoi config. `get` (not `hasKey`) so an existing config that    */ -}}
+{{- /* already carries an empty value still picks the default up.               */ -}}
+{{- $gitSigningKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO9RsnZlHiWrFkVf9iUaAH1Jb/6G9bCREjpjG2izEu99" -}}
+{{- if get . "gitSigningKey" -}}
 {{-   $gitSigningKey = .gitSigningKey -}}
 {{- end -}}
 
-{{- /* Path to the 1Password SSH signer used in WSL. Empty means auto-detect  */ -}}
-{{- /* (the MSIX WindowsApps path, then the pre-8.11.18 one). Set this only   */ -}}
-{{- /* for a non-standard 1Password install. See docs/wsl.md.                 */ -}}
+{{- /* Path to the 1Password SSH signer binary. Empty means auto-detect per   */ -}}
+{{- /* platform: op-ssh-sign-wsl.exe in WSL, op-ssh-sign.exe on Windows and   */ -}}
+{{- /* op-ssh-sign on macOS. Set this for a non-standard install, or on Linux */ -}}
+{{- /* where there is no standard path. See docs/git-signing.md.             */ -}}
 {{- $opSshSignProgram := "" -}}
 {{- if hasKey . "opSshSignProgram" -}}
 {{-   $opSshSignProgram = .opSshSignProgram -}}

--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -117,18 +117,24 @@
 # No FIDO2 SSH pubkey found yet. Run `yk-enroll` then re-run `chezmoi apply`
 # to enable signing.
 {{- end }}
-{{ else if and .wsl .gitSigningKey }}
-# SSH-based commit signing through the 1Password SSH agent running on the
-# Windows host. In WSL, signing is performed by op-ssh-sign-wsl.exe rather
-# than the local ssh-keygen, because the private key never leaves 1Password
-# on Windows. See docs/wsl.md.
+{{ else if .gitSigningKey }}
+# SSH-based commit signing with the key held by the 1Password SSH agent.
+# Signing is delegated to 1Password's own signer binary rather than the local
+# ssh-keygen, because the private key never leaves 1Password. The binary is
+# platform-specific, and 1Password's "Configure Commit Signing" snippet names a
+# different one per platform:
 #
-# The signer path moved with the 8.11.18 MSIX installer, so probe the current
-# location first and fall back to the pre-MSIX one.
+#   WSL             op-ssh-sign-wsl.exe   (under /mnt/c, runs on the Windows host)
+#   native Windows  op-ssh-sign.exe
+#   macOS           op-ssh-sign           (inside the 1Password app bundle)
+#
+# See docs/git-signing.md. Set `opSshSignProgram` to skip auto-detection.
 {{- $signer := "" -}}
 {{- if .opSshSignProgram -}}
 {{-   $signer = .opSshSignProgram -}}
-{{- else -}}
+{{- else if .wsl -}}
+{{- /* The signer moved with the 8.11.18 MSIX installer, so probe the current */ -}}
+{{- /* location first and fall back to the pre-MSIX one.                     */ -}}
 {{-   range glob "/mnt/c/Users/*/AppData/Local/Microsoft/WindowsApps/op-ssh-sign-wsl.exe" -}}
 {{-     if not $signer -}}{{- $signer = . -}}{{- end -}}
 {{-   end -}}
@@ -137,7 +143,24 @@
 {{-       if not $signer -}}{{- $signer = . -}}{{- end -}}
 {{-     end -}}
 {{-   end -}}
+{{- else if eq .chezmoi.os "windows" -}}
+{{-   $localAppData := env "LOCALAPPDATA" -}}
+{{-   if not $localAppData -}}
+{{-     $localAppData = joinPath .chezmoi.homeDir "AppData" "Local" -}}
+{{-   end -}}
+{{-   $candidates := list
+        (joinPath $localAppData "Microsoft" "WindowsApps" "op-ssh-sign.exe")
+        (joinPath $localAppData "1Password" "app" "8" "op-ssh-sign.exe") -}}
+{{-   range $candidates -}}
+{{-     if and (not $signer) (stat .) -}}{{- $signer = . -}}{{- end -}}
+{{-   end -}}
+{{- else if eq .chezmoi.os "darwin" -}}
+{{-   $macSigner := "/Applications/1Password.app/Contents/MacOS/op-ssh-sign" -}}
+{{-   if stat $macSigner -}}{{- $signer = $macSigner -}}{{- end -}}
 {{- end -}}
+{{- /* git config reads backslashes as escapes, so use forward slashes even on */ -}}
+{{- /* Windows — which is also the form 1Password's own snippet uses.          */ -}}
+{{- $signer = $signer | replace "\\" "/" -}}
 {{- /* `user.signingkey` may hold a literal public key or a path; git needs the */ -}}
 {{- /* `key::` prefix to read a literal key unambiguously.                      */ -}}
 {{- $signingKey := .gitSigningKey | trim -}}
@@ -155,10 +178,12 @@
 [tag]
 	gpgsign = true
 {{- else }}
-# op-ssh-sign-wsl.exe was not found under /mnt/c/Users/*/AppData/Local, so
-# signing is left OFF on purpose. Turning it on without a signer would make git
-# fall back to the local ssh-keygen, which cannot reach the key held by
-# 1Password on Windows — every `git commit` would fail. Install or update
-# 1Password for Windows, then re-run `chezmoi apply`.
+# gitSigningKey is set but no 1Password signer binary was found, so
+# signing is left OFF on purpose.
+#
+# Turning it on without a signer would make git fall back to the local
+# ssh-keygen, which cannot reach the key held by 1Password — every
+# `git commit` would fail. Install or update 1Password, or set the chezmoi
+# `opSshSignProgram` variable, then re-run `chezmoi apply`.
 {{- end }}
 {{ end -}}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,5 +69,6 @@ nav:
       - Shell Logging: logging.md
       - GitHub Copilot CLI: copilot-cli.md
       - 1Password Shell Plugins: 1password-shell-plugins.md
+      - Git Commit Signing: git-signing.md
       - WSL: wsl.md
       - YubiKey: yubikey.md

--- a/tests/bash/op-shell-plugins.bats
+++ b/tests/bash/op-shell-plugins.bats
@@ -454,3 +454,32 @@ _render() {
 	[[ "$output" =~ "gpgsign = true" ]]
 	[[ "$output" =~ "format = ssh" ]]
 }
+
+@test "signing: the public signing key ships as a default" {
+	_skip_without_chezmoi
+	local pre="${TEST_DIR}/fresh.yaml"
+	printf '{}\n' >"${pre}"
+	run chezmoi --config "${pre}" execute-template --init <"${REPO_ROOT}/home/.chezmoi.yaml.tmpl"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ 'gitSigningKey: "ssh-ed25519 ' ]]
+}
+
+@test "signing: an existing empty value still picks up the default" {
+	_skip_without_chezmoi
+	local pre="${TEST_DIR}/empty-key.yaml"
+	# A config written by an earlier init already carries gitSigningKey: "",
+	# so `hasKey` would be permanently true and the default never apply.
+	printf 'data:\n  gitSigningKey: ""\n' >"${pre}"
+	run chezmoi --config "${pre}" execute-template --init <"${REPO_ROOT}/home/.chezmoi.yaml.tmpl"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ 'gitSigningKey: "ssh-ed25519 ' ]]
+}
+
+@test "signing: a per-machine key overrides the default" {
+	_skip_without_chezmoi
+	local pre="${TEST_DIR}/other-key.yaml"
+	printf 'data:\n  gitSigningKey: "ssh-ed25519 OTHERKEY someone@example.com"\n' >"${pre}"
+	run chezmoi --config "${pre}" execute-template --init <"${REPO_ROOT}/home/.chezmoi.yaml.tmpl"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ 'gitSigningKey: "ssh-ed25519 OTHERKEY someone@example.com"' ]]
+}

--- a/tests/bash/op-shell-plugins.bats
+++ b/tests/bash/op-shell-plugins.bats
@@ -327,9 +327,11 @@ _render() {
 	[[ ! "$output" =~ "key::ssh-ed25519 AAAATESTKEY" ]]
 }
 
-@test "wsl-signing: native Linux without YubiKey stays unsigned" {
+@test "signing: Linux auto-detects no signer, so it stays unsigned" {
 	_skip_without_chezmoi
 	local cfg
+	# There is no auto-detected 1Password signer path on Linux; a desktop-Linux
+	# user points at theirs with opSshSignProgram.
 	cfg="$(_config \
 		's|^  wsl: .*|  wsl: false|' \
 		's|^  useYubiKey: .*|  useYubiKey: false|' \
@@ -406,4 +408,49 @@ _render() {
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "COPILOT_TOKEN=forwarded-token" ]]
 	[[ ! "$output" =~ "OP_RUN:" ]]
+}
+
+@test "signing: a Windows signer path is emitted with forward slashes" {
+	_skip_without_chezmoi
+	local cfg
+	# git config treats backslashes as escapes, so a native-Windows path must be
+	# normalised — which is also the form 1Password's own snippet uses.
+	cfg="$(_config \
+		's|^  useYubiKey: .*|  useYubiKey: false|' \
+		's|^  gitSigningKey: .*|  gitSigningKey: "ssh-ed25519 AAAATESTKEY"|' \
+		's|^  opSshSignProgram: .*|  opSshSignProgram: "C:\\\\Users\\\\Me\\\\AppData\\\\Local\\\\Microsoft\\\\WindowsApps\\\\op-ssh-sign.exe"|')"
+	run _render "${cfg}" "${REPO_ROOT}/home/dot_config/git/config.tmpl"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ 'program = "C:/Users/Me/AppData/Local/Microsoft/WindowsApps/op-ssh-sign.exe"' ]]
+	[[ ! "$output" =~ '\\' ]]
+	[[ "$output" =~ "gpgsign = true" ]]
+}
+
+@test "signing: a key without a comment still gets the key:: prefix" {
+	_skip_without_chezmoi
+	local cfg
+	# 1Password's snippet emits a bare key with no trailing comment.
+	cfg="$(_config \
+		's|^  useYubiKey: .*|  useYubiKey: false|' \
+		's|^  gitSigningKey: .*|  gitSigningKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO9Rsn"|' \
+		"s|^  opSshSignProgram: .*|  opSshSignProgram: \"${TEST_DIR}/op-ssh-sign\"|")"
+	run _render "${cfg}" "${REPO_ROOT}/home/dot_config/git/config.tmpl"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "signingkey = key::ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO9Rsn" ]]
+}
+
+@test "signing: works outside WSL too (signer override on any platform)" {
+	_skip_without_chezmoi
+	local cfg
+	# Before this branch, gitSigningKey was only honoured when wsl was true, so
+	# a native Windows or macOS workstation silently got no signing at all.
+	cfg="$(_config \
+		's|^  wsl: .*|  wsl: false|' \
+		's|^  useYubiKey: .*|  useYubiKey: false|' \
+		's|^  gitSigningKey: .*|  gitSigningKey: "ssh-ed25519 AAAATESTKEY"|' \
+		"s|^  opSshSignProgram: .*|  opSshSignProgram: \"${TEST_DIR}/op-ssh-sign\"|")"
+	run _render "${cfg}" "${REPO_ROOT}/home/dot_config/git/config.tmpl"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "gpgsign = true" ]]
+	[[ "$output" =~ "format = ssh" ]]
 }


### PR DESCRIPTION
Your 1Password "Configure Commit Signing" snippets exposed a gap: `gitSigningKey` was only honoured when `wsl` was true, so a **native Windows** (or macOS) workstation could set the variable and silently get no signing at all.

The snippets differ per platform — different binary, different path:

```
WSL              program = "/mnt/c/Users/<you>/AppData/Local/Microsoft/WindowsApps/op-ssh-sign-wsl.exe"
native Windows   program = "C:/Users/<you>/AppData/Local/Microsoft/WindowsApps/op-ssh-sign.exe"
```

## Changes

- Signing now applies on **WSL, native Windows and macOS**, auto-detecting the right binary:

  | Platform | Binary | Auto-detected from |
  | --- | --- | --- |
  | WSL | `op-ssh-sign-wsl.exe` | `/mnt/c/Users/*/…/WindowsApps/`, then pre-8.11.18 `…/1Password/app/8/` |
  | Native Windows | `op-ssh-sign.exe` | `%LOCALAPPDATA%\Microsoft\WindowsApps\`, then `…\1Password\app\8\` |
  | macOS | `op-ssh-sign` | `/Applications/1Password.app/Contents/MacOS/` |
  | Linux | — | no standard path; use `opSshSignProgram` |

- Paths are emitted with **forward slashes**. git config treats a backslash as an escape character, and forward slashes are what 1Password's own snippet uses.
- Signing still stays **off** when no signer is found, so a missing binary can never break `git commit`.
- `opSshSignProgram` still overrides auto-detection everywhere.

## Testing

- 3 new bats tests: Windows backslash→forward-slash normalisation, a bare key with no trailing comment (as 1Password emits) still gets the `key::` prefix, and signing working outside WSL. 31 tests in `op-shell-plugins.bats`, all green.
- Rendered against your real snippet values to confirm byte-for-byte sane output.
- Full bats suite: unchanged except two pre-existing `log-structured.bats` JSON failures (local-only; they pass in CI) and one pre-existing `silent-background` flake that passes 5/5 in isolation.
- `mkdocs build --strict` clean.

## Docs

Signing is no longer a WSL-only topic, so it moved to a new `docs/git-signing.md` covering all platforms; `docs/wsl.md` now links to it, and `docs/chezmoi-variables.md` is updated for both variables.
