### PR TITLE
feat(chezmoi-up): warn when the source repo is off its default branch

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -63,21 +63,27 @@ chezmoi verify
 `chezmoi update && chezmoi init && chezmoi apply` is the usual dance after a
 change lands. The `chezmoi-up` helper does it for you, in every shell:
 
-| Shell | Command | Alias |
-| --- | --- | --- |
-| Bash / Zsh | `chezmoi-up` | `czu` |
-| fish | `chezmoi_up` | `czu` |
+| Shell      | Command          | Alias                             |
+| ---------- | ---------------- | --------------------------------- |
+| Bash / Zsh | `chezmoi-up`     | `czu`                             |
+| fish       | `chezmoi_up`     | `czu`                             |
 | PowerShell | `Update-Chezmoi` | `chezmoi-up`, `chezmoi_up`, `czu` |
 
-It runs three steps and **stops at the first failure**, so a failed pull can
-never be followed by an apply of half-updated source:
+Before those steps it checks which branch the source repository is on, then
+runs three steps and **stops at the first failure**, so a failed pull can never
+be followed by an apply of half-updated source:
 
+0. **Branch guard** — `chezmoi update` pulls whichever branch is checked out,
+   so a feature branch you forgot about would be applied to the machine
+   silently. When the source repo is not on its default branch you get a
+   warning and an offer to switch and pull. See
+   [Branch guard](#branch-guard) below.
 1. `chezmoi update --apply=false` — pull the source repo only. Applying here
-   would use the *old* config, which breaks when the pull introduces a
+   would use the _old_ config, which breaks when the pull introduces a
    template variable your current config does not have yet.
 2. `chezmoi init` — **only when the config template actually changed.** It
    compares the SHA256 chezmoi recorded in its `configState` bucket (the same
-   data behind its *"config file template has changed"* warning) with the
+   data behind its _"config file template has changed"_ warning) with the
    template on disk. When it skips, it says so; when the state cannot be read
    it re-inits anyway, since a redundant init is harmless and a skipped one is
    not.
@@ -93,6 +99,36 @@ $ czu
 ==> Applying
 ✓ Dotfiles are up to date
 ```
+
+### Branch guard
+
+When the source repository is on another branch, `czu` says so and offers to
+put it back:
+
+```console
+$ czu
+! Source repository is on 'feat/new-aliases', not 'main'.
+! chezmoi update pulls whichever branch is checked out.
+Switch to 'main' and pull? [y/N] y
+==> Switching to 'main'
+==> Pulling the source repository
+```
+
+Declining is fine — working on a branch is a legitimate way to test dotfiles
+changes, so the run continues either way. The guard never switches a branch
+with uncommitted changes; it tells you to commit or stash first and carries on
+where you are. Pulls use `--ff-only`, so it will never create a merge commit in
+your dotfiles behind your back.
+
+Non-interactive shells answer "no" automatically, so scripts and CI are warned
+but never blocked.
+
+| Variable                         | Effect                                                            |
+| -------------------------------- | ----------------------------------------------------------------- |
+| `CHEZMOI_UP_BRANCH`              | Expected branch (default: the repo's default branch, else `main`) |
+| `CHEZMOI_UP_SKIP_BRANCH_CHECK=1` | Skip the guard entirely                                           |
+| `CHEZMOI_UP_ASSUME_YES=1`        | Switch without asking                                             |
+| `CHEZMOI_UP_ASSUME_NO=1`         | Never switch, even on a TTY                                       |
 
 ## Windows PATH
 

--- a/home/dot_config/fish/functions/chezmoi_up.fish
+++ b/home/dot_config/fish/functions/chezmoi_up.fish
@@ -6,6 +6,10 @@ function chezmoi_up --description 'Pull, re-init when the config template change
     # pull can never be followed by an apply of half-updated source.
     #
     # The steps are:
+    #   0. Branch guard — warn when the source repo is not on its default
+    #      branch (usually main), and offer to switch and pull. `chezmoi
+    #      update` pulls whichever branch is checked out, so a forgotten
+    #      feature branch would otherwise be applied to the machine silently.
     #   1. `chezmoi update --apply=false` — pull the source repo only. Applying
     #      here would use the OLD config, which breaks when the pull introduces
     #      a template variable the current config does not have yet.
@@ -16,6 +20,13 @@ function chezmoi_up --description 'Pull, re-init when the config template change
     #   3. `chezmoi apply` — apply with the freshly generated config.
     #
     # Usage: chezmoi_up [-f|--force-init] [-h|--help]   (alias: czu)
