### PR TITLE
feat(fastfetch): show winget update count on Windows

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -149,6 +149,52 @@ notice instead of a hung shell:
 
 Set `FASTFETCH_TIMEOUT_MS` to tune the limit (default 5000).
 
+### Extra status lines
+
+The banner carries a few extra lines that only appear when they have something
+to say — fastfetch hides a module entirely when it prints nothing, so a healthy
+machine stays clean:
+
+```console
+Updates: 📦 6 update(s) available (winget)
+Reboot: 🔄 Reboot required — linux-image-generic
+Ansible: ✅ ansible-pull OK · ran 5m ago · next in 25m
+```
+
+`Updates` works everywhere: apt/dnf/pacman/zypper/apk on Linux, brew on macOS,
+winget on Windows. `Reboot` and `Ansible` are Linux-only.
+
+Counting updates is far too slow to do while you wait for a prompt (a winget
+query takes tens of seconds), so nothing is ever computed on the login path.
+Instead the numbers come from a small cache that is refreshed in the background:
+the banner shows the previous result instantly while a fresh one is computed for
+the next login.
+
+| Platform    | Cache                                  | Filled by                                                                |
+| ----------- | -------------------------------------- | ------------------------------------------------------------------------ |
+| Linux/macOS | `~/.cache/fastfetch-status/`           | `~/.config/fastfetch/status.sh`, which self-spawns its own refresh        |
+| Windows     | `%LOCALAPPDATA%\fastfetch-status\`     | `~/.config/fastfetch/status.ps1`, spawned detached by the PowerShell profile |
+
+On Windows fastfetch reads the cache with `cmd /c type` rather than starting
+PowerShell, which keeps the line free (a few milliseconds).
+
+Refresh by hand — useful right after installing updates:
+
+```bash
+~/.config/fastfetch/status.sh refresh        # Linux/macOS
+```
+
+```powershell
+~/.config/fastfetch/status.ps1 refresh       # Windows
+```
+
+| Variable                     | Effect                                                       |
+| ---------------------------- | ------------------------------------------------------------ |
+| `FASTFETCH_STATUS_TTL`       | Cache lifetime in seconds (default 3600)                     |
+| `FASTFETCH_STATUS_DISABLE=1` | Print no status lines at all                                 |
+| `FASTFETCH_STATUS_CACHE_DIR` | Override the cache directory (Windows; testing)              |
+| `ANSIBLE_PULL_WORKDIR`       | ansible-pull checkout (default `/var/lib/ansible/local`)      |
+
 ## Windows PATH
 
 On Windows, the setup adds `%OneDrive%\Portable Programs` to the user-scope

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -24,14 +24,15 @@ renovate.json
 
 {{ if eq .chezmoi.os "windows" }}
 .chezmoiscripts/linux/**
-# fastfetch status modules are driven by a bash script (status.sh); Windows
-# fastfetch keeps its own default config instead.
+# The fastfetch status cache is filled by status.ps1 on Windows and status.sh
+# everywhere else; ship only the one the host can run.
 # Patterns match the TARGET path, so this is .config/… and not dot_config/….
-.config/fastfetch/**
+.config/fastfetch/status.sh
 {{ end }}
 
 {{ if ne .chezmoi.os "windows" }}
 .chezmoiscripts/windows/**
+.config/fastfetch/status.ps1
 Documents
 AppData
 {{ end }}

--- a/home/dot_config/fastfetch/config.jsonc.tmpl
+++ b/home/dot_config/fastfetch/config.jsonc.tmpl
@@ -1,6 +1,6 @@
 {
   "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json",
-  "//": "Managed by chezmoi (dot_config/fastfetch/config.jsonc). The three trailing 'command' modules call status.sh, which prints cached lines and refreshes in the background so login stays fast. Empty output makes a line disappear, so updates/reboot/ansible only show when relevant.",
+  "//": "Managed by chezmoi (dot_config/fastfetch/config.jsonc.tmpl). The trailing 'command' modules print cached status lines that are refreshed in the background so login stays fast. Empty output makes a line disappear, so updates/reboot/ansible only show when relevant.",
   "modules": [
     "title",
     "separator",
@@ -29,6 +29,15 @@
     "battery",
     "poweradapter",
     "locale",
+{{- if eq .chezmoi.os "windows" }}
+    {
+      "//": "Windows reads the cache with `cmd /c type` (a few milliseconds) instead of starting PowerShell; status.ps1 fills it from a detached background refresh spawned by the PowerShell profile. `cd` first because fastfetch cannot pass double quotes through to cmd, and an unquoted path would break on a user profile containing a space.",
+      "type": "command",
+      "key": "Updates",
+      "keyColor": "yellow",
+      "text": "cd /d %LOCALAPPDATA%\\fastfetch-status 2>nul && type updates 2>nul"
+    },
+{{- else }}
     {
       "type": "command",
       "key": "Updates",
@@ -47,6 +56,7 @@
       "keyColor": "blue",
       "text": "\"$HOME/.config/fastfetch/status.sh\" ansible"
     },
+{{- end }}
     "break",
     "colors"
   ]

--- a/home/dot_config/fastfetch/status.ps1
+++ b/home/dot_config/fastfetch/status.ps1
@@ -1,0 +1,302 @@
+<#
+.SYNOPSIS
+    Cached system status lines for fastfetch on Windows.
+
+.DESCRIPTION
+    Windows counterpart of dot_config/fastfetch/status.sh. It emits short,
+    self-hiding status lines that fastfetch renders as extra modules; today that
+    is the number of available winget package updates.
+
+    Speed is the priority: checking winget for updates takes tens of seconds, so
+    it must never happen on the login path. The script therefore uses the same
+    stale-while-revalidate strategy as the Unix version:
+
+      * 'refresh' does the expensive work and writes a tiny cache file.
+      * The cache file is printed on login. On Windows fastfetch reads it
+        directly with `cmd /c type` (see config.jsonc.tmpl) so no PowerShell
+        process is started at all; the 'updates' command here does the same
+        thing and exists for scripting and tests.
+      * The PowerShell profile spawns a detached 'refresh' when the cache is
+        older than the TTL, so the next login shows fresh numbers.
+
+    fastfetch hides a `command` module entirely when it prints nothing, so a
+    host with no pending updates simply does not get an "Updates" line.
+
+.PARAMETER Command
+    updates   Print the cached "updates available" line (may be empty).
+    refresh   Recompute the cache (respects a single-runner lock).
+    clear     Remove the cache.
+    help      Show this help.
+
+.PARAMETER Force
+    With 'refresh': take over a refresh lock held by another run.
+
+.EXAMPLE
+    status.ps1 updates
+
+.EXAMPLE
+    status.ps1 refresh -Force
+
+.NOTES
+    Environment:
+      FASTFETCH_STATUS_TTL         Cache lifetime in seconds (default 3600)
+      FASTFETCH_STATUS_DISABLE     When set to 1, all sections print nothing
+      FASTFETCH_STATUS_CACHE_DIR   Cache directory (default %LOCALAPPDATA%\fastfetch-status)
+
+    Never requires elevation. 'refresh' does reach the network (winget queries
+    its sources); the emit path never does.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [ValidateSet('updates', 'refresh', 'clear', 'help')]
+    [string]$Command = 'help',
+
+    [switch]$Force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+# U+1F4E6 PACKAGE. Built from its code point because .ps1 files in this repo
+# must stay ASCII (see .github/copilot-instructions.md): PowerShell 5.1 reads
+# unsigned scripts without a BOM as ANSI, which corrupts literal emoji.
+$script:PackageIcon = [char]::ConvertFromUtf32(0x1F4E6)
+
+function Get-StatusCacheDir {
+    if ($env:FASTFETCH_STATUS_CACHE_DIR) { return $env:FASTFETCH_STATUS_CACHE_DIR }
+    $base = if ($env:LOCALAPPDATA) { $env:LOCALAPPDATA } else { Join-Path $HOME '.cache' }
+    return (Join-Path $base 'fastfetch-status')
+}
+
+function Get-StatusTtl {
+    $ttl = 3600
+    $parsed = 0
+    if ($env:FASTFETCH_STATUS_TTL -and
+        [int]::TryParse($env:FASTFETCH_STATUS_TTL, [ref]$parsed) -and
+        $parsed -gt 0) {
+        $ttl = $parsed
+    }
+    return $ttl
+}
+
+function Test-StatusCacheStale {
+    <#
+    .SYNOPSIS
+    True when the cache is missing or older than the TTL.
+    #>
+    [CmdletBinding()]
+    param()
+
+    $stamp = Join-Path (Get-StatusCacheDir) '.refreshed-at'
+    if (-not (Test-Path -LiteralPath $stamp)) { return $true }
+
+    $age = (Get-Date) - (Get-Item -LiteralPath $stamp).LastWriteTime
+    return ($age.TotalSeconds -ge (Get-StatusTtl))
+}
+
+function Get-WingetUpdateCount {
+    <#
+    .SYNOPSIS
+    Number of packages with an available winget upgrade, or $null when winget
+    is not usable on this host.
+    #>
+    [CmdletBinding()]
+    param()
+
+    # Preferred path: the WinGet PowerShell module returns objects, so no
+    # locale-dependent table parsing is involved.
+    if (Get-Module -ListAvailable -Name Microsoft.WinGet.Client -ErrorAction SilentlyContinue) {
+        try {
+            Import-Module Microsoft.WinGet.Client -ErrorAction Stop
+            $outdated = @(Get-WinGetPackage -ErrorAction Stop |
+                    Where-Object { $_.IsUpdateAvailable })
+            return $outdated.Count
+        }
+        catch {
+            Write-Verbose "Microsoft.WinGet.Client failed, falling back to winget.exe: $($_.Exception.Message)"
+        }
+    }
+
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) { return $null }
+
+    try {
+        $output = & winget upgrade --include-unknown --accept-source-agreements 2>&1 | Out-String
+    }
+    catch {
+        return $null
+    }
+
+    return (Measure-WingetTableRow -Output $output)
+}
+
+function Measure-WingetTableRow {
+    <#
+    .SYNOPSIS
+    Count package rows in `winget upgrade` table output.
+
+    .DESCRIPTION
+    Best-effort fallback used only when the WinGet PowerShell module is
+    unavailable. Rows come after the dashed header separator and are padded
+    into columns, so they always contain a run of two or more spaces; the
+    localized summary and warning sentences that follow the table do not.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$Output
+    )
+
+    $lines = $Output -split "`r?`n"
+    $separator = -1
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -match '^-{5,}\s*$') { $separator = $i; break }
+    }
+    if ($separator -lt 0) { return 0 }
+
+    $rows = 0
+    for ($i = $separator + 1; $i -lt $lines.Count; $i++) {
+        $line = $lines[$i]
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        if ($line -match '^-{5,}\s*$') { continue }
+        if ($line -notmatch '\S {2,}\S') { continue }
+        $rows++
+    }
+    return $rows
+}
+
+function Get-UpdatesLine {
+    <#
+    .SYNOPSIS
+    The "N update(s) available (winget)" line, or an empty string.
+    #>
+    [CmdletBinding()]
+    param()
+
+    $count = Get-WingetUpdateCount
+    if ($null -eq $count -or $count -le 0) { return '' }
+    return ('{0} {1} update(s) available (winget)' -f $script:PackageIcon, $count)
+}
+
+function Write-StatusSection {
+    <#
+    .SYNOPSIS
+    Atomically write a cache section, or remove it when the value is empty.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Value
+    )
+
+    $file = Join-Path (Get-StatusCacheDir) $Name
+    if (-not $PSCmdlet.ShouldProcess($file, 'Write status section')) { return }
+
+    if ([string]::IsNullOrEmpty($Value)) {
+        Remove-Item -LiteralPath $file -Force -ErrorAction SilentlyContinue
+        return
+    }
+
+    # UTF-8 without BOM: `cmd /c type` copies the bytes straight through to
+    # fastfetch, so a BOM would show up as stray characters in the banner.
+    $encoding = New-Object System.Text.UTF8Encoding($false)
+    $tmp = "$file.tmp"
+    [System.IO.File]::WriteAllText($tmp, ($Value + "`r`n"), $encoding)
+    Move-Item -LiteralPath $tmp -Destination $file -Force
+}
+
+function Invoke-StatusEmit {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Name)
+
+    if ($env:FASTFETCH_STATUS_DISABLE -eq '1') { return }
+
+    $file = Join-Path (Get-StatusCacheDir) $Name
+    if (-not (Test-Path -LiteralPath $file)) { return }
+
+    Get-Content -LiteralPath $file -Encoding UTF8 |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        ForEach-Object { $_ }
+}
+
+function Invoke-StatusRefresh {
+    [CmdletBinding(SupportsShouldProcess)]
+    param([switch]$Force)
+
+    $cacheDir = Get-StatusCacheDir
+    if (-not $PSCmdlet.ShouldProcess($cacheDir, 'Refresh fastfetch status cache')) { return }
+
+    New-Item -ItemType Directory -Path $cacheDir -Force | Out-Null
+
+    # Single-runner lock. Creating the file with CreateNew is atomic at the OS
+    # level, so two concurrent refreshes cannot both win. A lock older than ten
+    # minutes was left behind by an interrupted refresh and is reclaimed.
+    $lock = Join-Path $cacheDir '.refresh.lock'
+    $handle = $null
+    try {
+        $handle = [System.IO.File]::Open($lock, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write)
+    }
+    catch {
+        $handle = $null
+    }
+
+    if (-not $handle -and (Test-Path -LiteralPath $lock)) {
+        $lockAge = (Get-Date) - (Get-Item -LiteralPath $lock).LastWriteTime
+        if ($Force -or $lockAge.TotalSeconds -gt 600) {
+            Remove-Item -LiteralPath $lock -Force -ErrorAction SilentlyContinue
+            try {
+                $handle = [System.IO.File]::Open($lock, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write)
+            }
+            catch {
+                $handle = $null
+            }
+        }
+    }
+
+    if (-not $handle) {
+        Write-Verbose 'Another refresh is already running; skipping.'
+        return
+    }
+
+    try {
+        Write-StatusSection -Name 'updates' -Value (Get-UpdatesLine)
+        $stamp = Join-Path $cacheDir '.refreshed-at'
+        [System.IO.File]::WriteAllText($stamp, '')
+    }
+    finally {
+        $handle.Dispose()
+        Remove-Item -LiteralPath $lock -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Show-StatusUsage {
+    @'
+Usage: status.ps1 <command> [-Force]
+
+Commands:
+  updates          Print cached "updates available" line (may be empty)
+  refresh          Recompute the cache (respects a single-runner lock)
+  clear            Remove the cache
+  help             Show this help
+
+Options:
+  -Force           With refresh: take over a lock held by another run
+
+Environment:
+  FASTFETCH_STATUS_TTL         Cache lifetime in seconds (default 3600)
+  FASTFETCH_STATUS_DISABLE     When set to 1, all sections print nothing
+  FASTFETCH_STATUS_CACHE_DIR   Cache directory (default %LOCALAPPDATA%\fastfetch-status)
+'@
+}
+
+# Dot-sourcing (tests) loads the functions without running a command.
+if ($MyInvocation.InvocationName -eq '.') { return }
+
+switch ($Command) {
+    'updates' { Invoke-StatusEmit -Name 'updates' }
+    'refresh' { Invoke-StatusRefresh -Force:$Force }
+    'clear' { Remove-Item -LiteralPath (Get-StatusCacheDir) -Recurse -Force -ErrorAction SilentlyContinue }
+    default { Show-StatusUsage }
+}

--- a/home/dot_config/powershell/profile.ps1
+++ b/home/dot_config/powershell/profile.ps1
@@ -112,6 +112,56 @@ if (Test-Path $completionsPath) {
 if ([Environment]::UserInteractive -and -not $env:CHEZMOI_SOURCE_DIR) {
     $fastfetchCmd = Get-Command fastfetch -ErrorAction SilentlyContinue
     if ($fastfetchCmd) {
+        # Stale-while-revalidate for the extra "Updates" module: fastfetch reads
+        # a cache file with `cmd /c type`, and the expensive winget query runs
+        # here in a detached background process. The banner below therefore
+        # shows the previous (possibly slightly stale) numbers instantly while a
+        # fresh copy is computed for the next login. Mirrors status.sh on Unix,
+        # which can self-spawn its refresh because its emit path is already a
+        # shell script.
+        try {
+            $statusScript = Join-Path (Split-Path $PSScriptRoot -Parent) 'fastfetch\status.ps1'
+            $statusCacheDir = if ($env:FASTFETCH_STATUS_CACHE_DIR) {
+                $env:FASTFETCH_STATUS_CACHE_DIR
+            } else {
+                Join-Path $env:LOCALAPPDATA 'fastfetch-status'
+            }
+            $statusStamp = Join-Path $statusCacheDir '.refreshed-at'
+
+            $statusTtlSeconds = 3600
+            $parsedTtl = 0
+            if ($env:FASTFETCH_STATUS_TTL -and
+                [int]::TryParse($env:FASTFETCH_STATUS_TTL, [ref]$parsedTtl) -and
+                $parsedTtl -gt 0) {
+                $statusTtlSeconds = $parsedTtl
+            }
+
+            $statusStale = -not (Test-Path -LiteralPath $statusStamp)
+            if (-not $statusStale) {
+                $statusAge = (Get-Date) - (Get-Item -LiteralPath $statusStamp).LastWriteTime
+                $statusStale = $statusAge.TotalSeconds -ge $statusTtlSeconds
+            }
+
+            if ($statusStale -and $env:FASTFETCH_STATUS_DISABLE -ne '1' -and (Test-Path -LiteralPath $statusScript)) {
+                $statusHost = (Get-Process -Id $PID).Path
+                if ($statusHost) {
+                    # Output is silenced inside the child (*>$null) as well as
+                    # redirected, because nobody drains these pipes: a chatty
+                    # child would otherwise block once the pipe buffer filled.
+                    $statusCommand = "& '{0}' refresh *>`$null" -f $statusScript.Replace("'", "''")
+                    $statusInfo = [System.Diagnostics.ProcessStartInfo]::new($statusHost)
+                    $statusInfo.Arguments = '-NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "{0}"' -f $statusCommand
+                    $statusInfo.UseShellExecute = $false
+                    $statusInfo.CreateNoWindow = $true
+                    $statusInfo.RedirectStandardOutput = $true
+                    $statusInfo.RedirectStandardError = $true
+                    [System.Diagnostics.Process]::Start($statusInfo) | Out-Null
+                }
+            }
+        } catch {
+            # A missing cache only costs an "Updates" line; never break the shell.
+        }
+
         # Allow users to tune the timeout (milliseconds) via an env var.
         $fastfetchTimeoutMs = 5000
         $parsedTimeout = 0

