### PR TITLE
fix(wsl): scope 1Password signer detection to current user

### DIFF
--- a/docs/git-signing.md
+++ b/docs/git-signing.md
@@ -59,7 +59,7 @@ right one:
 
 | Platform | Binary | Auto-detected from |
 | --- | --- | --- |
-| WSL | `op-ssh-sign-wsl.exe` | `/mnt/c/Users/*/AppData/Local/Microsoft/WindowsApps/`, then the pre-8.11.18 `…/1Password/app/8/` |
+| WSL | `op-ssh-sign-wsl.exe` | Current Windows user's `%LOCALAPPDATA%\Microsoft\WindowsApps\`, then the pre-8.11.18 `…\1Password\app\8\` |
 | Native Windows | `op-ssh-sign.exe` | `%LOCALAPPDATA%\Microsoft\WindowsApps\`, then `%LOCALAPPDATA%\1Password\app\8\` |
 | macOS | `op-ssh-sign` | `/Applications/1Password.app/Contents/MacOS/` |
 | Linux | — | no standard path; set it explicitly |

--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -135,12 +135,19 @@
 {{- else if .wsl -}}
 {{- /* The signer moved with the 8.11.18 MSIX installer, so probe the current */ -}}
 {{- /* location first and fall back to the pre-MSIX one.                     */ -}}
-{{-   range glob "/mnt/c/Users/*/AppData/Local/Microsoft/WindowsApps/op-ssh-sign-wsl.exe" -}}
-{{-     if not $signer -}}{{- $signer = . -}}{{- end -}}
+{{-   $localAppData := "" -}}
+{{-   if and (lookPath "sh") (lookPath "cmd.exe") -}}
+{{-     $windowsLocalAppData := output "sh" "-c" "cmd.exe /d /c 'echo %LOCALAPPDATA%' 2>/dev/null || true" | trim -}}
+{{-     if and $windowsLocalAppData (not (contains "%LOCALAPPDATA%" $windowsLocalAppData)) (lookPath "wslpath") -}}
+{{-       $localAppData = output "sh" "-c" "wslpath -u \"$1\" 2>/dev/null || true" "sh" $windowsLocalAppData | trim -}}
+{{-     end -}}
 {{-   end -}}
-{{-   if not $signer -}}
-{{-     range glob "/mnt/c/Users/*/AppData/Local/1Password/app/8/op-ssh-sign-wsl" -}}
-{{-       if not $signer -}}{{- $signer = . -}}{{- end -}}
+{{-   if $localAppData -}}
+{{-     $candidates := list
+          (joinPath $localAppData "Microsoft" "WindowsApps" "op-ssh-sign-wsl.exe")
+          (joinPath $localAppData "1Password" "app" "8" "op-ssh-sign-wsl") -}}
+{{-     range $candidates -}}
+{{-       if and (not $signer) (stat .) -}}{{- $signer = . -}}{{- end -}}
 {{-     end -}}
 {{-   end -}}
 {{- else if eq .chezmoi.os "windows" -}}

--- a/tests/bash/op-shell-plugins.bats
+++ b/tests/bash/op-shell-plugins.bats
@@ -63,6 +63,22 @@ _fake_dsregcmd() {
 	export PATH="${bin}:${PATH}"
 }
 
+# _fake_wsl_localappdata LOCAL_APP_DATA [WSLPATH_STATUS] -> put fake cmd.exe
+# and wslpath commands on PATH so WSL signer detection is host-independent.
+_fake_wsl_localappdata() {
+	local local_app_data="${1}" wslpath_status="${2:-0}"
+	local bin="${TEST_DIR}/fake-wsl-bin"
+	mkdir -p "${bin}"
+	printf '#!/bin/sh\nprintf "C:\\\\Users\\\\Test\\\\AppData\\\\Local\\r\\n"\n' >"${bin}/cmd.exe"
+	if [ "${wslpath_status}" -eq 0 ]; then
+		printf '#!/bin/sh\nprintf '\''%%s\\n'\'' '\''%s'\''\n' "${local_app_data}" >"${bin}/wslpath"
+	else
+		printf '#!/bin/sh\nexit %s\n' "${wslpath_status}" >"${bin}/wslpath"
+	fi
+	chmod +x "${bin}/cmd.exe" "${bin}/wslpath"
+	export PATH="${bin}:${PATH}"
+}
+
 @test "op-plugins: templates exist for bash/zsh and fish" {
 	[ -f "${BASH_TMPL}" ]
 	[ -f "${FISH_TMPL}" ]
@@ -299,10 +315,62 @@ _fake_dsregcmd() {
 
 @test "wsl-signing: a missing signer leaves signing OFF rather than breaking commits" {
 	_skip_without_chezmoi
+	local cfg chezmoi_bin
+	# Hide Windows interop even when this test runs inside WSL. Enabling gpgsign
+	# without a signer would make every commit fail.
+	cfg="$(_config \
+		's|^  wsl: .*|  wsl: true|' \
+		's|^  useYubiKey: .*|  useYubiKey: false|' \
+		's|^  gitSigningKey: .*|  gitSigningKey: "ssh-ed25519 AAAATESTKEY comment"|' \
+		's|^  opSshSignProgram: .*|  opSshSignProgram: ""|')"
+	chezmoi_bin="$(dirname "$(command -v chezmoi)")"
+	PATH="${chezmoi_bin}:/usr/bin:/bin" run _render "${cfg}" "${REPO_ROOT}/home/dot_config/git/config.tmpl"
+	[ "$status" -eq 0 ]
+	[[ ! "$output" =~ "gpgsign" ]]
+	[[ ! "$output" =~ "signingkey" ]]
+	[[ "$output" =~ "signing is left OFF on purpose" ]]
+}
+
+@test "wsl-signing: auto-detection uses the current user's MSIX signer" {
+	_skip_without_chezmoi
+	local cfg local_app_data="${TEST_DIR}/LocalAppData"
+	mkdir -p "${local_app_data}/Microsoft/WindowsApps" "${local_app_data}/1Password/app/8"
+	touch "${local_app_data}/Microsoft/WindowsApps/op-ssh-sign-wsl.exe"
+	touch "${local_app_data}/1Password/app/8/op-ssh-sign-wsl"
+	_fake_wsl_localappdata "${local_app_data}"
+	cfg="$(_config \
+		's|^  wsl: .*|  wsl: true|' \
+		's|^  useYubiKey: .*|  useYubiKey: false|' \
+		's|^  gitSigningKey: .*|  gitSigningKey: "ssh-ed25519 AAAATESTKEY comment"|' \
+		's|^  opSshSignProgram: .*|  opSshSignProgram: ""|')"
+	run _render "${cfg}" "${REPO_ROOT}/home/dot_config/git/config.tmpl"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "program = \"${local_app_data}/Microsoft/WindowsApps/op-ssh-sign-wsl.exe\"" ]]
+	[[ ! "$output" =~ "program = \"${local_app_data}/1Password/app/8/op-ssh-sign-wsl\"" ]]
+	[[ "$output" =~ "gpgsign = true" ]]
+}
+
+@test "wsl-signing: auto-detection falls back to the pre-MSIX signer" {
+	_skip_without_chezmoi
+	local cfg local_app_data="${TEST_DIR}/LocalAppData"
+	mkdir -p "${local_app_data}/1Password/app/8"
+	touch "${local_app_data}/1Password/app/8/op-ssh-sign-wsl"
+	_fake_wsl_localappdata "${local_app_data}"
+	cfg="$(_config \
+		's|^  wsl: .*|  wsl: true|' \
+		's|^  useYubiKey: .*|  useYubiKey: false|' \
+		's|^  gitSigningKey: .*|  gitSigningKey: "ssh-ed25519 AAAATESTKEY comment"|' \
+		's|^  opSshSignProgram: .*|  opSshSignProgram: ""|')"
+	run _render "${cfg}" "${REPO_ROOT}/home/dot_config/git/config.tmpl"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "program = \"${local_app_data}/1Password/app/8/op-ssh-sign-wsl\"" ]]
+	[[ "$output" =~ "gpgsign = true" ]]
+}
+
+@test "wsl-signing: a failed LocalAppData conversion leaves signing OFF" {
+	_skip_without_chezmoi
 	local cfg
-	# No signer override and no /mnt/c on this host, so auto-detection finds
-	# nothing. Enabling gpgsign anyway would make git fall back to the local
-	# ssh-keygen, which cannot reach the 1Password-held key: every commit fails.
+	_fake_wsl_localappdata "${TEST_DIR}/LocalAppData" 1
 	cfg="$(_config \
 		's|^  wsl: .*|  wsl: true|' \
 		's|^  useYubiKey: .*|  useYubiKey: false|' \
@@ -311,8 +379,12 @@ _fake_dsregcmd() {
 	run _render "${cfg}" "${REPO_ROOT}/home/dot_config/git/config.tmpl"
 	[ "$status" -eq 0 ]
 	[[ ! "$output" =~ "gpgsign" ]]
-	[[ ! "$output" =~ "signingkey" ]]
 	[[ "$output" =~ "signing is left OFF on purpose" ]]
+}
+
+@test "wsl-signing: auto-detection never scans every Windows profile" {
+	run grep -F "/mnt/c/Users/*/" "${REPO_ROOT}/home/dot_config/git/config.tmpl"
+	[ "$status" -ne 0 ]
 }
 
 @test "wsl-signing: no signing key means no signing configuration" {


### PR DESCRIPTION
## Summary

- replace the WSL-wide `/mnt/c/Users/*` signer globs with guarded current-user `%LOCALAPPDATA%` discovery through `cmd.exe` and `wslpath`
- `stat` only the MSIX and pre-MSIX 1Password signer candidates, preserving their priority
- leave signing off when interop or conversion is unavailable instead of aborting template rendering
- add deterministic Bats coverage and update the signing documentation

## Root cause

chezmoi's `glob` errors when it encounters an unreadable Windows service-account profile such as `C:\Users\WsiAccount`. Scanning every profile also risked selecting another user's signer. Resolving the current Windows user's LocalAppData avoids both problems and eliminates the directory walk.

## Validation

- `timeout 60 ./tests/bash/run-tests.sh --test op-shell-plugins.bats --test test-chezmoi-apply.bats` — 46 tests passed (1 unrelated skip)
- isolated `chezmoi init --apply --dry-run --no-tty --source=.` from WSL — passed
- staged-file `mise exec -- lefthook run pre-commit` — passed (no applicable `.sh`/`.bash` files)
- full local WSL `--ci` run still reports two unrelated existing failures in `log-structured.bats` (`json: special characters...` and `json: log_data...`)
- all-files lefthook reaches unrelated existing ShellCheck violations; its CRLF rewrites were removed so this PR contains only the three intended files

The commit was created with `--no-gpg-sign` because the local 1Password agent currently offers no signing identity.