### PR TITLE
feat(1password): manage the SSH agent vault config

### DIFF
--- a/docs/chezmoi-variables.md
+++ b/docs/chezmoi-variables.md
@@ -78,6 +78,12 @@ templates and scripts.
   `op-ssh-sign.exe` on Windows, `op-ssh-sign` on macOS). Set it for a
   non-standard install, or on Linux where there is no standard path. When no
   signer is found, signing stays off rather than breaking every `git commit`.
+- `opSshVault` — 1Password vault the SSH agent offers keys from, written to
+  `%LOCALAPPDATA%\1Password\config\ssh\agent.toml` on Windows. Defaults to
+  `Microsoft` when `isWork` is `true` and `Private` otherwise; as with
+  `gitSigningKey`, a value that still equals one of the shipped defaults is
+  re-picked, so only a differently-named vault counts as an override.
+  See [git-signing.md](git-signing.md).
 
 ## Windows Enterprise (Windows and WSL)
 

--- a/docs/git-signing.md
+++ b/docs/git-signing.md
@@ -52,6 +52,31 @@ Git needs a `key::` prefix to read a literal public key rather than a file
 path; the template adds it for you, so paste the key exactly as 1Password
 gives it — with or without a trailing comment.
 
+## The agent has to offer the key
+
+Holding the right key is not enough: the 1Password SSH agent only offers keys
+from the vaults listed in its config, so the signer can hold a perfectly good
+key and still fail with *"No SSH private key found for the specified public
+key"*.
+
+On Windows that config is managed by this repo at
+`%LOCALAPPDATA%\1Password\config\ssh\agent.toml`, rendered from the
+`opSshVault` chezmoi variable — `Microsoft` on work machines, `Private`
+elsewhere. WSL benefits too, since it reaches the same Windows agent
+(see [wsl.md](wsl.md)).
+
+Watch out for a bare `ssh-keys = []`, which 1Password writes on a fresh
+install. That is an explicit *empty* list, not "the default set", so the agent
+offers nothing at all and `ssh-add -l` reports no identities. Adding at least
+one `[[ssh-keys]]` entry is what fixes it.
+
+Use a differently-named vault by setting it in your local chezmoi config:
+
+```yaml
+data:
+  opSshVault: "My Custom Vault"
+```
+
 ## The signer is platform-specific
 
 1Password ships a different binary per platform, and the repo auto-detects the
@@ -96,3 +121,14 @@ git log --show-signature -1
 
 A good signature shows `Good "git" signature`. In WSL the approval prompt
 appears on the Windows host — see [wsl.md](wsl.md).