--- a/tests/powershell/FastfetchStatus.Tests.ps1
+++ b/tests/powershell/FastfetchStatus.Tests.ps1
@@ -1,0 +1,328 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Pester tests for the Windows fastfetch status script.
+
+.DESCRIPTION
+    Covers home/dot_config/fastfetch/status.ps1, which caches the winget update
+    count so the fastfetch banner can render it without ever querying winget on
+    the login path, plus the chezmoi wiring that ships it (config template,
+    .chezmoiignore and the profile's background refresh).
+
+.NOTES
+    winget itself is never invoked: the collector functions are dot-sourced and
+    mocked so the tests stay fast and offline.
+#>
+
+BeforeAll {
+    $script:RepoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+    $script:FastfetchDir = Join-Path $script:RepoRoot "home\dot_config\fastfetch"
+    $script:StatusScript = Join-Path $script:FastfetchDir "status.ps1"
+    $script:ConfigTemplate = Join-Path $script:FastfetchDir "config.jsonc.tmpl"
+    $script:ProfilePath = Join-Path $script:RepoRoot "home\dot_config\powershell\profile.ps1"
+
+    # Isolated cache so tests never touch the real %LOCALAPPDATA% cache.
+    $script:OriginalCacheDir = $env:FASTFETCH_STATUS_CACHE_DIR
+    $script:OriginalTtl = $env:FASTFETCH_STATUS_TTL
+    $script:OriginalDisable = $env:FASTFETCH_STATUS_DISABLE
+    $script:TestCacheDir = Join-Path ([System.IO.Path]::GetTempPath()) ("ff-status-" + [guid]::NewGuid().ToString('N'))
+    $env:FASTFETCH_STATUS_CACHE_DIR = $script:TestCacheDir
+
+    # Dot-sourcing loads the functions without dispatching a command.
+    . $script:StatusScript
+}
+
+AfterAll {
+    $env:FASTFETCH_STATUS_CACHE_DIR = $script:OriginalCacheDir
+    $env:FASTFETCH_STATUS_TTL = $script:OriginalTtl
+    $env:FASTFETCH_STATUS_DISABLE = $script:OriginalDisable
+    if (Test-Path -LiteralPath $script:TestCacheDir) {
+        Remove-Item -LiteralPath $script:TestCacheDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Describe "fastfetch status.ps1 file" {
+    It "should exist" {
+        $script:StatusScript | Should -Exist
+    }
+
+    It "should have valid PowerShell syntax" {
+        $errors = $null
+        [System.Management.Automation.Language.Parser]::ParseFile(
+            $script:StatusScript, [ref]$null, [ref]$errors) | Out-Null
+        $errors | Should -BeNullOrEmpty
+    }
+
+    It "should stay ASCII-only so unsigned loads under Windows PowerShell 5.1 do not corrupt strings" {
+        $bytes = [System.IO.File]::ReadAllBytes($script:StatusScript)
+        @($bytes | Where-Object { $_ -gt 127 }).Count | Should -Be 0
+    }
+}
+
+Describe "fastfetch status.ps1 commands" {
+    BeforeEach {
+        if (Test-Path -LiteralPath $script:TestCacheDir) {
+            Remove-Item -LiteralPath $script:TestCacheDir -Recurse -Force
+        }
+    }
+
+    It "help should print usage" {
+        $output = & $script:StatusScript help | Out-String
+        $output | Should -Match "Usage: status.ps1"
+        $output | Should -Match "updates"
+        $output | Should -Match "refresh"
+    }
+
+    It "should print usage when no command is given" {
+        $output = & $script:StatusScript | Out-String
+        $output | Should -Match "Usage: status.ps1"
+    }
+
+    It "should reject an unknown command" {
+        { & $script:StatusScript bogus } | Should -Throw
+    }
+
+    It "updates should print nothing when the cache is missing" {
+        $output = & $script:StatusScript updates
+        $output | Should -BeNullOrEmpty
+    }
+
+    It "updates should print the cached line" {
+        New-Item -ItemType Directory -Path $script:TestCacheDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $script:TestCacheDir 'updates') -Value '3 update(s) available (winget)'
+
+        $output = & $script:StatusScript updates | Out-String
+        $output | Should -Match "3 update\(s\) available \(winget\)"
+    }
+
+    It "updates should print nothing when disabled" {
+        New-Item -ItemType Directory -Path $script:TestCacheDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $script:TestCacheDir 'updates') -Value '3 update(s) available (winget)'
+
+        $env:FASTFETCH_STATUS_DISABLE = '1'
+        try {
+            $output = & $script:StatusScript updates
+            $output | Should -BeNullOrEmpty
+        }
+        finally {
+            $env:FASTFETCH_STATUS_DISABLE = $script:OriginalDisable
+        }
+    }
+
+    It "clear should remove the cache directory" {
+        New-Item -ItemType Directory -Path $script:TestCacheDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $script:TestCacheDir 'updates') -Value 'x'
+
+        & $script:StatusScript clear
+        $script:TestCacheDir | Should -Not -Exist
+    }
+}
+
+Describe "fastfetch status.ps1 cache staleness" {
+    BeforeEach {
+        if (Test-Path -LiteralPath $script:TestCacheDir) {
+            Remove-Item -LiteralPath $script:TestCacheDir -Recurse -Force
+        }
+    }
+
+    It "should be stale when the cache is missing" {
+        Test-StatusCacheStale | Should -BeTrue
+    }
+
+    It "should be fresh right after a refresh stamp is written" {
+        New-Item -ItemType Directory -Path $script:TestCacheDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $script:TestCacheDir '.refreshed-at') -Value ''
+
+        Test-StatusCacheStale | Should -BeFalse
+    }
+
+    It "should be stale once the stamp is older than the TTL" {
+        New-Item -ItemType Directory -Path $script:TestCacheDir -Force | Out-Null
+        $stamp = Join-Path $script:TestCacheDir '.refreshed-at'
+        Set-Content -LiteralPath $stamp -Value ''
+        (Get-Item -LiteralPath $stamp).LastWriteTime = (Get-Date).AddSeconds(-120)
+
+        $env:FASTFETCH_STATUS_TTL = '60'
+        try {
+            Test-StatusCacheStale | Should -BeTrue
+        }
+        finally {
+            $env:FASTFETCH_STATUS_TTL = $script:OriginalTtl
+        }
+    }
+}
+
+Describe "fastfetch status.ps1 winget table parsing" {
+    It "should count package rows and ignore the summary sentence" {
+        $output = @(
+            'Name                 Id                  Version   Available Source'
+            '--------------------------------------------------------------------'
+            'Copilot CLI          GitHub.Copilot      v1.0.71   v1.0.76   winget'
+            'mise-en-place        jdx.mise            2026.7.7  2026.7.15 winget'
+            '2 upgrades available.'
+        ) -join "`r`n"
+
+        Measure-WingetTableRow -Output $output | Should -Be 2
+    }
+
+    It "should return 0 when winget reports nothing to upgrade" {
+        Measure-WingetTableRow -Output 'No installed package found matching input criteria.' |
+            Should -Be 0
+    }
+
+    It "should return 0 for empty output" {
+        Measure-WingetTableRow -Output '' | Should -Be 0
+    }
+
+    It "should ignore trailing notes that are not table rows" {
+        $output = @(
+            'Name        Id            Version Available Source'
+            '---------------------------------------------------'
+            '7-Zip       7zip.7zip     24.09   25.01     winget'
+            '1 upgrades available.'
+            '1 package(s) have version numbers that cannot be determined.'
+        ) -join "`r`n"
+
+        Measure-WingetTableRow -Output $output | Should -Be 1
+    }
+}
+
+Describe "fastfetch status.ps1 update line" {
+    BeforeEach {
+        if (Test-Path -LiteralPath $script:TestCacheDir) {
+            Remove-Item -LiteralPath $script:TestCacheDir -Recurse -Force
+        }
+    }
+
+    It "should be empty when winget is unavailable" {
+        Mock Get-WingetUpdateCount { $null }
+        Get-UpdatesLine | Should -BeNullOrEmpty
+    }
+
+    It "should be empty when everything is up to date" {
+        Mock Get-WingetUpdateCount { 0 }
+        Get-UpdatesLine | Should -BeNullOrEmpty
+    }
+
+    It "should report the count and the manager" {
+        Mock Get-WingetUpdateCount { 6 }
+        Get-UpdatesLine | Should -Match '^\S+ 6 update\(s\) available \(winget\)$'
+    }
+
+    It "refresh should write a cache file and a stamp" {
+        Mock Get-WingetUpdateCount { 4 }
+        Invoke-StatusRefresh
+
+        Join-Path $script:TestCacheDir '.refreshed-at' | Should -Exist
+        $line = Get-Content -LiteralPath (Join-Path $script:TestCacheDir 'updates') -Raw
+        $line | Should -Match '4 update\(s\) available \(winget\)'
+    }
+
+    It "refresh should write the cache as UTF-8 without a BOM so cmd /c type stays clean" {
+        Mock Get-WingetUpdateCount { 4 }
+        Invoke-StatusRefresh
+
+        $bytes = [System.IO.File]::ReadAllBytes((Join-Path $script:TestCacheDir 'updates'))
+        $bytes[0] | Should -Not -Be 0xEF
+    }
+
+    It "refresh should remove the cache file when nothing is outdated" {
+        Mock Get-WingetUpdateCount { 3 }
+        Invoke-StatusRefresh
+        Join-Path $script:TestCacheDir 'updates' | Should -Exist
+
+        Mock Get-WingetUpdateCount { 0 }
+        Invoke-StatusRefresh
+        Join-Path $script:TestCacheDir 'updates' | Should -Not -Exist
+    }
+
+    It "refresh should release the lock on completion" {
+        Mock Get-WingetUpdateCount { 1 }
+        Invoke-StatusRefresh
+        Join-Path $script:TestCacheDir '.refresh.lock' | Should -Not -Exist
+    }
+
+    It "refresh should skip while another run holds a fresh lock" {
+        Mock Get-WingetUpdateCount { 5 }
+        New-Item -ItemType Directory -Path $script:TestCacheDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $script:TestCacheDir '.refresh.lock') -Value ''
+
+        Invoke-StatusRefresh
+        Join-Path $script:TestCacheDir 'updates' | Should -Not -Exist
+        Should -Invoke Get-WingetUpdateCount -Times 0
+    }
+
+    It "refresh -Force should take over a held lock" {
+        Mock Get-WingetUpdateCount { 5 }
+        New-Item -ItemType Directory -Path $script:TestCacheDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $script:TestCacheDir '.refresh.lock') -Value ''
+
+        Invoke-StatusRefresh -Force
+        Join-Path $script:TestCacheDir 'updates' | Should -Exist
+    }
+
+    It "refresh should reclaim a lock left behind by an interrupted run" {
+        Mock Get-WingetUpdateCount { 5 }
+        New-Item -ItemType Directory -Path $script:TestCacheDir -Force | Out-Null
+        $lock = Join-Path $script:TestCacheDir '.refresh.lock'
+        Set-Content -LiteralPath $lock -Value ''
+        (Get-Item -LiteralPath $lock).LastWriteTime = (Get-Date).AddMinutes(-30)
+
+        Invoke-StatusRefresh
+        Join-Path $script:TestCacheDir 'updates' | Should -Exist
+    }
+}
+
+Describe "fastfetch chezmoi wiring" {
+    BeforeAll {
+        $script:TemplateContent = Get-Content $script:ConfigTemplate -Raw
+        $script:IgnoreContent = Get-Content (Join-Path $script:RepoRoot "home\.chezmoiignore") -Raw
+        $script:ProfileContent = Get-Content $script:ProfilePath -Raw
+    }
+
+    It "config template should exist" {
+        $script:ConfigTemplate | Should -Exist
+    }
+
+    It "config template should branch on the OS" {
+        $script:TemplateContent | Should -Match 'if eq \.chezmoi\.os "windows"'
+    }
+
+    It "Windows branch should read the cache with cmd instead of PowerShell" {
+        $script:TemplateContent | Should -Match 'type updates'
+        # Double quotes cannot survive fastfetch's cmd invocation, so the path
+        # has to be entered with `cd` rather than quoted inline.
+        $script:TemplateContent | Should -Match 'cd /d %LOCALAPPDATA%'
+    }
+
+    It "Unix branch should keep the status.sh modules" {
+        $script:TemplateContent | Should -Match 'status\.sh\\" updates'
+        $script:TemplateContent | Should -Match 'status\.sh\\" reboot'
+        $script:TemplateContent | Should -Match 'status\.sh\\" ansible'
+    }
+
+    It "chezmoiignore should keep status.sh off Windows" {
+        $script:IgnoreContent | Should -Match '\.config/fastfetch/status\.sh'
+    }
+
+    It "chezmoiignore should keep status.ps1 off Unix" {
+        $script:IgnoreContent | Should -Match '\.config/fastfetch/status\.ps1'
+    }
+
+    It "chezmoiignore should no longer exclude the whole fastfetch directory on Windows" {
+        $script:IgnoreContent | Should -Not -Match '\.config/fastfetch/\*\*'
+    }
+
+    It "profile should spawn a background refresh of the status cache" {
+        $script:ProfileContent | Should -Match 'fastfetch\\status\.ps1'
+        $script:ProfileContent | Should -Match "'refresh'|refresh"
+    }
+
+    It "profile background refresh should not create a visible window" {
+        $script:ProfileContent | Should -Match 'CreateNoWindow'
+    }
+
+    It "profile should honour FASTFETCH_STATUS_DISABLE" {
+        $script:ProfileContent | Should -Match 'FASTFETCH_STATUS_DISABLE'
+    }
+}