+    #
+    # Environment:
+    #   CHEZMOI_UP_BRANCH             Expected branch (default: the source
+    #                                 repo's default branch, else main)
+    #   CHEZMOI_UP_SKIP_BRANCH_CHECK  Set to 1 to skip the branch guard
+    #   CHEZMOI_UP_ASSUME_YES=1       Switch branch without asking
+    #   CHEZMOI_UP_ASSUME_NO=1        Never switch, even on a TTY
 
     argparse --name=chezmoi_up h/help f/force-init -- $argv
     or return 1
@@ -37,6 +48,8 @@ function chezmoi_up --description 'Pull, re-init when the config template change
         set_color normal
         return 1
     end
+
+    _chezmoi_up_check_branch
 
     set_color --bold blue
     echo "==> Pulling the source repository"
@@ -85,6 +98,108 @@ function chezmoi_up --description 'Pull, re-init when the config template change
     set_color --bold green
     echo "✓ Dotfiles are up to date"
     set_color normal
+    return 0
+end
+
+# _chezmoi_up_expected_branch -> print the branch the source repo should be on.
+# Honours CHEZMOI_UP_BRANCH, else asks git which branch origin's HEAD points at
+# (so a repo that renames its default branch keeps working), else falls back to
+# main.
+function _chezmoi_up_expected_branch --description 'Branch the chezmoi source repo should be on' --argument-names source_dir
+    if set -q CHEZMOI_UP_BRANCH; and test -n "$CHEZMOI_UP_BRANCH"
+        echo $CHEZMOI_UP_BRANCH
+        return 0
+    end
+
+    set -l head (git -C $source_dir symbolic-ref --short -q refs/remotes/origin/HEAD 2>/dev/null)
+    if test -n "$head"
+        string replace -r '^origin/' '' -- $head
+        return 0
+    end
+
+    echo main
+end
+
+# _chezmoi_up_confirm PROMPT -> success when the user answers yes.
+# Non-interactive shells always answer no, so an automated run is warned but
+# never blocked.
+function _chezmoi_up_confirm --description 'Ask a yes/no question; always no when non-interactive' --argument-names prompt
+    test "$CHEZMOI_UP_ASSUME_YES" = 1; and return 0
+    test "$CHEZMOI_UP_ASSUME_NO" = 1; and return 1
+    isatty stdin; or return 1
+
+    read -l -P "$prompt [y/N] " reply
+    or return 1
+    string match -qir '^(y|yes)$' -- $reply
+end
+
+# _chezmoi_up_check_branch -> warn when the source repo is off its default
+# branch, and offer to switch and pull.
+#
+# Always succeeds: being on a feature branch is a legitimate way to test
+# dotfiles changes, so this warns and offers rather than blocking the run.
+function _chezmoi_up_check_branch --description 'Warn when the chezmoi source repo is off its default branch'
+    test "$CHEZMOI_UP_SKIP_BRANCH_CHECK" = 1; and return 0
+
+    set -l source_dir (chezmoi source-path 2>/dev/null)
+    or return 0
+    test -n "$source_dir" -a -d "$source_dir"; or return 0
+
+    # A source directory that is not a git checkout has no branch to be wrong.
+    git -C $source_dir rev-parse --is-inside-work-tree >/dev/null 2>&1; or return 0
+
+    set -l expected (_chezmoi_up_expected_branch $source_dir)
+    set -l current (git -C $source_dir symbolic-ref --short -q HEAD 2>/dev/null)
+
+    test "$current" = "$expected"; and return 0
+
+    set -l where "detached HEAD"
+    test -n "$current"; and set where "'$current'"
+
+    set_color yellow
+    if test -z "$current"
+        echo "! Source repository is in detached HEAD state, not on '$expected'." >&2
+    else
+        echo "! Source repository is on '$current', not '$expected'." >&2
+    end
+    echo "! chezmoi update pulls whichever branch is checked out." >&2
+    set_color normal
+
+    if not _chezmoi_up_confirm "Switch to '$expected' and pull?"
+        echo "==> Staying on $where."
+        return 0
+    end
+
+    # Switching with uncommitted changes would either fail or drag the changes
+    # onto the default branch; neither is something to do behind the user's back.
+    set -l dirty (git -C $source_dir status --porcelain 2>/dev/null)
+    if test (count $dirty) -gt 0
+        set_color red
+        echo "✗ Source repository has uncommitted changes; commit or stash them first." >&2
+        set_color normal
+        echo "==> Continuing on $where."
+        return 0
+    end
+
+    set_color --bold blue
+    echo "==> Switching to '$expected'"
+    set_color normal
+    if not git -C $source_dir checkout $expected
+        set_color red
+        echo "✗ Could not check out '$expected'; continuing on $where." >&2
+        set_color normal
+        return 0
+    end
+
+    # --ff-only: never create a merge commit in the dotfiles source behind the
+    # user's back. A diverged branch is reported instead.
+    if not git -C $source_dir pull --ff-only
+        set_color red
+        echo "✗ Could not fast-forward '$expected'; resolve it manually." >&2
+        set_color normal
+        return 0
+    end
+
     return 0
 end
 

