### PR TITLE
fix(fastfetch): show only the product name on the Host line

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -149,6 +149,12 @@ notice instead of a hung shell:
 
 Set `FASTFETCH_TIMEOUT_MS` to tune the limit (default 5000).
 
+The module list lives in `~/.config/fastfetch/config.jsonc`. One deviation from
+the defaults is worth knowing about: the `Host` line is formatted as `{name}`
+only, because fastfetch otherwise appends the product version — on OEM hardware
+that is a long firmware/SKU string such as `124I:00108T:000M:...` that pushes the
+useful part off the line.
+
 ### Extra status lines
 
 The banner carries a few extra lines that only appear when they have something

--- a/home/dot_config/fastfetch/config.jsonc.tmpl
+++ b/home/dot_config/fastfetch/config.jsonc.tmpl
@@ -5,7 +5,11 @@
     "title",
     "separator",
     "os",
-    "host",
+    {
+      "//": "Product name only. The default format appends {version}, which on OEM hardware is often a firmware/SKU string (e.g. '124I:00108T:...') that says nothing useful and makes the line unreadably long.",
+      "type": "host",
+      "format": "{name}"
+    },
     "kernel",
     "uptime",
     "packages",

--- a/tests/powershell/FastfetchStatus.Tests.ps1
+++ b/tests/powershell/FastfetchStatus.Tests.ps1
@@ -321,6 +321,13 @@ Describe "fastfetch chezmoi wiring" {
         $script:TemplateContent | Should -Match 'status\.sh\\" ansible'
     }
 
+    It "config template should trim the host line to the product name" {
+        # The default host format appends the product version, which on OEM
+        # hardware is a long firmware/SKU string.
+        $script:TemplateContent | Should -Match '"type": "host"'
+        $script:TemplateContent | Should -Match '"format": "\{name\}"'
+    }
+
     It "chezmoiignore should keep status.sh off Windows" {
         $script:IgnoreContent | Should -Match '\.config/fastfetch/status\.sh'
     }


### PR DESCRIPTION
## Why

On OEM hardware the fastfetch `Host` line is mostly noise. fastfetch's default host format appends the product version, which on a Surface Laptop is a firmware/SKU string, so the line reads:

```
Host: Microsoft Surface Laptop, 7th Edition (124I:00108T:000M:0000000F:0B:10C:12M:04D:03U:04T:1R:21S:0A:0)
```

The useful part (the model name) gets pushed out of view by 60 characters that mean nothing to a human reading a login banner.

## What changed

Replaces the bare `"host"` module in `config.jsonc.tmpl` with an explicit `{ "type": "host", "format": "{name}" }`, giving:

```
Host: Microsoft Surface Laptop, 7th Edition
```

`{name}` is populated on Linux and macOS too (it is the DMI/SMBIOS product name), so this is not Windows specific and the module stays in the shared, non-templated part of the config.

Also adds a short note in `docs/customization.md` explaining the deviation from fastfetch's defaults, and a Pester assertion in the existing "fastfetch chezmoi wiring" block so the format is not silently dropped by a future edit.

## Notes for reviewers

While looking into this, the `Updates` line was also missing from the banner. That turned out to be a stale cache from the source/rendered split in #654 rather than a code defect: the rendered `updates` file had no `.src` sibling yet, so it was cleaned up as an orphan while the refresh stamp was still fresh. A single `status.ps1 refresh` restored it, and hourly refreshes keep it correct from here, so no code change was needed for it.

## Testing

- `Invoke-Pester -Path tests\powershell\FastfetchStatus.Tests.ps1` (65 passed)
- Rendered the real banner locally after `chezmoi apply` to confirm the Host and Updates lines