### PR DESCRIPTION
## Summary

The `Updates` / `Reboot` / `Ansible` status lines in the fastfetch banner were Unix-only. `.chezmoiignore` dropped the entire `.config/fastfetch` directory on Windows, so Windows fell back to fastfetch's stock config with no update info at all.

This adds a Windows counterpart so the banner reports available **winget** updates, matching what Linux/macOS already show for apt/dnf/pacman/zypper/apk/brew.

```console
Updates: 📦 6 update(s) available (winget)
```

fastfetch hides a `command` module when it prints nothing, so a machine with nothing pending stays clean.

## How it works

A winget query is far too slow for the login path — **27s** on my machine. So nothing is ever computed while you wait for a prompt. Instead the same stale-while-revalidate cache as `status.sh` is used:

| Platform | Cache | Filled by |
| --- | --- | --- |
| Linux/macOS | `~/.cache/fastfetch-status/` | `status.sh`, which self-spawns its refresh |
| Windows | `%LOCALAPPDATA%\fastfetch-status\` | `status.ps1`, spawned detached by the PowerShell profile |

Windows reads the cached line with `cmd /c type` rather than starting PowerShell, so the module costs a few milliseconds.

## Changes

- **`home/dot_config/fastfetch/status.ps1`** (new) — counts winget upgrades via `Microsoft.WinGet.Client`, falling back to parsing `winget upgrade` table output. Atomic cache writes, single-runner lock with stale-lock recovery, `updates` / `refresh` / `clear` / `help` commands.
- **`config.jsonc` → `config.jsonc.tmpl`** — branches on `.chezmoi.os` so each platform gets the modules it can actually run.
- **`home/.chezmoiignore`** — stops hiding the whole fastfetch directory on Windows; each OS now receives only the status script it can run.
- **`home/dot_config/powershell/profile.ps1`** — spawns a hidden detached refresh when the cache exceeds its TTL, before rendering the banner.
- **`tests/powershell/FastfetchStatus.Tests.ps1`** (new, 37 cases) and a docs section in `docs/customization.md`.

## Two gotchas worth flagging

- **fastfetch cannot pass double quotes through to `cmd`** — they arrive escaped and the command silently produces nothing. The module therefore enters the directory first (`cd /d %LOCALAPPDATA%\fastfetch-status && type updates`), which needs no quoting and still works for a user profile containing a space.
- **The cache is written as UTF-8 without a BOM**, because `type` copies bytes straight through and a BOM would show up as stray characters in the banner. The 📦 icon is built with `[char]::ConvertFromUtf32` so `status.ps1` stays ASCII-only, per the repo's PowerShell encoding rule.

## Configuration

| Variable | Effect |
| --- | --- |
| `FASTFETCH_STATUS_TTL` | Cache lifetime in seconds (default 3600) |
| `FASTFETCH_STATUS_DISABLE=1` | Print no status lines at all |
| `FASTFETCH_STATUS_CACHE_DIR` | Override the cache directory (Windows; testing) |

Manual refresh after installing updates: `~/.config/fastfetch/status.ps1 refresh`.

## Testing

- New suite: 37/37 passing.
- Full Pester suite: **723 passed**, no new failures (the 4 remaining failures are pre-existing signing-cert tests, present on `main` too — baseline was 717 passed / 10 failed).
- PSScriptAnalyzer clean on all changed files.
- `chezmoi apply --dry-run` verified; `chezmoi managed` / `ignored` confirm the correct script ships per OS.
- Verified live end to end: the line renders with the real winget count, disappears when the cache is absent, and the profile's background spawn populates the cache correctly.

Follow-up: `Reboot` (pending-reboot registry keys) could be added for Windows later; this PR is scoped to winget updates as requested.