--- a/home/dot_config/powershell/modules/DotfilesHelpers/Public/ChezmoiUtilities.ps1
+++ b/home/dot_config/powershell/modules/DotfilesHelpers/Public/ChezmoiUtilities.ps1
@@ -125,6 +125,135 @@ function Test-ChezmoiConfigChanged {
     return ($stored -ne $actual)
 }
 
+function Get-ChezmoiExpectedBranch {
+    <#
+    .SYNOPSIS
+    The branch the chezmoi source repository should be on.
+
+    .DESCRIPTION
+    Honours CHEZMOI_UP_BRANCH, else asks git which branch origin's HEAD points
+    at (so a repository that renames its default branch keeps working), else
+    falls back to main. Private helper for Update-Chezmoi.
+
+    .PARAMETER SourceDir
+    The chezmoi source directory.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([Parameter(Mandatory = $true)][string]$SourceDir)
+
+    if (-not [string]::IsNullOrWhiteSpace($env:CHEZMOI_UP_BRANCH)) {
+        return $env:CHEZMOI_UP_BRANCH
+    }
+
+    $head = (& git -C $SourceDir symbolic-ref --short -q refs/remotes/origin/HEAD 2>$null | Out-String).Trim()
+    if (-not [string]::IsNullOrWhiteSpace($head)) {
+        return ($head -replace '^origin/', '')
+    }
+
+    return 'main'
+}
+
+function Get-ChezmoiBranchConfirmation {
+    <#
+    .SYNOPSIS
+    Ask a yes/no question, defaulting to "no" when nobody can answer.
+
+    .DESCRIPTION
+    Non-interactive sessions always answer "no" so an automated run is warned
+    but never blocked. CHEZMOI_UP_ASSUME_YES=1 answers yes,
+    CHEZMOI_UP_ASSUME_NO=1 answers no. Private helper for Update-Chezmoi.
+
+    .PARAMETER Message
+    The question to ask.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param([Parameter(Mandatory = $true)][string]$Message)
+
+    if ($env:CHEZMOI_UP_ASSUME_YES -eq '1') { return $true }
+    if ($env:CHEZMOI_UP_ASSUME_NO -eq '1') { return $false }
+    if (-not [Environment]::UserInteractive) { return $false }
+    if ([Console]::IsInputRedirected) { return $false }
+
+    $answer = Read-Host "$Message [y/N]"
+    return ($answer -match '^\s*(y|yes)\s*$')
+}
+
+function Test-ChezmoiSourceBranch {
+    <#
+    .SYNOPSIS
+    Warn when the chezmoi source repository is off its default branch, and
+    offer to switch and pull.
+
+    .DESCRIPTION
+    `chezmoi update` pulls whichever branch is checked out, so a forgotten
+    feature branch would otherwise be applied to the machine silently.
+
+    Always returns without failing: working on a feature branch is a legitimate
+    way to test dotfiles changes, so this warns and offers rather than blocking
+    the run. Private helper for Update-Chezmoi.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Interactive helper; progress output is the point.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Prompts for the branch switch itself; -WhatIf would be redundant.')]
+    [CmdletBinding()]
+    param()
+
+    if ($env:CHEZMOI_UP_SKIP_BRANCH_CHECK -eq '1') { return }
+    if (-not (Get-Command git -CommandType Application -ErrorAction SilentlyContinue)) { return }
+
+    try { $sourceDir = (& chezmoi source-path 2>$null | Out-String).Trim() }
+    catch { return }
+    if ([string]::IsNullOrWhiteSpace($sourceDir) -or -not (Test-Path -LiteralPath $sourceDir)) { return }
+
+    # A source directory that is not a git checkout has no branch to be wrong.
+    $null = & git -C $sourceDir rev-parse --is-inside-work-tree 2>$null
+    if ($LASTEXITCODE -ne 0) { return }
+
+    $expected = Get-ChezmoiExpectedBranch -SourceDir $sourceDir
+    $current = (& git -C $sourceDir symbolic-ref --short -q HEAD 2>$null | Out-String).Trim()
+
+    if ($current -eq $expected) { return }
+
+    $where = if ([string]::IsNullOrWhiteSpace($current)) { 'detached HEAD' } else { "'$current'" }
+    if ([string]::IsNullOrWhiteSpace($current)) {
+        Write-Host "[WARN] Source repository is in detached HEAD state, not on '$expected'." -ForegroundColor Yellow
+    }
+    else {
+        Write-Host "[WARN] Source repository is on '$current', not '$expected'." -ForegroundColor Yellow
+    }
+    Write-Host '[WARN] chezmoi update pulls whichever branch is checked out.' -ForegroundColor Yellow
+
+    if (-not (Get-ChezmoiBranchConfirmation -Message "Switch to '$expected' and pull?")) {
+        Write-Host "==> Staying on $where."
+        return
+    }
+
+    # Switching with uncommitted changes would either fail or drag the changes
+    # onto the default branch; neither is something to do behind the user's back.
+    $dirty = (& git -C $sourceDir status --porcelain 2>$null | Out-String).Trim()
+    if (-not [string]::IsNullOrWhiteSpace($dirty)) {
+        Write-Error 'Source repository has uncommitted changes; commit or stash them first.' -ErrorAction Continue
+        Write-Host "==> Continuing on $where."
+        return
+    }
+
+    Write-Host "==> Switching to '$expected'" -ForegroundColor Blue
+    & git -C $sourceDir checkout $expected
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Could not check out '$expected'; continuing on $where." -ErrorAction Continue
+        return
+    }
+
+    # --ff-only: never create a merge commit in the dotfiles source behind the
+    # user's back. A diverged branch is reported instead.
+    & git -C $sourceDir pull --ff-only
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Could not fast-forward '$expected'; resolve it manually." -ErrorAction Continue
+        return
+    }
+}
+
 function Update-Chezmoi {
     <#
     .SYNOPSIS
@@ -137,6 +266,8 @@ function Update-Chezmoi {
     never be followed by an apply of half-updated source.
 
     The steps are:
+      0. Branch guard - warn when the source repo is not on its default branch
+         (usually main) and offer to switch and pull.
       1. `chezmoi update --apply=false` - pull the source repo only. Applying
          here would use the OLD config, which breaks when the pull introduces a
          template variable the current config does not have yet.
@@ -167,6 +298,8 @@ function Update-Chezmoi {
         Write-Error 'chezmoi is not installed or not in PATH' -ErrorAction Continue
         return
     }
+
+    Test-ChezmoiSourceBranch
 
     Write-Host '==> Pulling the source repository' -ForegroundColor Blue
     & chezmoi update --apply=false

--- a/home/dot_config/shell/functions/chezmoi-up.sh
+++ b/home/dot_config/shell/functions/chezmoi-up.sh
@@ -6,6 +6,10 @@
 # never be followed by an apply of half-updated source.
 #
 # The steps are:
+#   0. Branch guard — warn when the source repo is not on its default branch
+#      (usually main), and offer to switch and pull. `chezmoi update` pulls
+#      whatever branch is checked out, so a forgotten feature branch would
+#      otherwise be applied to the machine silently.
 #   1. `chezmoi update --apply=false` — pull the source repo only. Applying
 #      here would use the OLD config, which breaks when the pull introduces a
 #      template variable the current config does not have yet.
@@ -18,6 +22,13 @@
 # Usage: chezmoi-up [-f|--force-init] [-h|--help]
 #   -f, --force-init   Run `chezmoi init` even if the template is unchanged
 #   -h, --help         Show this help message
+#
+# Environment:
+#   CHEZMOI_UP_BRANCH             Expected branch (default: the source repo's
+#                                 default branch, else main)
+#   CHEZMOI_UP_SKIP_BRANCH_CHECK  Set to 1 to skip the branch guard entirely
+#   CHEZMOI_UP_ASSUME_YES=1       Switch branch without asking
+#   CHEZMOI_UP_ASSUME_NO=1        Never switch, even on a TTY
 #
 # Alias: czu
 
@@ -73,6 +84,102 @@ _chezmoi_up_needs_init() {
     [ "${stored}" != "${actual}" ]
 }
 
+# _chezmoi_up_expected_branch -> print the branch the source repo should be on.
+# Honours CHEZMOI_UP_BRANCH, else asks git which branch origin's HEAD points at
+# (so a repo that renames its default branch keeps working), else falls back to
+# main.
+_chezmoi_up_expected_branch() {
+    local source_dir="${1}" head=""
+
+    if [ -n "${CHEZMOI_UP_BRANCH:-}" ]; then
+        printf '%s\n' "${CHEZMOI_UP_BRANCH}"
+        return 0
+    fi
+
+    head="$(git -C "${source_dir}" symbolic-ref --short -q refs/remotes/origin/HEAD 2>/dev/null || true)"
+    if [ -n "${head}" ]; then
+        printf '%s\n' "${head#origin/}"
+        return 0
+    fi
+
+    printf 'main\n'
+}
+
+# _chezmoi_up_confirm PROMPT -> 0 when the user answers yes. Non-interactive
+# shells always answer no, so an automated run is warned but never blocked.
+_chezmoi_up_confirm() {
+    [ "${CHEZMOI_UP_ASSUME_YES:-0}" = "1" ] && return 0
+    [ "${CHEZMOI_UP_ASSUME_NO:-0}" = "1" ] && return 1
+    [ -t 0 ] || return 1
+
+    local reply=""
+    printf '%s [y/N] ' "${1}" >&2
+    read -r reply || return 1
+    case "${reply}" in
+    [yY] | [yY][eE][sS]) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
+# _chezmoi_up_check_branch -> warn when the source repo is off its default
+# branch, and offer to switch and pull.
+#
+# Always returns 0: being on a feature branch is a legitimate way to test
+# dotfiles changes, so this warns and offers rather than blocking the run.
+_chezmoi_up_check_branch() {
+    [ "${CHEZMOI_UP_SKIP_BRANCH_CHECK:-0}" = "1" ] && return 0
+
+    local source_dir
+    source_dir="$(chezmoi source-path 2>/dev/null)" || return 0
+    [ -n "${source_dir}" ] && [ -d "${source_dir}" ] || return 0
+
+    # A source directory that is not a git checkout has no branch to be wrong.
+    git -C "${source_dir}" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+
+    local expected current
+    expected="$(_chezmoi_up_expected_branch "${source_dir}")"
+    current="$(git -C "${source_dir}" symbolic-ref --short -q HEAD 2>/dev/null || true)"
+
+    [ "${current}" = "${expected}" ] && return 0
+
+    if [ -z "${current}" ]; then
+        _chezmoi_up_say warn "Source repository is in detached HEAD state, not on '${expected}'."
+    else
+        _chezmoi_up_say warn "Source repository is on '${current}', not '${expected}'."
+    fi
+    _chezmoi_up_say warn "chezmoi update pulls whichever branch is checked out."
+
+    if ! _chezmoi_up_confirm "Switch to '${expected}' and pull?"; then
+        _chezmoi_up_say info "Staying on '${current:-detached HEAD}'."
+        return 0
+    fi
+
+    # Switching with uncommitted changes would either fail or drag the changes
+    # onto the default branch; neither is something to do behind the user's back.
+    local dirty=""
+    dirty="$(git -C "${source_dir}" status --porcelain 2>/dev/null || true)"
+    if [ -n "${dirty}" ]; then
+        _chezmoi_up_say error "Source repository has uncommitted changes; commit or stash them first."
+        _chezmoi_up_say info "Continuing on '${current:-detached HEAD}'."
+        return 0
+    fi
+
+    _chezmoi_up_say step "Switching to '${expected}'"
+    if ! git -C "${source_dir}" checkout "${expected}"; then
+        _chezmoi_up_say error "Could not check out '${expected}'; continuing on '${current:-detached HEAD}'."
+        return 0
+    fi
+
+    # --ff-only: never create a merge commit in the dotfiles source behind the
+    # user's back. A diverged branch is reported instead.
+    if ! git -C "${source_dir}" pull --ff-only; then
+        _chezmoi_up_say error "Could not fast-forward '${expected}'; resolve it manually."
+        return 0
+    fi
+
+    return 0
+}
+
 # _chezmoi_up_load_log -> make log.sh's helpers available when we can.
 # config.bash/config.zsh source every file in this directory, but this one
 # sorts before log.sh, so pull it in on first use. Falls back to the copy next
@@ -107,6 +214,9 @@ _chezmoi_up_say() {
         ;;
     info)
         if command -v log_info >/dev/null 2>&1; then log_info "$*"; else printf '==> %s\n' "$*"; fi
+        ;;
+    warn)
+        if command -v log_warn >/dev/null 2>&1; then log_warn "$*"; else printf '! %s\n' "$*" >&2; fi
         ;;
     result)
         if command -v log_result >/dev/null 2>&1; then log_result "$*"; else printf '\342\234\223 %s\n' "$*"; fi
