### PR TITLE
feat(shell): add chezmoi-up to pull, re-init and apply in one step

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -58,6 +58,42 @@ chezmoi data
 chezmoi verify
 ```
 
+## Updating everything at once
+
+`chezmoi update && chezmoi init && chezmoi apply` is the usual dance after a
+change lands. The `chezmoi-up` helper does it for you, in every shell:
+
+| Shell | Command | Alias |
+| --- | --- | --- |
+| Bash / Zsh | `chezmoi-up` | `czu` |
+| fish | `chezmoi_up` | `czu` |
+| PowerShell | `Update-Chezmoi` | `chezmoi-up`, `chezmoi_up`, `czu` |
+
+It runs three steps and **stops at the first failure**, so a failed pull can
+never be followed by an apply of half-updated source:
+
+1. `chezmoi update --apply=false` — pull the source repo only. Applying here
+   would use the *old* config, which breaks when the pull introduces a
+   template variable your current config does not have yet.
+2. `chezmoi init` — **only when the config template actually changed.** It
+   compares the SHA256 chezmoi recorded in its `configState` bucket (the same
+   data behind its *"config file template has changed"* warning) with the
+   template on disk. When it skips, it says so; when the state cannot be read
+   it re-inits anyway, since a redundant init is harmless and a skipped one is
+   not.
+3. `chezmoi apply` — apply with the freshly generated config.
+
+Pass `--force-init` (`-ForceInit` in PowerShell) to regenerate the config even
+when the template is unchanged.
+
+```console
+$ czu
+==> Pulling the source repository
+==> Config template unchanged, skipping chezmoi init
+==> Applying
+✓ Dotfiles are up to date
+```
+
 ## Windows PATH
 
 On Windows, the setup adds `%OneDrive%\Portable Programs` to the user-scope

--- a/home/dot_config/fish/conf.d/aliases.fish
+++ b/home/dot_config/fish/conf.d/aliases.fish
@@ -35,6 +35,7 @@ alias cz 'chezmoi'
 alias czd 'chezmoi diff'
 alias cza 'chezmoi apply'
 alias cze 'chezmoi edit'
+alias czu 'chezmoi_up'
 
 # Docker shortcuts
 alias d 'docker'

--- a/home/dot_config/fish/functions/chezmoi_up.fish
+++ b/home/dot_config/fish/functions/chezmoi_up.fish
@@ -1,0 +1,142 @@
+function chezmoi_up --description 'Pull, re-init when the config template changed, then apply'
+    # chezmoi_up - Pull, re-init if needed, and apply your dotfiles in one go.
+    #
+    # Replaces the usual `chezmoi update && chezmoi init && chezmoi apply`
+    # dance. Each step is a gate: if one fails the run stops there, so a failed
+    # pull can never be followed by an apply of half-updated source.
+    #
+    # The steps are:
+    #   1. `chezmoi update --apply=false` — pull the source repo only. Applying
+    #      here would use the OLD config, which breaks when the pull introduces
+    #      a template variable the current config does not have yet.
+    #   2. `chezmoi init` — only when the config template actually changed,
+    #      which is the same check chezmoi uses for its "config file template
+    #      has changed" warning: the SHA256 stored in its configState bucket
+    #      versus the template now on disk. Skipping is logged.
+    #   3. `chezmoi apply` — apply with the freshly generated config.
+    #
+    # Usage: chezmoi_up [-f|--force-init] [-h|--help]   (alias: czu)
+
+    argparse --name=chezmoi_up h/help f/force-init -- $argv
+    or return 1
+
+    if set -q _flag_help
+        echo "Usage: chezmoi_up [-f|--force-init] [-h|--help]"
+        echo
+        echo "Pull, re-init when the config template changed, then apply."
+        echo
+        echo "Options:"
+        echo "  -f, --force-init   Run 'chezmoi init' even if the template is unchanged"
+        echo "  -h, --help         Show this help message"
+        return 0
+    end
+
+    if not command -q chezmoi
+        set_color red
+        echo "chezmoi_up: chezmoi is not installed or not in PATH" >&2
+        set_color normal
+        return 1
+    end
+
+    set_color --bold blue
+    echo "==> Pulling the source repository"
+    set_color normal
+    if not command chezmoi update --apply=false
+        set_color red
+        echo "✗ chezmoi update failed; not continuing to init/apply" >&2
+        set_color normal
+        return 1
+    end
+
+    set -l run_init false
+    set -l reason ""
+    if set -q _flag_force_init
+        set run_init true
+        set reason "forced"
+    else if _chezmoi_up_needs_init
+        set run_init true
+        set reason "config template changed"
+    end
+
+    if test $run_init = true
+        set_color --bold blue
+        echo "==> Regenerating the config file ($reason)"
+        set_color normal
+        if not command chezmoi init
+            set_color red
+            echo "✗ chezmoi init failed; not continuing to apply" >&2
+            set_color normal
+            return 1
+        end
+    else
+        echo "==> Config template unchanged, skipping chezmoi init"
+    end
+
+    set_color --bold blue
+    echo "==> Applying"
+    set_color normal
+    if not command chezmoi apply
+        set_color red
+        echo "✗ chezmoi apply failed" >&2
+        set_color normal
+        return 1
+    end
+
+    set_color --bold green
+    echo "✓ Dotfiles are up to date"
+    set_color normal
+    return 0
+end
+
+# _chezmoi_up_config_template -> print the chezmoi config template path
+# (usually <source>/.chezmoi.yaml.tmpl), or nothing when there is none.
+function _chezmoi_up_config_template --description 'Locate the chezmoi config template'
+    set -l source_dir (command chezmoi source-path 2>/dev/null)
+    or return 0
+    test -n "$source_dir"; or return 0
+
+    for ext in yaml toml json jsonc yml
+        set -l candidate "$source_dir/.chezmoi.$ext.tmpl"
+        if test -f "$candidate"
+            echo $candidate
+            return 0
+        end
+    end
+    return 0
+end
+
+# _chezmoi_up_sha256 FILE -> print the file's SHA256, or nothing.
+function _chezmoi_up_sha256 --description 'SHA256 of a file' --argument-names file
+    set -l out
+    if command -q sha256sum
+        set out (command sha256sum "$file" 2>/dev/null)
+    else if command -q shasum
+        set out (command shasum -a 256 "$file" 2>/dev/null)
+    end
+    test -n "$out"; or return 0
+    string split -f1 ' ' -- $out[1]
+end
+
+# _chezmoi_up_needs_init -> success when `chezmoi init` should run.
+# Compares the SHA256 chezmoi recorded for the config template with the
+# template on disk. When either side cannot be determined we return success and
+# let init run: a redundant init is harmless, a skipped one is not.
+function _chezmoi_up_needs_init --description 'Has the chezmoi config template changed?'
+    set -l template (_chezmoi_up_config_template)
+    test -n "$template"; or return 0
+
+    set -l state (command chezmoi state get --bucket=configState --key=configState 2>/dev/null)
+    test -n "$state"; or return 0
+
+    set -l stored (string match -r '"configTemplateContentsSHA256"\s*:\s*"([0-9a-f]+)"' -- (string join ' ' $state))[2]
+    test -n "$stored"; or return 0
+
+    set -l actual (_chezmoi_up_sha256 $template)
+    test -n "$actual"; or return 0
+
+    test "$stored" != "$actual"
+end
+
+complete -c chezmoi_up -f
+complete -c chezmoi_up -s h -l help -d "Show help message"
+complete -c chezmoi_up -s f -l force-init -d "Run chezmoi init even if the template is unchanged"

--- a/home/dot_config/powershell/aliases.ps1
+++ b/home/dot_config/powershell/aliases.ps1
@@ -48,6 +48,11 @@ function pubkey { Get-Content ~/.ssh/id_rsa.pub | Set-Clipboard; Write-Host '=> 
 Set-Alias -Name copilot-ssh -Value Connect-CopilotSsh
 Set-Alias -Name copilot_ssh -Value Connect-CopilotSsh
 
+# Chezmoi shortcuts
+Set-Alias -Name chezmoi-up -Value Update-Chezmoi
+Set-Alias -Name chezmoi_up -Value Update-Chezmoi
+Set-Alias -Name czu -Value Update-Chezmoi
+
 # Winget shortcuts
 Set-Alias -Name wup -Value Invoke-WingetUpgrade
 Set-Alias -Name winup -Value Invoke-WingetUpgrade

--- a/home/dot_config/powershell/modules/DotfilesHelpers/DotfilesHelpers.psd1
+++ b/home/dot_config/powershell/modules/DotfilesHelpers/DotfilesHelpers.psd1
@@ -24,6 +24,7 @@
         'Reset-ChezmoiScripts'
         'Reset-ChezmoiEntries'
         'Invoke-ChezmoiSigning'
+        'Update-Chezmoi'
 
         # Copilot CLI
         'Connect-CopilotSsh'

--- a/home/dot_config/powershell/modules/DotfilesHelpers/Public/ChezmoiUtilities.ps1
+++ b/home/dot_config/powershell/modules/DotfilesHelpers/Public/ChezmoiUtilities.ps1
@@ -71,7 +71,13 @@ function Get-ChezmoiConfigTemplate {
     [OutputType([string])]
     param()
 
-    $sourceDir = & chezmoi source-path 2>$null
+    # Guard and catch: with $ErrorActionPreference = 'Stop' (as under GitHub
+    # Actions' `shell: pwsh`) a missing chezmoi would otherwise throw.
+    if (-not (Get-Command chezmoi -CommandType Application -ErrorAction SilentlyContinue)) { return $null }
+
+    $sourceDir = $null
+    try { $sourceDir = & chezmoi source-path 2>$null }
+    catch { return $null }
     if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($sourceDir)) { return $null }
 
     foreach ($ext in @('yaml', 'toml', 'json', 'jsonc', 'yml')) {
@@ -99,7 +105,9 @@ function Test-ChezmoiConfigChanged {
     $template = Get-ChezmoiConfigTemplate
     if (-not $template) { return $true }
 
-    $state = & chezmoi state get --bucket=configState --key=configState 2>$null
+    $state = $null
+    try { $state = & chezmoi state get --bucket=configState --key=configState 2>$null }
+    catch { return $true }
     if ($LASTEXITCODE -ne 0 -or -not $state) { return $true }
 
     $stored = $null

--- a/home/dot_config/powershell/modules/DotfilesHelpers/Public/ChezmoiUtilities.ps1
+++ b/home/dot_config/powershell/modules/DotfilesHelpers/Public/ChezmoiUtilities.ps1
@@ -60,6 +60,146 @@ function Invoke-ChezmoiSigning {
     & $signingScript -CertificateThumbprint $CertificateThumbprint -Path $repoRoot
 }
 
+function Get-ChezmoiConfigTemplate {
+    <#
+    .SYNOPSIS
+    Returns the path of the chezmoi config template, or $null when there is none.
+    .DESCRIPTION
+    Usually <source-path>/.chezmoi.yaml.tmpl. Private helper for Update-Chezmoi.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    $sourceDir = & chezmoi source-path 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($sourceDir)) { return $null }
+
+    foreach ($ext in @('yaml', 'toml', 'json', 'jsonc', 'yml')) {
+        $candidate = Join-Path $sourceDir ".chezmoi.$ext.tmpl"
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) { return $candidate }
+    }
+    return $null
+}
+
+function Test-ChezmoiConfigChanged {
+    <#
+    .SYNOPSIS
+    Returns $true when `chezmoi init` should run.
+    .DESCRIPTION
+    Compares the SHA256 chezmoi recorded for the config template (its
+    configState bucket, the same data behind its "config file template has
+    changed" warning) with the template on disk. When either side cannot be
+    determined this returns $true and lets init run: a redundant init is
+    harmless, a skipped one is not.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    $template = Get-ChezmoiConfigTemplate
+    if (-not $template) { return $true }
+
+    $state = & chezmoi state get --bucket=configState --key=configState 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $state) { return $true }
+
+    $stored = $null
+    try {
+        $stored = ($state | ConvertFrom-Json).configTemplateContentsSHA256
+    }
+    catch {
+        return $true
+    }
+    if ([string]::IsNullOrWhiteSpace($stored)) { return $true }
+
+    $actual = (Get-FileHash -LiteralPath $template -Algorithm SHA256).Hash
+    if ([string]::IsNullOrWhiteSpace($actual)) { return $true }
+
+    return ($stored -ne $actual)
+}
+
+function Update-Chezmoi {
+    <#
+    .SYNOPSIS
+    Pull, re-init when the config template changed, then apply, stopping on the
+    first failure.
+
+    .DESCRIPTION
+    Replaces the usual `chezmoi update; chezmoi init; chezmoi apply` dance.
+    Each step is a gate: if one fails the run stops there, so a failed pull can
+    never be followed by an apply of half-updated source.
+
+    The steps are:
+      1. `chezmoi update --apply=false` - pull the source repo only. Applying
+         here would use the OLD config, which breaks when the pull introduces a
+         template variable the current config does not have yet.
+      2. `chezmoi init` - only when the config template actually changed.
+         Skipping is logged.
+      3. `chezmoi apply` - apply with the freshly generated config.
+
+    .PARAMETER ForceInit
+    Run `chezmoi init` even when the config template is unchanged.
+
+    .EXAMPLE
+    Update-Chezmoi
+    Pull, conditionally re-init, and apply.
+
+    .EXAMPLE
+    czu -ForceInit
+    Same, but always regenerate the config file.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Interactive helper; progress output is the point.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Thin wrapper around chezmoi, which owns its own --dry-run/--force flags.')]
+    [CmdletBinding()]
+    param(
+        [Alias('f')]
+        [switch]$ForceInit
+    )
+
+    if (-not (Get-Command chezmoi -CommandType Application -ErrorAction SilentlyContinue)) {
+        Write-Error 'chezmoi is not installed or not in PATH' -ErrorAction Continue
+        return
+    }
+
+    Write-Host '==> Pulling the source repository' -ForegroundColor Blue
+    & chezmoi update --apply=false
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error 'chezmoi update failed; not continuing to init/apply' -ErrorAction Continue
+        return
+    }
+
+    $runInit = $false
+    $reason = ''
+    if ($ForceInit) {
+        $runInit = $true
+        $reason = 'forced'
+    }
+    elseif (Test-ChezmoiConfigChanged) {
+        $runInit = $true
+        $reason = 'config template changed'
+    }
+
+    if ($runInit) {
+        Write-Host "==> Regenerating the config file ($reason)" -ForegroundColor Blue
+        & chezmoi init
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error 'chezmoi init failed; not continuing to apply' -ErrorAction Continue
+            return
+        }
+    }
+    else {
+        Write-Host '==> Config template unchanged, skipping chezmoi init'
+    }
+
+    Write-Host '==> Applying' -ForegroundColor Blue
+    & chezmoi apply
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error 'chezmoi apply failed' -ErrorAction Continue
+        return
+    }
+
+    Write-Host '[OK] Dotfiles are up to date' -ForegroundColor Green
+}
+
 # SIG # Begin signature block
 # MIIfEQYJKoZIhvcNAQcCoIIfAjCCHv4CAQExDzANBglghkgBZQMEAgEFADB5Bgor
 # BgEEAYI3AgEEoGswaTA0BgorBgEEAYI3AgEeMCYCAwEAAAQQH8w7YFlLCE63JNLG

--- a/home/dot_config/shell/functions/chezmoi-up.sh
+++ b/home/dot_config/shell/functions/chezmoi-up.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# chezmoi-up - Pull, re-init if needed, and apply your dotfiles in one go.
+#
+# Replaces the usual `chezmoi update && chezmoi init && chezmoi apply` dance.
+# Each step is a gate: if one fails the run stops there, so a failed pull can
+# never be followed by an apply of half-updated source.
+#
+# The steps are:
+#   1. `chezmoi update --apply=false` — pull the source repo only. Applying
+#      here would use the OLD config, which breaks when the pull introduces a
+#      template variable the current config does not have yet.
+#   2. `chezmoi init` — only when the config template actually changed, which
+#      is the same check chezmoi uses for its "config file template has
+#      changed" warning: the SHA256 stored in its configState bucket versus
+#      the template now on disk. Skipping is logged.
+#   3. `chezmoi apply` — apply with the freshly generated config.
+#
+# Usage: chezmoi-up [-f|--force-init] [-h|--help]
+#   -f, --force-init   Run `chezmoi init` even if the template is unchanged
+#   -h, --help         Show this help message
+#
+# Alias: czu
+
+# _chezmoi_up_config_template -> print the path of the chezmoi config template
+# (usually <source>/.chezmoi.yaml.tmpl), or nothing when there is none.
+_chezmoi_up_config_template() {
+    local source_dir candidate ext
+    source_dir="$(chezmoi source-path 2>/dev/null)" || return 0
+    [ -n "${source_dir}" ] || return 0
+
+    for ext in yaml toml json jsonc yml; do
+        candidate="${source_dir}/.chezmoi.${ext}.tmpl"
+        if [ -f "${candidate}" ]; then
+            printf '%s\n' "${candidate}"
+            return 0
+        fi
+    done
+    return 0
+}
+
+# _chezmoi_up_sha256 FILE -> print the file's SHA256, or nothing.
+_chezmoi_up_sha256() {
+    local out=""
+    if command -v sha256sum >/dev/null 2>&1; then
+        out="$(sha256sum "${1}" 2>/dev/null || true)"
+    elif command -v shasum >/dev/null 2>&1; then
+        out="$(shasum -a 256 "${1}" 2>/dev/null || true)"
+    fi
+    [ -n "${out}" ] || return 0
+    printf '%s\n' "${out%% *}"
+}
+
+# _chezmoi_up_needs_init -> 0 when `chezmoi init` should run.
+# Compares the SHA256 chezmoi recorded for the config template with the
+# template on disk. When either side cannot be determined we return 0 and let
+# init run: a redundant init is harmless, a skipped one is not.
+_chezmoi_up_needs_init() {
+    local template stored actual
+    template="$(_chezmoi_up_config_template)"
+    [ -n "${template}" ] || return 0
+
+    local state
+    state="$(chezmoi state get --bucket=configState --key=configState 2>/dev/null || true)"
+    [ -n "${state}" ] || return 0
+    stored="$(awk -F: '/configTemplateContentsSHA256/ { gsub(/[ ",]/, "", $2); print $2 }' <<<"${state}")"
+    [ -n "${stored}" ] || return 0
+
+    actual="$(_chezmoi_up_sha256 "${template}")"
+    [ -n "${actual}" ] || return 0
+
+    [ "${stored}" != "${actual}" ]
+}
+
+chezmoi-up() {
+    local force_init=false
+
+    while [ $# -gt 0 ]; do
+        case "${1}" in
+        -f | --force-init)
+            force_init=true
+            shift
+            ;;
+        -h | --help)
+            echo "Usage: chezmoi-up [-f|--force-init] [-h|--help]"
+            echo "Pull, re-init when the config template changed, then apply."
+            echo ""
+            echo "Options:"
+            echo "  -f, --force-init   Run 'chezmoi init' even if the template is unchanged"
+            echo "  -h, --help         Show this help message"
+            return 0
+            ;;
+        *)
+            echo "chezmoi-up: unknown option: ${1}" >&2
+            echo "Use --help for usage information" >&2
+            return 1
+            ;;
+        esac
+    done
+
+    if ! command -v chezmoi >/dev/null 2>&1; then
+        echo "chezmoi-up: chezmoi is not installed or not in PATH" >&2
+        return 1
+    fi
+
+    # log.sh is sourced by config.bash/config.zsh, but this file sorts before
+    # it, so pull it in when running standalone.
+    if ! command -v log_step >/dev/null 2>&1 && [ -f "${HOME}/.config/shell/functions/log.sh" ]; then
+        # shellcheck source=/dev/null
+        . "${HOME}/.config/shell/functions/log.sh"
+    fi
+    # shellcheck disable=SC2034  # consumed by log.sh
+    local LOG_TAG="chezmoi-up"
+
+    log_step "Pulling the source repository"
+    if ! chezmoi update --apply=false; then
+        log_error "chezmoi update failed; not continuing to init/apply"
+        return 1
+    fi
+
+    if [ "${force_init}" = true ]; then
+        log_step "Regenerating the config file (forced)"
+        if ! chezmoi init; then
+            log_error "chezmoi init failed; not continuing to apply"
+            return 1
+        fi
+    elif _chezmoi_up_needs_init; then
+        log_step "Config template changed, regenerating the config file"
+        if ! chezmoi init; then
+            log_error "chezmoi init failed; not continuing to apply"
+            return 1
+        fi
+    else
+        log_info "Config template unchanged, skipping chezmoi init"
+    fi
+
+    log_step "Applying"
+    if ! chezmoi apply; then
+        log_error "chezmoi apply failed"
+        return 1
+    fi
+
+    log_result "Dotfiles are up to date"
+    return 0
+}
+
+# Defined here rather than in aliases.sh so the function and its shorthand stay
+# together; every file in this directory is sourced at shell startup.
+alias czu='chezmoi-up'
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    chezmoi-up "$@"
+fi

--- a/home/dot_config/shell/functions/chezmoi-up.sh
+++ b/home/dot_config/shell/functions/chezmoi-up.sh
@@ -62,13 +62,60 @@ _chezmoi_up_needs_init() {
     local state
     state="$(chezmoi state get --bucket=configState --key=configState 2>/dev/null || true)"
     [ -n "${state}" ] || return 0
-    stored="$(awk -F: '/configTemplateContentsSHA256/ { gsub(/[ ",]/, "", $2); print $2 }' <<<"${state}")"
+    # Keep only hex so the parse survives both chezmoi's pretty-printed JSON
+    # and a compact one-line object (where a trailing } would otherwise stick).
+    stored="$(awk -F: '/configTemplateContentsSHA256/ { gsub(/[^0-9a-fA-F]/, "", $2); print $2 }' <<<"${state}")"
     [ -n "${stored}" ] || return 0
 
     actual="$(_chezmoi_up_sha256 "${template}")"
     [ -n "${actual}" ] || return 0
 
     [ "${stored}" != "${actual}" ]
+}
+
+# _chezmoi_up_load_log -> make log.sh's helpers available when we can.
+# config.bash/config.zsh source every file in this directory, but this one
+# sorts before log.sh, so pull it in on first use. Falls back to the copy next
+# to this file, which is how it is reachable from a bare repo checkout.
+_chezmoi_up_load_log() {
+    command -v log_step >/dev/null 2>&1 && return 0
+
+    local here="" candidate
+    if [ -n "${BASH_SOURCE[0]:-}" ]; then
+        here="$(dirname -- "${BASH_SOURCE[0]}")"
+    fi
+
+    for candidate in "${HOME}/.config/shell/functions/log.sh" "${here}/log.sh"; do
+        if [ -n "${candidate}" ] && [ -f "${candidate}" ]; then
+            # shellcheck source=/dev/null
+            . "${candidate}" && return 0
+        fi
+    done
+    return 0
+}
+
+# _chezmoi_up_say KIND MESSAGE... -> print a message through log.sh when it is
+# available, else through plain echo. Never let a missing log.sh swallow output
+# (or abort the run) on a machine where the dotfiles are not applied yet.
+_chezmoi_up_say() {
+    local kind="${1}"
+    shift
+
+    case "${kind}" in
+    step)
+        if command -v log_step >/dev/null 2>&1; then log_step "$*"; else printf '==> %s\n' "$*"; fi
+        ;;
+    info)
+        if command -v log_info >/dev/null 2>&1; then log_info "$*"; else printf '==> %s\n' "$*"; fi
+        ;;
+    result)
+        if command -v log_result >/dev/null 2>&1; then log_result "$*"; else printf '\342\234\223 %s\n' "$*"; fi
+        ;;
+    error)
+        if command -v log_error >/dev/null 2>&1; then log_error "$*"; else printf '\342\234\227 %s\n' "$*" >&2; fi
+        ;;
+    *) printf '%s\n' "$*" ;;
+    esac
 }
 
 chezmoi-up() {
@@ -102,44 +149,39 @@ chezmoi-up() {
         return 1
     fi
 
-    # log.sh is sourced by config.bash/config.zsh, but this file sorts before
-    # it, so pull it in when running standalone.
-    if ! command -v log_step >/dev/null 2>&1 && [ -f "${HOME}/.config/shell/functions/log.sh" ]; then
-        # shellcheck source=/dev/null
-        . "${HOME}/.config/shell/functions/log.sh"
-    fi
+    _chezmoi_up_load_log
     # shellcheck disable=SC2034  # consumed by log.sh
     local LOG_TAG="chezmoi-up"
 
-    log_step "Pulling the source repository"
+    _chezmoi_up_say step "Pulling the source repository"
     if ! chezmoi update --apply=false; then
-        log_error "chezmoi update failed; not continuing to init/apply"
+        _chezmoi_up_say error "chezmoi update failed; not continuing to init/apply"
         return 1
     fi
 
     if [ "${force_init}" = true ]; then
-        log_step "Regenerating the config file (forced)"
+        _chezmoi_up_say step "Regenerating the config file (forced)"
         if ! chezmoi init; then
-            log_error "chezmoi init failed; not continuing to apply"
+            _chezmoi_up_say error "chezmoi init failed; not continuing to apply"
             return 1
         fi
     elif _chezmoi_up_needs_init; then
-        log_step "Config template changed, regenerating the config file"
+        _chezmoi_up_say step "Config template changed, regenerating the config file"
         if ! chezmoi init; then
-            log_error "chezmoi init failed; not continuing to apply"
+            _chezmoi_up_say error "chezmoi init failed; not continuing to apply"
             return 1
         fi
     else
-        log_info "Config template unchanged, skipping chezmoi init"
+        _chezmoi_up_say info "Config template unchanged, skipping chezmoi init"
     fi
 
-    log_step "Applying"
+    _chezmoi_up_say step "Applying"
     if ! chezmoi apply; then
-        log_error "chezmoi apply failed"
+        _chezmoi_up_say error "chezmoi apply failed"
         return 1
     fi
 
-    log_result "Dotfiles are up to date"
+    _chezmoi_up_say result "Dotfiles are up to date"
     return 0
 }
 

--- a/tests/bash/chezmoi-up.bats
+++ b/tests/bash/chezmoi-up.bats
@@ -17,7 +17,7 @@ setup() {
 	ORIGINAL_PATH="${PATH}"
 	export ORIGINAL_PATH
 
-	mkdir -p "${TEST_DIR}/bin" "${TEST_DIR}/src"
+	mkdir -p "${TEST_DIR}/bin" "${TEST_DIR}/src" "${TEST_DIR}/home"
 	printf 'template-v1\n' >"${TEST_DIR}/src/.chezmoi.yaml.tmpl"
 
 	# Stub chezmoi: records each invocation and honours FAKE_*_RC exit codes.
@@ -50,7 +50,10 @@ teardown() {
 
 # _run_up [env assignments...] -> source the function and run it.
 _run_up() {
-	PATH="${TEST_DIR}/bin:${ORIGINAL_PATH}" run bash -c "source '${SCRIPT}'; chezmoi-up $*; echo \"rc=\$?\""
+	# HOME points at an empty dir: CI runners have no ~/.config/shell/functions,
+	# so this keeps local runs honest about the log.sh fallback path.
+	PATH="${TEST_DIR}/bin:${ORIGINAL_PATH}" HOME="${TEST_DIR}/home" \
+		run bash -c "source '${SCRIPT}'; chezmoi-up $*; echo \"rc=\$?\""
 }
 
 @test "chezmoi-up: script exists and is executable" {
@@ -148,6 +151,56 @@ _run_up() {
 	[[ "$output" =~ "chezmoi apply failed" ]]
 	[[ ! "$output" =~ "up to date" ]]
 	[[ "$output" =~ "rc=1" ]]
+}
+
+
+@test "chezmoi-up: still reports every step when log.sh is unavailable" {
+	# A machine that has not applied the dotfiles yet has no log.sh at all.
+	# Missing log helpers must not swallow the output or abort the run.
+	local isolated="${TEST_DIR}/isolated"
+	mkdir -p "${isolated}"
+	cp "${SCRIPT}" "${isolated}/chezmoi-up.sh"
+
+	PATH="${TEST_DIR}/bin:${ORIGINAL_PATH}" HOME="${TEST_DIR}/home" FAKE_STORED_SHA="${TEMPLATE_SHA}" \
+		run bash -c "source '${isolated}/chezmoi-up.sh'; chezmoi-up; echo \"rc=\$?\""
+	[[ "$output" =~ "Pulling the source repository" ]]
+	[[ "$output" =~ "skipping chezmoi init" ]]
+	[[ "$output" =~ "Applying" ]]
+	[[ "$output" =~ "up to date" ]]
+	[[ ! "$output" =~ "command not found" ]]
+	[[ "$output" =~ "rc=0" ]]
+}
+
+@test "chezmoi-up: reports failures when log.sh is unavailable" {
+	local isolated="${TEST_DIR}/isolated-fail"
+	mkdir -p "${isolated}"
+	cp "${SCRIPT}" "${isolated}/chezmoi-up.sh"
+
+	PATH="${TEST_DIR}/bin:${ORIGINAL_PATH}" HOME="${TEST_DIR}/home" FAKE_UPDATE_RC=1 \
+		run bash -c "source '${isolated}/chezmoi-up.sh'; chezmoi-up; echo \"rc=\$?\""
+	[[ "$output" =~ "chezmoi update failed" ]]
+	[[ ! "$output" =~ "command not found" ]]
+	[[ "$output" =~ "rc=1" ]]
+}
+
+@test "chezmoi-up: parses a compact one-line state object" {
+	# chezmoi pretty-prints today, but a compact object must not leave a
+	# trailing brace glued to the hash and make every run look changed.
+	cat >"${TEST_DIR}/bin/chezmoi" <<'EOF'
+#!/bin/bash
+if [ "$1" = "source-path" ]; then echo "${FAKE_SRC}"; exit 0; fi
+case "$1" in
+update) echo "UPDATE: $*"; exit 0 ;;
+init)   echo "INIT: $*"; exit 0 ;;
+apply)  echo "APPLY: $*"; exit 0 ;;
+state)  printf '{"configTemplateContentsSHA256": "%s"}\n' "${FAKE_STORED_SHA}"; exit 0 ;;
+esac
+EOF
+	chmod +x "${TEST_DIR}/bin/chezmoi"
+
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" _run_up
+	[[ "$output" =~ "skipping chezmoi init" ]]
+	[[ ! "$output" =~ "INIT:" ]]
 }
 
 # --- fish twin --------------------------------------------------------------

--- a/tests/bash/chezmoi-up.bats
+++ b/tests/bash/chezmoi-up.bats
@@ -1,0 +1,225 @@
+#!/usr/bin/env bats
+# Tests for the chezmoi-up helper (bash/zsh) and its fish twin.
+#
+# chezmoi is replaced with a stub so the steps, their order, the conditional
+# `chezmoi init` and the stop-on-failure gating can be asserted without
+# touching the real dotfiles.
+
+setup() {
+	REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+	export REPO_ROOT
+	SCRIPT="${REPO_ROOT}/home/dot_config/shell/functions/chezmoi-up.sh"
+	FISH_FUNC="${REPO_ROOT}/home/dot_config/fish/functions/chezmoi_up.fish"
+	export SCRIPT FISH_FUNC
+
+	TEST_DIR="$(mktemp -d)"
+	export TEST_DIR
+	ORIGINAL_PATH="${PATH}"
+	export ORIGINAL_PATH
+
+	mkdir -p "${TEST_DIR}/bin" "${TEST_DIR}/src"
+	printf 'template-v1\n' >"${TEST_DIR}/src/.chezmoi.yaml.tmpl"
+
+	# Stub chezmoi: records each invocation and honours FAKE_*_RC exit codes.
+	cat >"${TEST_DIR}/bin/chezmoi" <<'EOF'
+#!/bin/bash
+if [ "$1" = "source-path" ]; then echo "${FAKE_SRC}"; exit 0; fi
+case "$1" in
+update) echo "UPDATE: $*"; exit "${FAKE_UPDATE_RC:-0}" ;;
+init)   echo "INIT: $*";   exit "${FAKE_INIT_RC:-0}" ;;
+apply)  echo "APPLY: $*";  exit "${FAKE_APPLY_RC:-0}" ;;
+state)  [ -n "${FAKE_STORED_SHA}" ] || exit 1
+        printf '{\n  "configTemplateContentsSHA256": "%s"\n}\n' "${FAKE_STORED_SHA}"; exit 0 ;;
+esac
+exit 0
+EOF
+	chmod +x "${TEST_DIR}/bin/chezmoi"
+
+	FAKE_SRC="${TEST_DIR}/src"
+	export FAKE_SRC
+	TEMPLATE_SHA="$(sha256sum "${TEST_DIR}/src/.chezmoi.yaml.tmpl" | cut -d' ' -f1)"
+	export TEMPLATE_SHA
+}
+
+teardown() {
+	export PATH="${ORIGINAL_PATH}"
+	if [ -n "${TEST_DIR}" ] && [ -d "${TEST_DIR}" ]; then
+		rm -rf "${TEST_DIR}"
+	fi
+}
+
+# _run_up [env assignments...] -> source the function and run it.
+_run_up() {
+	PATH="${TEST_DIR}/bin:${ORIGINAL_PATH}" run bash -c "source '${SCRIPT}'; chezmoi-up $*; echo \"rc=\$?\""
+}
+
+@test "chezmoi-up: script exists and is executable" {
+	[ -f "${SCRIPT}" ]
+	[ -x "${SCRIPT}" ]
+}
+
+@test "chezmoi-up: has valid bash and zsh syntax" {
+	run bash -n "${SCRIPT}"
+	[ "$status" -eq 0 ]
+	if command -v zsh >/dev/null 2>&1; then
+		run zsh -n "${SCRIPT}"
+		[ "$status" -eq 0 ]
+	fi
+}
+
+@test "chezmoi-up: help option displays usage" {
+	run bash -c "source '${SCRIPT}'; chezmoi-up --help"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "Usage: chezmoi-up" ]]
+	[[ "$output" =~ "--force-init" ]]
+}
+
+@test "chezmoi-up: unknown option returns an error" {
+	run bash -c "source '${SCRIPT}'; chezmoi-up --bogus"
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "unknown option" ]]
+}
+
+@test "chezmoi-up: defines the czu alias" {
+	run bash -c "source '${SCRIPT}'; alias czu"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "chezmoi-up" ]]
+}
+
+@test "chezmoi-up: errors when chezmoi is not installed" {
+	PATH="/usr/bin:/bin" run bash -c "source '${SCRIPT}'; chezmoi-up"
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "chezmoi is not installed" ]]
+}
+
+@test "chezmoi-up: pulls without applying, then applies" {
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" _run_up
+	[[ "$output" =~ "UPDATE: update --apply=false" ]]
+	[[ "$output" =~ "APPLY: apply" ]]
+	[[ "$output" =~ "rc=0" ]]
+}
+
+@test "chezmoi-up: skips init when the config template is unchanged" {
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" _run_up
+	[[ "$output" =~ "skipping chezmoi init" ]]
+	[[ ! "$output" =~ "INIT:" ]]
+	[[ "$output" =~ "rc=0" ]]
+}
+
+@test "chezmoi-up: runs init when the config template changed" {
+	FAKE_STORED_SHA="0000000000000000000000000000000000000000000000000000000000000000" _run_up
+	[[ "$output" =~ "Config template changed" ]]
+	[[ "$output" =~ "INIT: init" ]]
+	[[ "$output" =~ "rc=0" ]]
+}
+
+@test "chezmoi-up: --force-init runs init even when unchanged" {
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" _run_up --force-init
+	[[ "$output" =~ "INIT: init" ]]
+	[[ ! "$output" =~ "skipping chezmoi init" ]]
+}
+
+@test "chezmoi-up: runs init when chezmoi has no recorded state" {
+	# Unknown state must fall back to running init: a redundant init is
+	# harmless, a skipped one leaves a stale config behind.
+	FAKE_STORED_SHA="" _run_up
+	[[ "$output" =~ "INIT: init" ]]
+}
+
+@test "chezmoi-up: a failed update stops before init and apply" {
+	FAKE_UPDATE_RC=1 FAKE_STORED_SHA="deadbeef" _run_up
+	[[ "$output" =~ "chezmoi update failed" ]]
+	[[ ! "$output" =~ "INIT:" ]]
+	[[ ! "$output" =~ "APPLY:" ]]
+	[[ "$output" =~ "rc=1" ]]
+}
+
+@test "chezmoi-up: a failed init stops before apply" {
+	FAKE_INIT_RC=1 FAKE_STORED_SHA="deadbeef" _run_up
+	[[ "$output" =~ "INIT: init" ]]
+	[[ "$output" =~ "chezmoi init failed" ]]
+	[[ ! "$output" =~ "APPLY:" ]]
+	[[ "$output" =~ "rc=1" ]]
+}
+
+@test "chezmoi-up: a failed apply is reported" {
+	FAKE_APPLY_RC=1 FAKE_STORED_SHA="${TEMPLATE_SHA}" _run_up
+	[[ "$output" =~ "APPLY: apply" ]]
+	[[ "$output" =~ "chezmoi apply failed" ]]
+	[[ ! "$output" =~ "up to date" ]]
+	[[ "$output" =~ "rc=1" ]]
+}
+
+# --- fish twin --------------------------------------------------------------
+
+_fish_available() {
+	command -v fish >/dev/null 2>&1 || skip "fish not installed"
+}
+
+# _run_up_fish ARGS -> run chezmoi_up under fish with the same stubs.
+_run_up_fish() {
+	run fish --no-config -c "set -gx PATH '${TEST_DIR}/bin' \$PATH; \
+set -gx FAKE_SRC '${FAKE_SRC}'; \
+set -gx FAKE_STORED_SHA '${FAKE_STORED_SHA:-}'; \
+set -gx FAKE_UPDATE_RC '${FAKE_UPDATE_RC:-0}'; \
+set -gx FAKE_INIT_RC '${FAKE_INIT_RC:-0}'; \
+set -gx FAKE_APPLY_RC '${FAKE_APPLY_RC:-0}'; \
+source '${FISH_FUNC}'; chezmoi_up $*; echo \"rc=\$status\""
+}
+
+@test "chezmoi_up (fish): has valid syntax" {
+	_fish_available
+	run fish -n "${FISH_FUNC}"
+	[ "$status" -eq 0 ]
+}
+
+@test "chezmoi_up (fish): help option displays usage" {
+	_fish_available
+	run fish --no-config -c "source '${FISH_FUNC}'; chezmoi_up --help"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "Usage: chezmoi_up" ]]
+}
+
+@test "chezmoi_up (fish): skips init when the config template is unchanged" {
+	_fish_available
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" _run_up_fish
+	[[ "$output" =~ "skipping chezmoi init" ]]
+	[[ ! "$output" =~ "INIT:" ]]
+	[[ "$output" =~ "rc=0" ]]
+}
+
+@test "chezmoi_up (fish): runs init when the config template changed" {
+	_fish_available
+	FAKE_STORED_SHA="0000000000000000000000000000000000000000000000000000000000000000" _run_up_fish
+	[[ "$output" =~ "INIT: init" ]]
+	[[ "$output" =~ "rc=0" ]]
+}
+
+@test "chezmoi_up (fish): --force-init runs init even when unchanged" {
+	_fish_available
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" _run_up_fish --force-init
+	[[ "$output" =~ "INIT: init" ]]
+	[[ ! "$output" =~ "skipping chezmoi init" ]]
+}
+
+@test "chezmoi_up (fish): a failed update stops before init and apply" {
+	_fish_available
+	FAKE_UPDATE_RC=1 FAKE_STORED_SHA="deadbeef" _run_up_fish
+	[[ "$output" =~ "chezmoi update failed" ]]
+	[[ ! "$output" =~ "INIT:" ]]
+	[[ ! "$output" =~ "APPLY:" ]]
+	[[ "$output" =~ "rc=1" ]]
+}
+
+@test "chezmoi_up (fish): a failed init stops before apply" {
+	_fish_available
+	FAKE_INIT_RC=1 FAKE_STORED_SHA="deadbeef" _run_up_fish
+	[[ "$output" =~ "chezmoi init failed" ]]
+	[[ ! "$output" =~ "APPLY:" ]]
+	[[ "$output" =~ "rc=1" ]]
+}
+
+@test "chezmoi_up (fish): czu alias is defined in aliases.fish" {
+	run grep -F "alias czu 'chezmoi_up'" "${REPO_ROOT}/home/dot_config/fish/conf.d/aliases.fish"
+	[ "$status" -eq 0 ]
+}

--- a/tests/powershell/ChezmoiUtilities.Tests.ps1
+++ b/tests/powershell/ChezmoiUtilities.Tests.ps1
@@ -73,6 +73,90 @@ Describe "Invoke-ChezmoiSigning" -Tag "Unit" {
     }
 }
 
+
+Describe "Update-Chezmoi" -Tag "Unit" {
+    BeforeAll {
+        $script:Module = Get-Module DotfilesHelpers
+        $script:Body = (Get-Command Update-Chezmoi).ScriptBlock.ToString()
+    }
+
+    It "Should be available as a function" {
+        Get-Command Update-Chezmoi -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+    }
+
+    It "Should be exported by the module manifest" {
+        $manifestPath = Join-Path $script:RepoRoot "home/dot_config/powershell/modules/DotfilesHelpers/DotfilesHelpers.psd1"
+        (Import-PowerShellDataFile -Path $manifestPath).FunctionsToExport | Should -Contain 'Update-Chezmoi'
+    }
+
+    It "Should be aliased as chezmoi-up, chezmoi_up and czu in aliases.ps1" {
+        $aliases = Get-Content (Join-Path $script:RepoRoot "home/dot_config/powershell/aliases.ps1") -Raw
+        $aliases | Should -Match 'Set-Alias\s+-Name\s+chezmoi-up\s+-Value\s+Update-Chezmoi'
+        $aliases | Should -Match 'Set-Alias\s+-Name\s+chezmoi_up\s+-Value\s+Update-Chezmoi'
+        $aliases | Should -Match 'Set-Alias\s+-Name\s+czu\s+-Value\s+Update-Chezmoi'
+    }
+
+    It "Should pull without applying, so the old config is never used to apply" {
+        $script:Body | Should -Match 'chezmoi update --apply=false'
+    }
+
+    It "Should stop after a failed step instead of continuing" {
+        # Every external call is followed by a $LASTEXITCODE gate that returns.
+        ([regex]::Matches($script:Body, '\$LASTEXITCODE -ne 0')).Count | Should -BeGreaterOrEqual 3
+        $script:Body | Should -Match 'not continuing to init/apply'
+        $script:Body | Should -Match 'not continuing to apply'
+    }
+
+    It "Should log when it skips the init step" {
+        $script:Body | Should -Match 'skipping chezmoi init'
+    }
+
+    It "Should expose a ForceInit switch" {
+        (Get-Command Update-Chezmoi).Parameters.ContainsKey('ForceInit') | Should -Be $true
+    }
+
+    It "Should keep its helpers private (not exported by the manifest)" {
+        $manifestPath = Join-Path $script:RepoRoot "home/dot_config/powershell/modules/DotfilesHelpers/DotfilesHelpers.psd1"
+        $exported = (Import-PowerShellDataFile -Path $manifestPath).FunctionsToExport
+        $exported | Should -Not -Contain 'Get-ChezmoiConfigTemplate'
+        $exported | Should -Not -Contain 'Test-ChezmoiConfigChanged'
+    }
+}
+
+Describe "Test-ChezmoiConfigChanged" -Tag "Unit" {
+    BeforeAll {
+        $script:Module = Get-Module DotfilesHelpers
+        $script:Body = & $script:Module { (Get-Command Test-ChezmoiConfigChanged).ScriptBlock.ToString() }
+    }
+
+    It "Should compare the recorded SHA256 with the template on disk" {
+        $script:Body | Should -Match 'configState'
+        $script:Body | Should -Match 'configTemplateContentsSHA256'
+        $script:Body | Should -Match 'Get-FileHash'
+    }
+
+    It "Should default to running init when the state cannot be determined" {
+        # Every early exit returns $true: a redundant init is harmless, a
+        # skipped one leaves a stale config behind.
+        ([regex]::Matches($script:Body, 'return \$true')).Count | Should -BeGreaterOrEqual 4
+    }
+
+    It "Should return a boolean when chezmoi is unavailable" {
+        # No chezmoi on PATH in CI: the helper must not throw.
+        $result = & $script:Module { Test-ChezmoiConfigChanged }
+        $result | Should -BeOfType [bool]
+    }
+}
+
+Describe "Get-ChezmoiConfigTemplate" -Tag "Unit" {
+    It "Should look for the known chezmoi config template extensions" {
+        $module = Get-Module DotfilesHelpers
+        $body = & $module { (Get-Command Get-ChezmoiConfigTemplate).ScriptBlock.ToString() }
+        $body | Should -Match "'yaml'"
+        $body | Should -Match '\.chezmoi\.\$ext\.tmpl'
+    }
+}
+
 # SIG # Begin signature block
 # MIIfEQYJKoZIhvcNAQcCoIIfAjCCHv4CAQExDzANBglghkgBZQMEAgEFADB5Bgor
 # BgEEAYI3AgEEoGswaTA0BgorBgEEAYI3AgEeMCYCAwEAAAQQH8w7YFlLCE63JNLG

--- a/tests/powershell/ChezmoiUtilities.Tests.ps1
+++ b/tests/powershell/ChezmoiUtilities.Tests.ps1
@@ -142,9 +142,22 @@ Describe "Test-ChezmoiConfigChanged" -Tag "Unit" {
     }
 
     It "Should return a boolean when chezmoi is unavailable" {
-        # No chezmoi on PATH in CI: the helper must not throw.
-        $result = & $script:Module { Test-ChezmoiConfigChanged }
-        $result | Should -BeOfType [bool]
+        # Deterministically hide chezmoi rather than relying on the runner not
+        # having it. With $ErrorActionPreference = 'Stop' (GitHub Actions'
+        # `shell: pwsh`) an unguarded call would throw instead of returning.
+        $originalPath = $env:PATH
+        try {
+            $env:PATH = Join-Path ([System.IO.Path]::GetTempPath()) "no-chezmoi-$(Get-Random)"
+            $result = & $script:Module {
+                $ErrorActionPreference = 'Stop'
+                Test-ChezmoiConfigChanged
+            }
+            $result | Should -BeOfType [bool]
+            $result | Should -BeTrue
+        }
+        finally {
+            $env:PATH = $originalPath
+        }
     }
 }
 

--- a/tests/powershell/Profile.Tests.ps1
+++ b/tests/powershell/Profile.Tests.ps1
@@ -284,6 +284,8 @@ Describe "DotfilesHelpers Module" {
             'Wait-CopilotSshPort'
             'Invoke-CopilotSshAzureRecovery'
             'Test-CopilotSshPreflight'
+            'Get-ChezmoiConfigTemplate'
+            'Test-ChezmoiConfigChanged'
         )
 
         # Discover every top-level function defined across the Public files using


### PR DESCRIPTION
`chezmoi update && chezmoi init && chezmoi apply` was getting typed a lot. This adds one helper to every supported shell, with failure gating.

| Shell | Function | Alias |
| --- | --- | --- |
| Bash / Zsh | `chezmoi-up` | `czu` |
| fish | `chezmoi_up` | `czu` |
| PowerShell | `Update-Chezmoi` | `chezmoi-up`, `chezmoi_up`, `czu` |

## Stops at the first failure

Each step gates the next, so a failed pull can never be followed by an apply of half-updated source. The exit status reflects the failing step.

```console
$ czu   # update fails
==> Pulling the source repository
✗ chezmoi update failed; not continuing to init/apply
rc=1
```

## Two refinements over typing it by hand

**1. Pull without applying** — `chezmoi update --apply=false`.

A plain `chezmoi update` applies using the **old** config, which is exactly what breaks when the pull introduces a template variable the current config doesn't have yet (the `.opShellPlugins` failure we hit earlier this week).

**2. `chezmoi init` only when the config template actually changed**, as requested.

Detection uses chezmoi's own bookkeeping rather than parsing warning text: the SHA256 in its `configState` bucket versus the template on disk — the same data behind its *"config file template has changed"* warning. Verified they match exactly:

```
stored:  7101ef89e3a583dc04add62093411db05e9e2d62b56910d491f47569358afbb2
sha256:  7101ef89e3a583dc04add62093411db05e9e2d62b56910d491f47569358afbb2
```

Skipping is **logged**. If the state can't be read, init runs anyway — a redundant init is harmless, a skipped one leaves a stale config. `--force-init` / `-ForceInit` overrides.

```console
$ czu
==> Pulling the source repository
==> Config template unchanged, skipping chezmoi init
==> Applying
✓ Dotfiles are up to date
```

## Testing

- New `tests/bash/chezmoi-up.bats` — 22 tests covering bash **and** fish against a stubbed `chezmoi`: step order, `--apply=false`, skip vs. run init, unknown-state fallback, `--force-init`, the `czu` alias, and that each failing step stops the ones after it.
- `tests/powershell/ChezmoiUtilities.Tests.ps1` — 21 tests for `Update-Chezmoi` and its private helpers.
- Full suites green: bats (except two pre-existing `log-structured.bats` JSON failures that pass in CI) and 452 Pester tests.
- shellcheck / shfmt / `fish -n` / PSScriptAnalyzer clean on changed files.

## Notes

- The bash `czu` alias lives in `chezmoi-up.sh` next to its function rather than in `aliases.sh`; every file in that directory is sourced at startup, and `aliases.sh` currently fails the repo's strict shellcheck config for unrelated pre-existing reasons. fish needs its alias in `conf.d/aliases.fish` because `functions/` there is lazily autoloaded.
- Docs: new "Updating everything at once" section in `docs/customization.md`.