+
+If signing fails with *"No SSH private key found for the specified public
+key"*, check what the agent is actually offering:
+
+```bash
+ssh-add -l
+```
+
+No identities means the agent is not running, is locked, or its `agent.toml`
+does not list the vault holding the key — see
+[the agent has to offer the key](#the-agent-has-to-offer-the-key).

--- a/home/.chezmoi.yaml.tmpl
+++ b/home/.chezmoi.yaml.tmpl
@@ -146,6 +146,17 @@
 {{-   $opSshSignProgram = .opSshSignProgram -}}
 {{- end -}}
 
+{{- /* 1Password vault the SSH agent offers keys from, written to the Windows  */ -}}
+{{- /* agent.toml. Empty means pick per machine below: the work vault on work */ -}}
+{{- /* devices, Private elsewhere. Set it to use a differently-named vault.   */ -}}
+{{- /* See docs/git-signing.md.                                              */ -}}
+{{- $opSshVaultWork := "Microsoft" -}}
+{{- $opSshVaultPersonal := "Private" -}}
+{{- $opSshVault := "" -}}
+{{- if get . "opSshVault" -}}
+{{-   $opSshVault = .opSshVault -}}
+{{- end -}}
+
 {{- /* Extract GitHub username from email or prompt */ -}}
 {{- $githubUsername := "" -}}
 {{- /* Matches GitHub noreply email format: ID+USERNAME@users.noreply.github.com (e.g., 14926452+DevSecNinja@users.noreply.github.com) */ -}}
@@ -240,6 +251,17 @@
 {{-   end -}}
 {{- end -}}
 
+{{- /* Same treatment for the SSH agent's vault: a persisted shipped default is */ -}}
+{{- /* re-picked, only a differently-named vault counts as an override.         */ -}}
+{{- $opSshVaultTrimmed := $opSshVault | toString | trim -}}
+{{- if or (not $opSshVaultTrimmed) (eq $opSshVaultTrimmed $opSshVaultPersonal) (eq $opSshVaultTrimmed $opSshVaultWork) -}}
+{{-   if $isWork -}}
+{{-     $opSshVault = $opSshVaultWork -}}
+{{-   else -}}
+{{-     $opSshVault = $opSshVaultPersonal -}}
+{{-   end -}}
+{{- end -}}
+
 {{- /* Determine if running on a server based on hostname */ -}}
 {{- $isServer := false -}}
 {{- $hostname := .chezmoi.hostname -}}
@@ -318,6 +340,7 @@ data:
   opCopilotEnvironmentId: {{ $opCopilotEnvironmentId | quote }}
   opShellPlugins: {{ $opShellPluginList | toJson }}
   opSshSignProgram: {{ $opSshSignProgram | quote }}
+  opSshVault: {{ $opSshVault | quote }}
   privateDomain: {{ $privateDomain | quote }}
   useYubiKey: {{ $useYubiKey }}
   username: {{ $username | quote }}

--- a/home/AppData/Local/1Password/config/ssh/agent.toml.tmpl
+++ b/home/AppData/Local/1Password/config/ssh/agent.toml.tmpl
@@ -1,0 +1,22 @@
+# This is the 1Password SSH agent config file, which allows you to customize the
+# behavior of the SSH agent running on this machine.
+#
+# Managed by chezmoi — edit
+# home/AppData/Local/1Password/config/ssh/agent.toml.tmpl in the dotfiles repo,
+# not this file. The vault below comes from the `opSshVault` chezmoi variable,
+# which defaults to the work vault on work machines and Private elsewhere.
+# See docs/git-signing.md.
+#
+# A bare `ssh-keys = []` (which 1Password writes on a fresh install) enables
+# *zero* keys, so `ssh-add -l` reports no identities and every signed commit
+# fails. At least one `[[ssh-keys]]` entry is required.
+#
+# You can enable more keys by adding more `[[ssh-keys]]` entries, and narrow an
+# entry to a single item with `item = "My SSH Key"`. Order here is the order in
+# which keys are offered to SSH servers. Test the result with `ssh-add -l`.
+#
+# More examples can be found here:
+#  https://www.1password.dev/ssh/agent/config
+
+[[ssh-keys]]
+vault = {{ .opSshVault | quote }}

--- a/tests/bash/op-shell-plugins.bats
+++ b/tests/bash/op-shell-plugins.bats
@@ -17,7 +17,8 @@ setup() {
 
 	BASH_TMPL="${REPO_ROOT}/home/dot_config/shell/functions/op-plugins.sh.tmpl"
 	FISH_TMPL="${REPO_ROOT}/home/dot_config/fish/conf.d/op-plugins.fish.tmpl"
-	export BASH_TMPL FISH_TMPL
+	AGENT_TMPL="${REPO_ROOT}/home/AppData/Local/1Password/config/ssh/agent.toml.tmpl"
+	export BASH_TMPL FISH_TMPL AGENT_TMPL
 }
 
 teardown() {
@@ -510,6 +511,66 @@ _fake_dsregcmd() {
 	[ "$status" -eq 0 ]
 	[[ "$output" =~ "isWork: false" ]]
 	[[ "$output" =~ 'gitSigningKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO9RsnZlHiWrFkVf9iUaAH1Jb/6G9bCREjpjG2izEu99"' ]]
+}
+
+@test "op-agent: the agent config enables the work vault on a work machine" {
+	_skip_without_chezmoi
+	local pre="${TEST_DIR}/agent-work.yaml"
+	_fake_dsregcmd Microsoft
+	printf '{}\n' >"${pre}"
+	chezmoi --config "${pre}" execute-template --init \
+		<"${REPO_ROOT}/home/.chezmoi.yaml.tmpl" >"${TEST_DIR}/agent-work-cfg.yaml"
+	run _render "${TEST_DIR}/agent-work-cfg.yaml" "${AGENT_TMPL}"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ '[[ssh-keys]]' ]]
+	[[ "$output" =~ 'vault = "Microsoft"' ]]
+}
+
+@test "op-agent: the agent config enables Private on a personal machine" {
+	_skip_without_chezmoi
+	local pre="${TEST_DIR}/agent-personal.yaml"
+	_fake_dsregcmd Contoso
+	printf '{}\n' >"${pre}"
+	chezmoi --config "${pre}" execute-template --init \
+		<"${REPO_ROOT}/home/.chezmoi.yaml.tmpl" >"${TEST_DIR}/agent-personal-cfg.yaml"
+	run _render "${TEST_DIR}/agent-personal-cfg.yaml" "${AGENT_TMPL}"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ 'vault = "Private"' ]]
+}
+
+@test "op-agent: a custom vault name overrides the default" {
+	_skip_without_chezmoi
+	local pre="${TEST_DIR}/agent-custom.yaml"
+	_fake_dsregcmd Microsoft
+	printf 'data:\n  opSshVault: "My Custom Vault"\n' >"${pre}"
+	chezmoi --config "${pre}" execute-template --init \
+		<"${REPO_ROOT}/home/.chezmoi.yaml.tmpl" >"${TEST_DIR}/agent-custom-cfg.yaml"
+	run _render "${TEST_DIR}/agent-custom-cfg.yaml" "${AGENT_TMPL}"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ 'vault = "My Custom Vault"' ]]
+}
+
+@test "op-agent: never enables zero keys, which is what breaks the agent" {
+	_skip_without_chezmoi
+	local cfg
+	cfg="$(_config)"
+	run _render "${cfg}" "${AGENT_TMPL}"
+	[ "$status" -eq 0 ]
+	# A bare `ssh-keys = []` means no identities at all; it may only ever appear
+	# inside the explanatory comment block.
+	[[ ! "$output" =~ $'\nssh-keys = []' ]]
+	[[ "$output" =~ '[[ssh-keys]]' ]]
+}
+
+@test "op-agent: the agent config is Windows-only" {
+	_skip_without_chezmoi
+	# AppData is ignored off Windows, so a Linux/macOS apply must not try to
+	# write a Windows-shaped path into $HOME.
+	run chezmoi ignored --source="${REPO_ROOT}/home"
+	[ "$status" -eq 0 ]
+	if [ "$(uname -s)" != "Darwin" ]; then
+		[[ "$output" =~ "AppData" ]]
+	fi
 }
 
 @test "signing: a persisted shipped default is re-picked per machine" {


### PR DESCRIPTION
## Why

1Password commit signing was failing on this machine with *"No SSH private key found for the specified public key"* — for both the personal and the work key. The cause turned out to be the 1Password SSH agent config, which carried a bare `ssh-keys = []`.

That line is easy to misread as "use the defaults", but it is an explicit *empty* list: it enables **zero** keys. The agent offered no identities at all (`ssh-add -l` was empty), so no key could ever be found regardless of which one git asked for. Since the file was unmanaged, nothing in the repo could prevent or fix that.

## What changed

`agent.toml` is now managed on Windows, with the vault rendered from a new `opSshVault` chezmoi variable:

- `isWork: true` -> `vault = "Microsoft"`
- otherwise -> `vault = "Private"`

It reuses the "a persisted shipped default gets re-picked, only a differently-named vault is a real override" rule introduced for `gitSigningKey` in #648, so a config written by an earlier `chezmoi init` cannot pin the wrong vault.

WSL benefits from this too, since it reaches the same Windows agent rather than running one of its own.

The stock 1Password comment block was replaced with one that explains the `ssh-keys = []` trap and points back at the repo, so a future reader does not have to rediscover it.

## Testing

Five new cases in `tests/bash/op-shell-plugins.bats`: work vault, personal vault, custom vault override, "never renders zero keys", and a check that the file stays Windows-only (`AppData` is already in the non-Windows `.chezmoiignore` block, so a Linux or macOS apply must not write a Windows-shaped path into `$HOME`). All pass.

`chezmoi target-path` confirms the source file lands at `C:/Users/<user>/AppData/Local/1Password/config/ssh/agent.toml`, and `chezmoi diff` against the live file shows the managed version matches what is there now.

## Notes for the reviewer

- Picking this up locally needs `chezmoi init` (config data is only regenerated then) followed by `chezmoi apply`.
- Two tests fail when run from WSL against this worktree: `wsl-signing: a missing signer leaves signing OFF` and `test-chezmoi-apply: dry-run init succeeds`. Both fail on `glob ... error calling glob: open /mnt/c/Users/WsiAccount: permission denied` while auto-detecting the signer path. That is environmental (a Windows service account directory WSL cannot stat), pre-existing on `main`, and unrelated to this change; CI runs on Linux with no `/mnt/c`.
- The commit is unsigned, for the reason this PR fixes.