@@ -152,6 +262,8 @@ chezmoi-up() {
     _chezmoi_up_load_log
     # shellcheck disable=SC2034  # consumed by log.sh
     local LOG_TAG="chezmoi-up"
+
+    _chezmoi_up_check_branch
 
     _chezmoi_up_say step "Pulling the source repository"
     if ! chezmoi update --apply=false; then

--- a/tests/bash/chezmoi-up.bats
+++ b/tests/bash/chezmoi-up.bats
@@ -276,3 +276,138 @@ source '${FISH_FUNC}'; chezmoi_up $*; echo \"rc=\$status\""
 	run grep -F "alias czu 'chezmoi_up'" "${REPO_ROOT}/home/dot_config/fish/conf.d/aliases.fish"
 	[ "$status" -eq 0 ]
 }
+
+# --- branch guard -----------------------------------------------------------
+#
+# `chezmoi update` pulls whichever branch is checked out, so chezmoi-up warns
+# when the source repo is not on its default branch. The source dir used by the
+# tests above is deliberately not a git repo, which is itself the "no branch to
+# be wrong" case asserted below.
+
+# _make_git_src -> turn ${TEST_DIR}/src into a clone of a bare origin on main.
+_make_git_src() {
+	git init -q --bare -b main "${TEST_DIR}/origin"
+	git -c init.defaultBranch=main init -q "${TEST_DIR}/src"
+	git -C "${TEST_DIR}/src" config user.email t@t.t
+	git -C "${TEST_DIR}/src" config user.name t
+	git -C "${TEST_DIR}/src" config commit.gpgsign false
+	git -C "${TEST_DIR}/src" add -A
+	git -C "${TEST_DIR}/src" commit -qm init
+	git -C "${TEST_DIR}/src" branch -M main
+	git -C "${TEST_DIR}/src" remote add origin "${TEST_DIR}/origin"
+	git -C "${TEST_DIR}/src" push -q -u origin main
+	git -C "${TEST_DIR}/src" remote set-head origin -a >/dev/null 2>&1 || true
+}
+
+_src_branch() {
+	git -C "${TEST_DIR}/src" symbolic-ref --short -q HEAD 2>/dev/null || echo "DETACHED"
+}
+
+@test "chezmoi-up: says nothing when the source repo is on the default branch" {
+	_make_git_src
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" _run_up
+	[[ ! "$output" =~ "not 'main'" ]]
+	[[ "$output" =~ "rc=0" ]]
+}
+
+@test "chezmoi-up: warns when the source repo is on another branch" {
+	_make_git_src
+	git -C "${TEST_DIR}/src" checkout -q -b feature/x
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" CHEZMOI_UP_ASSUME_NO=1 _run_up
+	[[ "$output" =~ "is on 'feature/x', not 'main'" ]]
+	[[ "$output" =~ "rc=0" ]]
+}
+
+@test "chezmoi-up: warns before pulling, not after" {
+	_make_git_src
+	git -C "${TEST_DIR}/src" checkout -q -b feature/x
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" CHEZMOI_UP_ASSUME_NO=1 _run_up
+	local warn_line update_line
+	warn_line="$(printf '%s\n' "$output" | grep -n "not 'main'" | head -1 | cut -d: -f1)"
+	update_line="$(printf '%s\n' "$output" | grep -n 'UPDATE:' | head -1 | cut -d: -f1)"
+	[ "${warn_line}" -lt "${update_line}" ]
+}
+
+@test "chezmoi-up: declining the switch keeps the branch and still applies" {
+	_make_git_src
+	git -C "${TEST_DIR}/src" checkout -q -b feature/x
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" CHEZMOI_UP_ASSUME_NO=1 _run_up
+	[[ "$output" =~ "Staying on 'feature/x'" ]]
+	[[ "$output" =~ "APPLY: apply" ]]
+	[ "$(_src_branch)" = "feature/x" ]
+}
+
+@test "chezmoi-up: accepting the switch checks out the default branch" {
+	_make_git_src
+	git -C "${TEST_DIR}/src" checkout -q -b feature/x
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" CHEZMOI_UP_ASSUME_YES=1 _run_up
+	[[ "$output" =~ "rc=0" ]]
+	[ "$(_src_branch)" = "main" ]
+}
+
+@test "chezmoi-up: refuses to switch with uncommitted changes and keeps them" {
+	_make_git_src
+	git -C "${TEST_DIR}/src" checkout -q -b feature/x
+	printf 'dirty\n' >>"${TEST_DIR}/src/.chezmoi.yaml.tmpl"
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" CHEZMOI_UP_ASSUME_YES=1 _run_up
+	[[ "$output" =~ "uncommitted changes" ]]
+	[ "$(_src_branch)" = "feature/x" ]
+	grep -q dirty "${TEST_DIR}/src/.chezmoi.yaml.tmpl"
+}
+
+@test "chezmoi-up: warns about a detached HEAD" {
+	_make_git_src
+	git -C "${TEST_DIR}/src" checkout -q --detach
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" CHEZMOI_UP_ASSUME_NO=1 _run_up
+	[[ "$output" =~ "detached HEAD" ]]
+	[[ "$output" =~ "rc=0" ]]
+}
+
+@test "chezmoi-up: CHEZMOI_UP_SKIP_BRANCH_CHECK skips the guard" {
+	_make_git_src
+	git -C "${TEST_DIR}/src" checkout -q -b feature/x
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" CHEZMOI_UP_SKIP_BRANCH_CHECK=1 _run_up
+	[[ ! "$output" =~ "not 'main'" ]]
+	[[ "$output" =~ "rc=0" ]]
+}
+
+@test "chezmoi-up: CHEZMOI_UP_BRANCH overrides the expected branch" {
+	_make_git_src
+	git -C "${TEST_DIR}/src" checkout -q -b develop
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" CHEZMOI_UP_BRANCH=develop _run_up
+	[[ ! "$output" =~ "not 'develop'" ]]
+	[[ "$output" =~ "rc=0" ]]
+}
+
+@test "chezmoi-up: says nothing when the source dir is not a git repo" {
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" _run_up
+	[[ ! "$output" =~ "not 'main'" ]]
+	[[ "$output" =~ "rc=0" ]]
+}
+
+@test "chezmoi_up (fish): warns when the source repo is on another branch" {
+	_fish_available
+	_make_git_src
+	git -C "${TEST_DIR}/src" checkout -q -b feature/x
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" CHEZMOI_UP_ASSUME_NO=1 _run_up_fish
+	[[ "$output" =~ "is on 'feature/x', not 'main'" ]]
+	[[ "$output" =~ "rc=0" ]]
+}
+
+@test "chezmoi_up (fish): accepting the switch checks out the default branch" {
+	_fish_available
+	_make_git_src
+	git -C "${TEST_DIR}/src" checkout -q -b feature/x
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" CHEZMOI_UP_ASSUME_YES=1 _run_up_fish
+	[ "$(_src_branch)" = "main" ]
+}
+
+@test "chezmoi_up (fish): refuses to switch with uncommitted changes" {
+	_fish_available
+	_make_git_src
+	git -C "${TEST_DIR}/src" checkout -q -b feature/x
+	printf 'dirty\n' >>"${TEST_DIR}/src/.chezmoi.yaml.tmpl"
+	FAKE_STORED_SHA="${TEMPLATE_SHA}" CHEZMOI_UP_ASSUME_YES=1 _run_up_fish
+	[[ "$output" =~ "uncommitted changes" ]]
+	[ "$(_src_branch)" = "feature/x" ]
+}

