### PR TITLE
fix(windows): respect managed power button policy

### DIFF
--- a/home/.chezmoiscripts/windows/run_onchange_disable-surface-laptop-power-button.ps1
+++ b/home/.chezmoiscripts/windows/run_onchange_disable-surface-laptop-power-button.ps1
@@ -41,11 +41,52 @@ function Invoke-PowerCfg {
         throw "powercfg.exe was not found at '$powerCfgPath'."
     }
 
-    $output = & $powerCfgPath @ArgumentList 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        $details = ($output | Out-String).Trim()
-        throw "powercfg.exe failed with exit code $LASTEXITCODE for '$($ArgumentList -join ' ')': $details"
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        # Windows PowerShell 5.1 surfaces native stderr as NativeCommandError.
+        # Capture it for the exit-code error without treating stderr as success.
+        $ErrorActionPreference = "Continue"
+        $output = & $powerCfgPath @ArgumentList 2>&1
+        $exitCode = $LASTEXITCODE
     }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+
+    if ($exitCode -ne 0) {
+        $details = ($output | Out-String).Trim()
+        throw "powercfg.exe failed with exit code $exitCode for '$($ArgumentList -join ' ')': $details"
+    }
+}
+
+function Get-PowerButtonPolicy {
+    $policyPath = "HKLM:\SOFTWARE\Policies\Microsoft\Power\PowerSettings\7648EFA3-DD9C-4E3E-B566-50F929386280"
+    $policy = [pscustomobject]@{
+        Path  = $policyPath
+        HasAC = $false
+        AC    = $null
+        HasDC = $false
+        DC    = $null
+    }
+
+    if (-not (Test-Path -LiteralPath $policyPath)) {
+        return $policy
+    }
+
+    $values = Get-ItemProperty -LiteralPath $policyPath -ErrorAction Stop
+    $acProperty = $values.PSObject.Properties["ACSettingIndex"]
+    if ($null -ne $acProperty) {
+        $policy.HasAC = $true
+        $policy.AC = [int]$acProperty.Value
+    }
+
+    $dcProperty = $values.PSObject.Properties["DCSettingIndex"]
+    if ($null -ne $dcProperty) {
+        $policy.HasDC = $true
+        $policy.DC = [int]$dcProperty.Value
+    }
+
+    return $policy
 }
 
 function Disable-SurfaceLaptopPowerButton {
@@ -58,6 +99,10 @@ function Disable-SurfaceLaptopPowerButton {
         [scriptblock]$InvokePowerCfg = {
             param([string[]]$ArgumentList)
             Invoke-PowerCfg -ArgumentList $ArgumentList
+        },
+
+        [scriptblock]$GetPowerButtonPolicy = {
+            Get-PowerButtonPolicy
         }
     )
 
@@ -69,6 +114,27 @@ function Disable-SurfaceLaptopPowerButton {
             Changed = $false
             Model   = [string]$computerSystem.Model
         }
+    }
+
+    $policy = & $GetPowerButtonPolicy
+    if ($policy.HasAC -and $policy.HasDC -and $policy.AC -eq 0 -and $policy.DC -eq 0) {
+        Write-Host "[OK] Power button action is managed by Group Policy for AC and battery power." -ForegroundColor Green
+        return [pscustomobject]@{
+            Status  = "ManagedByPolicy"
+            Changed = $false
+            Model   = [string]$computerSystem.Model
+        }
+    }
+
+    if ($policy.HasAC -or $policy.HasDC) {
+        $acValue = if ($policy.HasAC) { [string]$policy.AC } else { "<not configured>" }
+        $dcValue = if ($policy.HasDC) { [string]$policy.DC } else { "<not configured>" }
+        throw (
+            "Group Policy owns the Surface Laptop power-button setting but does not enforce " +
+            "'Take no action' for both power states (ACSettingIndex=$acValue, " +
+            "DCSettingIndex=$dcValue). Update or remove the policy at '$($policy.Path)'; " +
+            "dotfiles will not override managed settings."
+        )
     }
 
     $powerButtonSetting = "7648efa3-dd9c-4e3e-b566-50f929386280"

