### PR TITLE
fix(test): make the branch guard ordering test line-ending agnostic

### DIFF
--- a/tests/powershell/ChezmoiUtilities.Tests.ps1
+++ b/tests/powershell/ChezmoiUtilities.Tests.ps1
@@ -265,10 +265,15 @@ Describe "Test-ChezmoiSourceBranch" -Tag "Unit" {
 
 Describe "Update-Chezmoi branch guard wiring" -Tag "Unit" {
     It "Runs the branch guard before pulling" {
+        # Normalise line endings before matching. .gitattributes pins *.ps1 to
+        # eol=crlf, so the working tree is CRLF on every OS while
+        # [Environment]::NewLine is LF on Linux/macOS - matching against it
+        # would only ever succeed on Windows.
+        #
         # Match the invocations, not the comment-based help above them, which
         # also names `chezmoi update --apply=false`.
-        $body = (Get-Command Update-Chezmoi).Definition
-        $guard = $body.IndexOf('Test-ChezmoiSourceBranch' + [Environment]::NewLine)
+        $body = (Get-Command Update-Chezmoi).Definition -replace "`r`n", "`n"
+        $guard = $body.IndexOf("Test-ChezmoiSourceBranch`n")
         $pull = $body.IndexOf('& chezmoi update --apply=false')
         $guard | Should -BeGreaterThan -1
         $pull | Should -BeGreaterThan -1


### PR DESCRIPTION
The test added in #623 fails on Linux and macOS. It is currently red on `main`.

## Cause

```powershell
$guard = $body.IndexOf('Test-ChezmoiSourceBranch' + [Environment]::NewLine)
```

`.gitattributes` pins `*.ps1` to `eol=crlf`, so the working tree is **CRLF on every OS** — but `[Environment]::NewLine` is **LF on Linux/macOS**. The match therefore only ever succeeded on Windows.

CI runs the Pester suite on Windows, which is why this passed review and still broke `main` for anyone running the suite locally on Linux or macOS.

Reproduced on a clean clone of `main`:

```
[-] Update-Chezmoi branch guard wiring.Runs the branch guard before pulling
 Expected the actual value to be greater than '-1', but got -1.
Tests Passed: 31, Failed: 1
```

## Fix

Normalise CRLF to LF before matching. My bug from #623.

## Verification

- 463 Pester tests pass on Linux (was 462 passing + 1 failing)
- Grepped for the same pattern elsewhere: the only other `[Environment]::NewLine` is in `install.ps1`, where it is correct (joining output for display)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>