--- a/tests/powershell/ChezmoiUtilities.Tests.ps1
+++ b/tests/powershell/ChezmoiUtilities.Tests.ps1
@@ -170,6 +170,112 @@ Describe "Get-ChezmoiConfigTemplate" -Tag "Unit" {
     }
 }
 
+
+Describe "Get-ChezmoiExpectedBranch" -Tag "Unit" {
+    AfterEach {
+        Remove-Item Env:CHEZMOI_UP_BRANCH -ErrorAction SilentlyContinue
+    }
+
+    It "Prefers CHEZMOI_UP_BRANCH when it is set" {
+        $env:CHEZMOI_UP_BRANCH = 'develop'
+        InModuleScope DotfilesHelpers {
+            Get-ChezmoiExpectedBranch -SourceDir '/tmp' | Should -Be 'develop'
+        }
+    }
+
+    It "Falls back to main when git cannot resolve origin/HEAD" {
+        InModuleScope DotfilesHelpers {
+            # A directory that is not a git repo: git writes to stderr and the
+            # helper must not surface that as a branch name.
+            $tmp = [System.IO.Path]::GetTempPath()
+            Get-ChezmoiExpectedBranch -SourceDir $tmp | Should -Be 'main'
+        }
+    }
+}
+
+Describe "Get-ChezmoiBranchConfirmation" -Tag "Unit" {
+    AfterEach {
+        Remove-Item Env:CHEZMOI_UP_ASSUME_YES -ErrorAction SilentlyContinue
+        Remove-Item Env:CHEZMOI_UP_ASSUME_NO -ErrorAction SilentlyContinue
+    }
+
+    It "Answers yes when CHEZMOI_UP_ASSUME_YES is 1" {
+        $env:CHEZMOI_UP_ASSUME_YES = '1'
+        InModuleScope DotfilesHelpers {
+            Get-ChezmoiBranchConfirmation -Message 'Switch?' | Should -BeTrue
+        }
+    }
+
+    It "Answers no when CHEZMOI_UP_ASSUME_NO is 1" {
+        $env:CHEZMOI_UP_ASSUME_NO = '1'
+        InModuleScope DotfilesHelpers {
+            Get-ChezmoiBranchConfirmation -Message 'Switch?' | Should -BeFalse
+        }
+    }
+
+    It "Prefers an explicit yes over an explicit no" {
+        $env:CHEZMOI_UP_ASSUME_YES = '1'
+        $env:CHEZMOI_UP_ASSUME_NO = '1'
+        InModuleScope DotfilesHelpers {
+            Get-ChezmoiBranchConfirmation -Message 'Switch?' | Should -BeTrue
+        }
+    }
+}
+
+Describe "Test-ChezmoiSourceBranch" -Tag "Unit" {
+    AfterEach {
+        Remove-Item Env:CHEZMOI_UP_SKIP_BRANCH_CHECK -ErrorAction SilentlyContinue
+    }
+
+    It "Should be available as a function" {
+        InModuleScope DotfilesHelpers {
+            Get-Command Test-ChezmoiSourceBranch -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    It "Returns immediately when CHEZMOI_UP_SKIP_BRANCH_CHECK is 1" {
+        $env:CHEZMOI_UP_SKIP_BRANCH_CHECK = '1'
+        InModuleScope DotfilesHelpers {
+            Mock Get-Command { throw 'the guard ran past its skip check' }
+            { Test-ChezmoiSourceBranch } | Should -Not -Throw
+        }
+    }
+
+    It "Does not throw when the source path cannot be determined" {
+        InModuleScope DotfilesHelpers {
+            { Test-ChezmoiSourceBranch } | Should -Not -Throw
+        }
+    }
+
+    It "Uses --ff-only so it never creates a merge commit unattended" {
+        InModuleScope DotfilesHelpers {
+            (Get-Command Test-ChezmoiSourceBranch).Definition | Should -Match '--ff-only'
+        }
+    }
+
+    It "Checks for uncommitted changes before switching branches" {
+        InModuleScope DotfilesHelpers {
+            $body = (Get-Command Test-ChezmoiSourceBranch).Definition
+            $body | Should -Match 'status --porcelain'
+            $body | Should -Match 'uncommitted changes'
+            $body.IndexOf('status --porcelain') | Should -BeLessThan $body.IndexOf('checkout $expected')
+        }
+    }
+}
+
+Describe "Update-Chezmoi branch guard wiring" -Tag "Unit" {
+    It "Runs the branch guard before pulling" {
+        # Match the invocations, not the comment-based help above them, which
+        # also names `chezmoi update --apply=false`.
+        $body = (Get-Command Update-Chezmoi).Definition
+        $guard = $body.IndexOf('Test-ChezmoiSourceBranch' + [Environment]::NewLine)
+        $pull = $body.IndexOf('& chezmoi update --apply=false')
+        $guard | Should -BeGreaterThan -1
+        $pull | Should -BeGreaterThan -1
+        $guard | Should -BeLessThan $pull
+    }
+}
+
 # SIG # Begin signature block
 # MIIfEQYJKoZIhvcNAQcCoIIfAjCCHv4CAQExDzANBglghkgBZQMEAgEFADB5Bgor
 # BgEEAYI3AgEEoGswaTA0BgorBgEEAYI3AgEeMCYCAwEAAAQQH8w7YFlLCE63JNLG

--- a/tests/powershell/Profile.Tests.ps1
+++ b/tests/powershell/Profile.Tests.ps1
@@ -286,6 +286,9 @@ Describe "DotfilesHelpers Module" {
             'Test-CopilotSshPreflight'
             'Get-ChezmoiConfigTemplate'
             'Test-ChezmoiConfigChanged'
+            'Get-ChezmoiExpectedBranch'
+            'Get-ChezmoiBranchConfirmation'
+            'Test-ChezmoiSourceBranch'
         )
 
         # Discover every top-level function defined across the Public files using


### PR DESCRIPTION
`chezmoi update` pulls whichever branch is checked out, so a feature branch left over from testing gets applied to the machine silently. `czu` now checks the source repo's branch before pulling and offers to put it back.

```console
$ czu
! Source repository is on 'feat/new-aliases', not 'main'.
! chezmoi update pulls whichever branch is checked out.
Switch to 'main' and pull? [y/N] y
==> Switching to 'main'
==> Pulling the source repository
```

Declining continues the run — working on a branch is a legitimate way to test dotfiles changes, so this warns and offers rather than blocking.

## Care taken around the destructive edges

A guard that switches branches for you can lose work, so it deliberately does not:

- **Uncommitted changes are never carried onto the default branch.** It reports them and stays put instead of checking out.
- **Pulls are `--ff-only`**, so it cannot create a merge commit in your dotfiles unattended.
- **Non-interactive shells answer no**, so CI is warned but never hangs on the prompt.
- A detached HEAD, a source dir that is not a git checkout, and a failed checkout or pull are all handled without aborting the run.

The expected branch comes from `origin/HEAD` rather than being hardcoded, so renaming the default branch keeps working.

| Variable | Effect |
| --- | --- |
| `CHEZMOI_UP_BRANCH` | Expected branch (default: repo's default branch, else `main`) |
| `CHEZMOI_UP_SKIP_BRANCH_CHECK=1` | Skip the guard entirely |
| `CHEZMOI_UP_ASSUME_YES=1` | Switch without asking |
| `CHEZMOI_UP_ASSUME_NO=1` | Never switch, even on a TTY |

## Testing

Implemented in all three shells (bash/zsh, fish, PowerShell).

- **13 new bats tests**, including that the warning is emitted *before* the pull, that uncommitted changes survive intact, and that a non-git source dir stays silent
- **19 new Pester tests**
- 463 Pester tests pass, bats at its 2 known pre-existing `json:` failures (reproduced on clean `main`)
- shellcheck clean, `shfmt --diff` reports no changes, `fish -n` clean
- PSScriptAnalyzer: 9 findings before and after — my additions add none

Docs updated in `docs/customization.md`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>