### PR TITLE
feat(pwsh): show fastfetch at PowerShell startup

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -130,6 +130,25 @@ but never blocked.
 | `CHEZMOI_UP_ASSUME_YES=1`        | Switch without asking                                             |
 | `CHEZMOI_UP_ASSUME_NO=1`         | Never switch, even on a TTY                                       |
 
+## System info at shell startup
+
+Both shells print a `fastfetch` banner when you open an interactive session:
+fish via `fish_greeting`, PowerShell via the profile. fastfetch is installed by
+the dotfiles (apt/brew on Unix, `Fastfetch-cli.Fastfetch` via winget on
+Windows), and when it is missing the banner is simply skipped — a light install
+stays quiet.
+
+The PowerShell side runs it behind a timeout, because a fetch tool can hang on a
+hardware probe (the GPU query on Snapdragon X, for instance) and would otherwise
+freeze the whole profile load while ignoring Ctrl+C. If that happens you get a
+notice instead of a hung shell:
+
+```console
+(fastfetch timed out after 5.0s; skipping)
+```
+
+Set `FASTFETCH_TIMEOUT_MS` to tune the limit (default 5000).
+
 ## Windows PATH
 
 On Windows, the setup adds `%OneDrive%\Portable Programs` to the user-scope

--- a/home/dot_config/powershell/profile.ps1
+++ b/home/dot_config/powershell/profile.ps1
@@ -100,42 +100,46 @@ if (Test-Path $completionsPath) {
     }
 }
 
