### PR TITLE
feat(git): pick the Git signing key based on isWork

### DIFF
--- a/docs/chezmoi-variables.md
+++ b/docs/chezmoi-variables.md
@@ -61,14 +61,17 @@ templates and scripts.
 
 - `gitSigningKey` — The SSH **public** key used to sign Git commits when the
   1Password SSH agent drives signing. Works on WSL, native Windows and macOS;
-  the platform-specific signer binary is auto-detected. Defaults to the
-  repository owner's key, which is a public key and already published at
-  <https://github.com/DevSecNinja.keys>, so it is safe to ship in the repo.
-  Override it per-machine by setting `gitSigningKey` in your local chezmoi
-  config to your own key — copy it from the 1Password app, *item → ⋮ →
-  Configure Commit Signing → Copy Snippet*. An empty value falls back to the
-  default. Ignored when `useYubiKey` is `true`, since the YubiKey flow derives
-  its key from `~/.ssh/id_*_sk*.pub` instead.
+  the platform-specific signer binary is auto-detected. Two defaults ship: a
+  work key, used when `isWork` is `true`, and the repository owner's personal
+  key for every other machine. Both are public keys — the personal one is
+  already published at <https://github.com/DevSecNinja.keys> — so they are safe
+  to ship in the repo. Override it per-machine by setting `gitSigningKey` in
+  your local chezmoi config to your own key — copy it from the 1Password app,
+  *item → ⋮ → Configure Commit Signing → Copy Snippet*. An empty value falls
+  back to the work/personal default, as does a value that still equals one of
+  the shipped defaults (so a config written by an earlier `chezmoi init` never
+  pins the wrong one). Ignored when `useYubiKey` is `true`, since
+  the YubiKey flow derives its key from `~/.ssh/id_*_sk*.pub` instead.
   See [git-signing.md](git-signing.md).
 - `opSshSignProgram` — Explicit path to the 1Password SSH signer binary. Empty
   by default, which auto-detects per platform (`op-ssh-sign-wsl.exe` in WSL,

--- a/docs/git-signing.md
+++ b/docs/git-signing.md
@@ -10,10 +10,22 @@ everything on this page.
 
 ## Setup
 
-The repository owner's public key ships as the default for `gitSigningKey`, so
+The repository owner's public keys ship as the defaults for `gitSigningKey`, so
 signing switches itself on as soon as a 1Password signer binary is present —
-nothing to configure. (That key is public and already published at
-<https://github.com/DevSecNinja.keys>.)
+nothing to configure. Which default applies depends on the machine:
+
+| Machine | Default key |
+| --- | --- |
+| Entra ID tenant ending in `Microsoft` (`isWork = true`) | work key |
+| Everything else | personal key ([published][keys]) |
+
+[keys]: https://github.com/DevSecNinja.keys
+
+`isWork` comes from `dsregcmd /status` on Windows and WSL; elsewhere it is
+`false`, so the personal key applies. A `gitSigningKey` left over in your local
+chezmoi config from an earlier `chezmoi init` is re-evaluated whenever it still
+equals one of the shipped defaults, so a machine never gets pinned to the wrong
+one — only a key of your own is treated as an override.
 
 **Using your own key instead:**
 

--- a/home/.chezmoi.yaml.tmpl
+++ b/home/.chezmoi.yaml.tmpl
@@ -122,12 +122,17 @@
 {{- /* platform-specific signer binary is auto-detected. Ignored when           */ -}}
 {{- /* useYubiKey is true. See docs/git-signing.md.                             */ -}}
 {{- /*                                                                          */ -}}
-{{- /* This is a PUBLIC key, not a secret — it is already published at          */ -}}
-{{- /* https://github.com/DevSecNinja.keys — so it is safe to ship as the       */ -}}
-{{- /* default. Override it per-machine by setting `gitSigningKey` in your      */ -}}
-{{- /* local chezmoi config. `get` (not `hasKey`) so an existing config that    */ -}}
-{{- /* already carries an empty value still picks the default up.               */ -}}
-{{- $gitSigningKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO9RsnZlHiWrFkVf9iUaAH1Jb/6G9bCREjpjG2izEu99" -}}
+{{- /* These are PUBLIC keys, not secrets — the personal one is already         */ -}}
+{{- /* published at https://github.com/DevSecNinja.keys — so they are safe to   */ -}}
+{{- /* ship as defaults. Two defaults ship: one for work machines (see          */ -}}
+{{- /* `isWork` below) and one for everything else; the pick happens after the  */ -}}
+{{- /* Entra ID detection has run. Override it per-machine by setting           */ -}}
+{{- /* `gitSigningKey` in your local chezmoi config. `get` (not `hasKey`) so an */ -}}
+{{- /* existing config that already carries an empty value still picks a        */ -}}
+{{- /* default up.                                                              */ -}}
+{{- $gitSigningKeyPersonal := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO9RsnZlHiWrFkVf9iUaAH1Jb/6G9bCREjpjG2izEu99" -}}
+{{- $gitSigningKeyWork := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINHf9KPQ4uBdDqzZFrKyE1ugMJBee1XXVZwLLUKklNQV" -}}
+{{- $gitSigningKey := "" -}}
 {{- if get . "gitSigningKey" -}}
 {{-   $gitSigningKey = .gitSigningKey -}}
 {{- end -}}
@@ -218,6 +223,20 @@
 {{-     if $entraIDTenantName -}}
 {{-       $isWork = hasSuffix "Microsoft" $entraIDTenantName -}}
 {{-     end -}}
+{{-   end -}}
+{{- end -}}
+
+{{- /* Now that work/personal is known, fall back to the matching default key.  */ -}}
+{{- /* A value that is merely one of the shipped defaults is not a real         */ -}}
+{{- /* override — re-pick it, so a config written by an earlier init (or on a   */ -}}
+{{- /* machine that has since changed work/personal status) does not pin the    */ -}}
+{{- /* wrong key forever.                                                       */ -}}
+{{- $gitSigningKeyTrimmed := $gitSigningKey | toString | trim -}}
+{{- if or (not $gitSigningKeyTrimmed) (eq $gitSigningKeyTrimmed $gitSigningKeyPersonal) (eq $gitSigningKeyTrimmed $gitSigningKeyWork) -}}
+{{-   if $isWork -}}
+{{-     $gitSigningKey = $gitSigningKeyWork -}}
+{{-   else -}}
+{{-     $gitSigningKey = $gitSigningKeyPersonal -}}
 {{-   end -}}
 {{- end -}}
 

--- a/tests/bash/op-shell-plugins.bats
+++ b/tests/bash/op-shell-plugins.bats
@@ -50,6 +50,19 @@ _render() {
 	chezmoi --config "${1}" execute-template <"${2}"
 }
 
+# _fake_dsregcmd TENANT_NAME -> put a fake wslinfo + dsregcmd.exe on PATH so the
+# config template's Entra ID detection is deterministic regardless of the host
+# it runs on. A tenant ending in "Microsoft" is what flips isWork to true.
+_fake_dsregcmd() {
+	local bin="${TEST_DIR}/fake-bin"
+	mkdir -p "${bin}"
+	printf '#!/bin/sh\necho "2.5.7"\n' >"${bin}/wslinfo"
+	printf '#!/bin/sh\nprintf "AzureAdJoined : YES\\nTenantName : %s\\n"\n' "${1}" \
+		>"${bin}/dsregcmd.exe"
+	chmod +x "${bin}/wslinfo" "${bin}/dsregcmd.exe"
+	export PATH="${bin}:${PATH}"
+}
+
 @test "op-plugins: templates exist for bash/zsh and fish" {
 	[ -f "${BASH_TMPL}" ]
 	[ -f "${FISH_TMPL}" ]
@@ -473,6 +486,43 @@ _render() {
 	run chezmoi --config "${pre}" execute-template --init <"${REPO_ROOT}/home/.chezmoi.yaml.tmpl"
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ 'gitSigningKey: "ssh-ed25519 ' ]]
+}
+
+@test "signing: a work machine gets the work default key" {
+	_skip_without_chezmoi
+	local pre="${TEST_DIR}/work.yaml"
+	_fake_dsregcmd Microsoft
+	printf '{}\n' >"${pre}"
+	run chezmoi --config "${pre}" execute-template --init \
+		<"${REPO_ROOT}/home/.chezmoi.yaml.tmpl"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "isWork: true" ]]
+	[[ "$output" =~ 'gitSigningKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINHf9KPQ4uBdDqzZFrKyE1ugMJBee1XXVZwLLUKklNQV"' ]]
+}
+
+@test "signing: a non-work machine gets the personal default key" {
+	_skip_without_chezmoi
+	local pre="${TEST_DIR}/personal.yaml"
+	_fake_dsregcmd Contoso
+	printf '{}\n' >"${pre}"
+	run chezmoi --config "${pre}" execute-template --init \
+		<"${REPO_ROOT}/home/.chezmoi.yaml.tmpl"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "isWork: false" ]]
+	[[ "$output" =~ 'gitSigningKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO9RsnZlHiWrFkVf9iUaAH1Jb/6G9bCREjpjG2izEu99"' ]]
+}
+
+@test "signing: a persisted shipped default is re-picked per machine" {
+	_skip_without_chezmoi
+	local pre="${TEST_DIR}/stale-default.yaml"
+	# A config written before the work key existed carries the personal default;
+	# that is not a real override, so a work machine must still get the work key.
+	_fake_dsregcmd Microsoft
+	printf 'data:\n  gitSigningKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO9RsnZlHiWrFkVf9iUaAH1Jb/6G9bCREjpjG2izEu99"\n' >"${pre}"
+	run chezmoi --config "${pre}" execute-template --init \
+		<"${REPO_ROOT}/home/.chezmoi.yaml.tmpl"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ 'gitSigningKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINHf9KPQ4uBdDqzZFrKyE1ugMJBee1XXVZwLLUKklNQV"' ]]
 }
 
 @test "signing: a per-machine key overrides the default" {


### PR DESCRIPTION
## Why

On work machines, Git commits were being signed with the personal SSH key. `gitSigningKey` shipped a single hardcoded default in `.chezmoi.yaml.tmpl`, so every machine got the same key unless it was overridden by hand in a local chezmoi config.

## What changed

Two defaults now ship: a personal key (unchanged) and a work key. The pick is driven by the `isWork` flag that already exists in the config template, derived from `dsregcmd /status` reporting an Entra ID tenant name ending in `Microsoft`.

Two details worth a look:

- **The selection moved down the template.** `gitSigningKey` used to be resolved above the Entra ID detection block, so `isWork` was not yet known at that point. The variable is now initialised early (to keep the override check next to its documentation) and the default is chosen after detection runs.
- **A persisted shipped default is re-evaluated, not treated as an override.** My local `~/.config/chezmoi/chezmoi.yaml` already carries `gitSigningKey: "<personal key>"` from an earlier `chezmoi init`, so a plain "only fall back when empty" rule would have pinned the wrong key forever. A value that still equals *either* shipped default is re-picked; only a genuinely custom key wins.

Docs updated in `docs/git-signing.md` and `docs/chezmoi-variables.md`.

## Testing

Three new cases in `tests/bash/op-shell-plugins.bats` (work, non-work, stale-persisted-default) using a fake `wslinfo` + `dsregcmd.exe` on `PATH`, so they are deterministic regardless of the host running them. Full file passes (37 tests). `validate-chezmoi.bats` passes.

Verified by hand on a work machine: `isWork: true` renders `signingkey = key::ssh-ed25519 AAAA...NHf9KPQ...` in `~/.config/git/config`.

## Notes for the reviewer

- Picking up the new key locally requires re-running `chezmoi init` (config data is only regenerated then) followed by `chezmoi apply`.
- The commit on this branch is unsigned: the 1Password SSH agent had no identities available at the time (`ssh-add -l` empty), so signing failed for both keys. Happy to amend with a signed commit if that matters for this repo.