--- a/tests/powershell/SurfaceLaptopPowerButton.Tests.ps1
+++ b/tests/powershell/SurfaceLaptopPowerButton.Tests.ps1
@@ -66,6 +66,27 @@ Describe "Surface Laptop power button script" -Tag "Unit" {
             }) | Should -BeFalse
     }
 
+    It "reads the documented AC and DC policy values" {
+        $expectedPath = "HKLM:\SOFTWARE\Policies\Microsoft\Power\PowerSettings\7648EFA3-DD9C-4E3E-B566-50F929386280"
+        Mock Test-Path { $true } -ParameterFilter { $LiteralPath -eq $expectedPath }
+        Mock Get-ItemProperty {
+            [pscustomobject]@{
+                ACSettingIndex = 0
+                DCSettingIndex = 0
+            }
+        } -ParameterFilter { $LiteralPath -eq $expectedPath }
+
+        $result = Get-PowerButtonPolicy
+
+        $result.Path | Should -Be $expectedPath
+        $result.HasAC | Should -BeTrue
+        $result.AC | Should -Be 0
+        $result.HasDC | Should -BeTrue
+        $result.DC | Should -Be 0
+        Should -Invoke Get-ItemProperty -Times 1 -Exactly `
+            -ParameterFilter { $LiteralPath -eq $expectedPath }
+    }
+
     It "does not invoke powercfg on non-Surface hardware" {
         $script:PowerCfgCalls = @()
 
@@ -99,6 +120,14 @@ Describe "Surface Laptop power button script" -Tag "Unit" {
             -InvokePowerCfg {
                 param([string[]]$ArgumentList)
                 $script:PowerCfgCalls += , $ArgumentList
+            } `
+            -GetPowerButtonPolicy {
+                [pscustomobject]@{
+                    HasAC = $false
+                    AC    = $null
+                    HasDC = $false
+                    DC    = $null
+                }
             }
 
         $result.Status | Should -Be "Disabled"
@@ -117,6 +146,73 @@ Describe "Surface Laptop power button script" -Tag "Unit" {
         $script:PowerCfgCalls[2] -join " " | Should -Be "/SETACTIVE SCHEME_CURRENT"
     }
 
+    It "does not invoke powercfg when the desired policy manages both power states" {
+        $script:PowerCfgCalls = @()
+        $policy = {
+            [pscustomobject]@{
+                Path  = "HKLM:\policy"
+                HasAC = $true
+                AC    = 0
+                HasDC = $true
+                DC    = 0
+            }
+        }
+        $surface = {
+            [pscustomobject]@{
+                Manufacturer = "Microsoft Corporation"
+                Model        = "Surface Laptop 7"
+            }
+        }
+        $powerCfg = {
+            param([string[]]$ArgumentList)
+            $script:PowerCfgCalls += , $ArgumentList
+        }
+
+        $firstResult = Disable-SurfaceLaptopPowerButton `
+            -GetComputerSystem $surface `
+            -InvokePowerCfg $powerCfg `
+            -GetPowerButtonPolicy $policy
+        $secondResult = Disable-SurfaceLaptopPowerButton `
+            -GetComputerSystem $surface `
+            -InvokePowerCfg $powerCfg `
+            -GetPowerButtonPolicy $policy
+
+        $firstResult.Status | Should -Be "ManagedByPolicy"
+        $firstResult.Changed | Should -BeFalse
+        $secondResult.Status | Should -Be "ManagedByPolicy"
+        $secondResult.Changed | Should -BeFalse
+        $script:PowerCfgCalls | Should -BeNullOrEmpty
+    }
+
+    It "rejects conflicting policy without invoking powercfg" {
+        $script:PowerCfgCalls = @()
+
+        {
+            Disable-SurfaceLaptopPowerButton `
+                -GetComputerSystem {
+                    [pscustomobject]@{
+                        Manufacturer = "Microsoft Corporation"
+                        Model        = "Surface Laptop 7"
+                    }
+                } `
+                -InvokePowerCfg {
+                    param([string[]]$ArgumentList)
+                    $script:PowerCfgCalls += , $ArgumentList
+                } `
+                -GetPowerButtonPolicy {
+                    [pscustomobject]@{
+                        Path  = "HKLM:\SOFTWARE\Policies\Microsoft\Power\PowerSettings\7648EFA3-DD9C-4E3E-B566-50F929386280"
+                        HasAC = $true
+                        AC    = 1
+                        HasDC = $true
+                        DC    = 0
+                    }
+                }
+        } | Should -Throw "*Group Policy owns*ACSettingIndex=1, DCSettingIndex=0*will not override*"
+
+        $script:PowerCfgCalls | Should -BeNullOrEmpty
+    }
+
     It "does not invoke powercfg under WhatIf" {
         $script:PowerCfgCalls = @()
 
@@ -131,6 +227,14 @@ Describe "Surface Laptop power button script" -Tag "Unit" {
                 param([string[]]$ArgumentList)
                 $script:PowerCfgCalls += , $ArgumentList
             } `
+            -GetPowerButtonPolicy {
+                [pscustomobject]@{
+                    HasAC = $false
+                    AC    = $null
+                    HasDC = $false
+                    DC    = $null
+                }
+            } `
             -WhatIf
 
         $result.Status | Should -Be "WhatIf"
@@ -138,7 +242,7 @@ Describe "Surface Laptop power button script" -Tag "Unit" {
         $script:PowerCfgCalls | Should -BeNullOrEmpty
     }
 
-    It "propagates powercfg failures" {
+    It "propagates native-command failures on unmanaged devices" {
         {
             Disable-SurfaceLaptopPowerButton `
                 -GetComputerSystem {
@@ -148,9 +252,17 @@ Describe "Surface Laptop power button script" -Tag "Unit" {
                     }
                 } `
                 -InvokePowerCfg {
-                    throw "powercfg failed"
+                    throw "powercfg.exe failed with exit code 1"
+                } `
+                -GetPowerButtonPolicy {
+                    [pscustomobject]@{
+                        HasAC = $false
+                        AC    = $null
+                        HasDC = $false
+                        DC    = $null
+                    }
                 }
-        } | Should -Throw "*powercfg failed*"
+        } | Should -Throw "*powercfg.exe failed with exit code 1*"
     }
 }
 


### PR DESCRIPTION
## Summary

- detect the documented `ACSettingIndex` and `DCSettingIndex` policy values before invoking `powercfg`
- return `ManagedByPolicy` without writes when both values enforce `Take no action`
- fail with actionable policy ownership details for partial or conflicting policy configuration
- preserve unmanaged Surface behavior, non-Surface skips, `WhatIf`, PowerShell 5.1 native-error handling, and strict nonzero exit propagation
- add focused Pester coverage for registry detection, desired and conflicting policy, idempotency, unmanaged writes, `WhatIf`, and native errors

## Root cause

PR #711 added a current-user `powercfg` write for Surface Laptop power-button behavior. Machines provisioned by `windows-iso-maker` already carry machine-wide Power ADMX policy values for the same setting, so Windows correctly rejects the lower-precedence power-plan write with a Group Policy override error.

## Validation

- targeted Pester: 14 passed
- full PowerShell Pester suite: 798 passed, 14 skipped
- PSScriptAnalyzer: no Error/Warning findings
- `chezmoi apply --dry-run --source=.`: passed
- Lefthook pre-commit (`shellcheck`, `shfmt`, executable-bit checks): passed
- Bash/Bats broader suite: 855 passed and 1 unrelated existing `git-config-credentials` failure on this environment