-# Show horizonfetch only in interactive sessions (not when scripts import modules)
-# Guarded with a timeout because horizonfetch occasionally hangs on some
-# hardware probes (e.g. GPU query on Snapdragon X), which would otherwise
-# freeze the entire profile load and ignore Ctrl+C. See issue: pwsh session
-# hangs on profile load.
+# Show fastfetch only in interactive sessions (not when scripts import modules),
+# mirroring the fish_greeting behaviour on Linux/macOS. fastfetch is installed on
+# Windows via winget (Fastfetch-cli.Fastfetch) and simply does not run when it is
+# absent, so a light install stays quiet.
+#
+# Guarded with a timeout because a fetch tool occasionally hangs on a hardware
+# probe (e.g. the GPU query on Snapdragon X), which would otherwise freeze the
+# entire profile load and ignore Ctrl+C. See issue: pwsh session hangs on
+# profile load.
 if ([Environment]::UserInteractive -and -not $env:CHEZMOI_SOURCE_DIR) {
-    $horizonfetchCmd = Get-Command horizonfetch -ErrorAction SilentlyContinue
-    if ($horizonfetchCmd) {
+    $fastfetchCmd = Get-Command fastfetch -ErrorAction SilentlyContinue
+    if ($fastfetchCmd) {
         # Allow users to tune the timeout (milliseconds) via an env var.
-        $horizonfetchTimeoutMs = 5000
+        $fastfetchTimeoutMs = 5000
         $parsedTimeout = 0
-        if ($env:HORIZONFETCH_TIMEOUT_MS -and
-            [int]::TryParse($env:HORIZONFETCH_TIMEOUT_MS, [ref]$parsedTimeout) -and
+        if ($env:FASTFETCH_TIMEOUT_MS -and
+            [int]::TryParse($env:FASTFETCH_TIMEOUT_MS, [ref]$parsedTimeout) -and
             $parsedTimeout -gt 0) {
-            $horizonfetchTimeoutMs = $parsedTimeout
+            $fastfetchTimeoutMs = $parsedTimeout
         }
 
-        if ($horizonfetchCmd.CommandType -in @([System.Management.Automation.CommandTypes]::Application,
-                                               [System.Management.Automation.CommandTypes]::ExternalScript)) {
+        if ($fastfetchCmd.CommandType -in @([System.Management.Automation.CommandTypes]::Application,
+                                            [System.Management.Automation.CommandTypes]::ExternalScript)) {
             # External executable/script: launch it attached to the current
             # console so colors/unicode render normally, and kill it if it
             # doesn't finish within the timeout.
             try {
-                $horizonfetchProc = Start-Process -FilePath $horizonfetchCmd.Source `
+                $fastfetchProc = Start-Process -FilePath $fastfetchCmd.Source `
                     -NoNewWindow -PassThru -ErrorAction Stop
-                if (-not $horizonfetchProc.WaitForExit($horizonfetchTimeoutMs)) {
-                    try { $horizonfetchProc.Kill() } catch { }
-                    Write-Host "`n(horizonfetch timed out after $([math]::Round($horizonfetchTimeoutMs / 1000, 1))s; skipping)" -ForegroundColor DarkYellow
+                if (-not $fastfetchProc.WaitForExit($fastfetchTimeoutMs)) {
+                    try { $fastfetchProc.Kill() } catch { }
+                    Write-Host "`n(fastfetch timed out after $([math]::Round($fastfetchTimeoutMs / 1000, 1))s; skipping)" -ForegroundColor DarkYellow
                 }
             } catch {
-                Write-Host "(horizonfetch failed to start: $($_.Exception.Message))" -ForegroundColor DarkYellow
+                Write-Host "(fastfetch failed to start: $($_.Exception.Message))" -ForegroundColor DarkYellow
             }
         } else {
             # Function/alias/cmdlet: no reliable way to cancel cooperatively,
             # so just invoke it directly.
-            horizonfetch
+            fastfetch
         }
     }
 }

--- a/tests/powershell/Profile.Tests.ps1
+++ b/tests/powershell/Profile.Tests.ps1
@@ -394,30 +394,49 @@ Describe "PowerShell Aliases" {
     }
 }
 
-Describe "Profile horizonfetch timeout guard" {
+Describe "Profile fastfetch startup guard" {
     BeforeAll {
         $script:ProfileContent = Get-Content $script:ProfilePath -Raw
     }
 
-    It "Profile should invoke horizonfetch with a timeout guard" {
-        # Ensure the raw bare invocation has been replaced by a guarded one.
-        # A bare `horizonfetch` call that is not preceded by a CommandType check
+    It "Profile should run fastfetch at startup" {
+        $script:ProfileContent | Should -Match 'Get-Command fastfetch'
+    }
+
+    It "Profile should only run fastfetch in interactive sessions" {
+        # Importing the module from a script must not print a system info banner.
+        $script:ProfileContent | Should -Match '\[Environment\]::UserInteractive'
+    }
+
+    It "Profile should invoke fastfetch with a timeout guard" {
+        # A bare `fastfetch` call that is not preceded by a CommandType check
         # would allow a hang to block the profile.
         $script:ProfileContent | Should -Match 'Start-Process'
         $script:ProfileContent | Should -Match 'WaitForExit'
     }
 
-    It "Profile should kill horizonfetch when the timeout elapses" {
-        $script:ProfileContent | Should -Match '\$horizonfetchProc\.Kill\(\)'
+    It "Profile should kill fastfetch when the timeout elapses" {
+        $script:ProfileContent | Should -Match '\$fastfetchProc\.Kill\(\)'
     }
 
-    It "Profile should support overriding the horizonfetch timeout via env var" {
-        $script:ProfileContent | Should -Match 'HORIZONFETCH_TIMEOUT_MS'
+    It "Profile should support overriding the fastfetch timeout via env var" {
+        $script:ProfileContent | Should -Match 'FASTFETCH_TIMEOUT_MS'
     }
 
-    It "Profile should only start horizonfetch for Application or ExternalScript commands" {
+    It "Profile should only start fastfetch for Application or ExternalScript commands" {
         $script:ProfileContent | Should -Match 'CommandTypes\]::Application'
         $script:ProfileContent | Should -Match 'CommandTypes\]::ExternalScript'
+    }
+
+    It "Profile should no longer reference horizonfetch" {
+        # Replaced by fastfetch, which is the tool the dotfiles actually install.
+        $script:ProfileContent | Should -Not -Match 'horizonfetch'
+    }
+
+    It "Profile should tolerate fastfetch being absent" {
+        # -ErrorAction SilentlyContinue plus the if () guard is what keeps a
+        # light install (no fastfetch) from erroring on every shell start.
+        $script:ProfileContent | Should -Match 'Get-Command fastfetch -ErrorAction SilentlyContinue'
     }
 }
 


### PR DESCRIPTION
fish prints a fastfetch banner via `fish_greeting`, but PowerShell only exposed it as the `ff`/`sysinfo`/`motd` aliases — so Windows sessions started without one.

## Why it replaces horizonfetch rather than joining it

The profile already had a guarded `horizonfetch` block, but **horizonfetch is not installed by these dotfiles anywhere** — it appears in no package list, only in `profile.ps1` and its test. On a clean machine that block never fired.

fastfetch *is* installed on Windows via winget (`Fastfetch-cli.Fastfetch`), so it takes over the slot and PowerShell now matches fish.

## Timeout guard kept

The existing guard is what stops a hardware probe hang (the GPU query on Snapdragon X) from freezing the whole profile load while ignoring Ctrl+C. Only the tool name changed, including the tuning variable: `HORIZONFETCH_TIMEOUT_MS` → `FASTFETCH_TIMEOUT_MS` (default 5000).

```console
(fastfetch timed out after 5.0s; skipping)
```

## Verified behaviourally, not just by inspection

The block was extracted and executed against stubs:

| Scenario | Result |
| --- | --- |
| fastfetch on PATH | banner prints |
| fastfetch absent | silent, no error — a light install stays quiet |
| fastfetch hangs | killed at the timeout; block returns in ~2.5s instead of blocking |

## Testing

- 456 Pester tests pass; bats at its 2 known pre-existing `json:` failures (reproduced on clean `main`)
- PSScriptAnalyzer: 7 findings on `origin/main`, 7 on this branch — no new ones
- New tests cover the interactive-only guard, tolerating absence, the timeout guard, and a regression test that `horizonfetch` is gone

Docs: new "System info at shell startup" section in `docs/customization.md`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>